### PR TITLE
fix: [PIE-1661]: multi type icon fixed for text area

### DIFF
--- a/src/modules/10-common/components/MultiTypeTextArea/MultiTypeTextArea.module.scss
+++ b/src/modules/10-common/components/MultiTypeTextArea/MultiTypeTextArea.module.scss
@@ -2,8 +2,20 @@
   width: 100%;
   // Prevent horizontal resizing since it is breaking UI
   resize: vertical;
+  min-height: var(--spacing-12) !important;
 }
 
 .multi-btn {
-  height: auto !important;
+  height: var(--spacing-7) !important;
+  width: var(--spacing-7) !important;
+  padding: 0 !important;
+  position: absolute !important;
+  top: 10px !important;
+  right: 10px !important;
+  border: 1px solid var(--form-field-border) !important;
+  border-radius: var(--spacing-2) !important;
+
+  &::before {
+    display: none !important;
+  }
 }

--- a/src/modules/10-common/components/MultiTypeTextArea/MultiTypeTextArea.tsx
+++ b/src/modules/10-common/components/MultiTypeTextArea/MultiTypeTextArea.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useCallback, useState } from 'react'
 import { FormGroup, IFormGroupProps, Intent, ITextAreaProps, TextArea } from '@blueprintjs/core'
 import {
   ExpressionAndRuntimeType,
@@ -54,16 +54,26 @@ export interface MultiTypeTextAreaProps
 export const MultiTypeTextArea: React.FC<MultiTypeTextAreaProps> = props => {
   const { name, value, onChange, enableConfigureOptions = true, textAreaProps, configureOptionsProps, ...rest } = props
   const { getString } = useStrings()
+  const [multiType, setMultiType] = useState<MultiTypeInputType>(getMultiTypeFromValue(value))
+
+  const handleChange = useCallback(
+    (val, valueType, type) => {
+      setMultiType(type)
+      onChange?.(val, valueType, type)
+    },
+    [onChange]
+  )
+
   const expressionAndRuntimeTypeComponent = (
     <ExpressionAndRuntimeType
       name={name}
       value={value}
-      onChange={onChange}
+      onChange={handleChange}
       {...rest}
       fixedTypeComponentProps={textAreaProps}
       fixedTypeComponent={MultiTypeTextAreaFixedTypeComponent}
       style={{ flexGrow: 1 }}
-      btnClassName={css.multiBtn}
+      btnClassName={multiType === MultiTypeInputType.FIXED ? css.multiBtn : ''}
     />
   )
   return (
@@ -71,7 +81,7 @@ export const MultiTypeTextArea: React.FC<MultiTypeTextAreaProps> = props => {
       {enableConfigureOptions ? (
         <div style={{ display: 'flex', alignItems: 'center' }}>
           {expressionAndRuntimeTypeComponent}
-          {getMultiTypeFromValue(value) === MultiTypeInputType.RUNTIME && (
+          {multiType === MultiTypeInputType.RUNTIME && (
             <ConfigureOptions
               value={value as string}
               type={getString('string')}


### PR DESCRIPTION
##### Summary:

Fixes the alignment of multi input icon for text area component

##### Jira Links:

https://harness.atlassian.net/browse/PIE-1661

######## Design link

https://www.figma.com/file/bYQtU9kWVuVEsLksbVgGM4/hex2o?node-id=7513%3A282


##### Screenshots:

<img width="1787" alt="Screenshot 2022-01-06 at 2 26 06 AM" src="https://user-images.githubusercontent.com/96409598/148290280-80501104-fb89-468c-b523-1541a0ffd529.png">

<img width="1766" alt="Screenshot 2022-01-06 at 2 26 22 AM" src="https://user-images.githubusercontent.com/96409598/148290267-a58f6889-64a6-406c-9858-f481d50740fb.png">

<img width="1725" alt="Screenshot 2022-01-06 at 2 26 33 AM" src="https://user-images.githubusercontent.com/96409598/148290251-b0799674-cec8-4f76-9132-1c8d1de84785.png">

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
