### PR TITLE
fix: [GTM-655]: fix show plans page for community edition

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nextgenui",
   "description": "Harness Inc",
-  "version": "0.282.3",
+  "version": "0.282.4",
   "author": "Harness Inc",
   "license": "Harness Inc",
   "homepage": "http://app.harness.io/",

--- a/src/modules/30-auth-settings/pages/subscriptions/SubscriptionTab.tsx
+++ b/src/modules/30-auth-settings/pages/subscriptions/SubscriptionTab.tsx
@@ -14,6 +14,7 @@ import type { AccountPathProps, Module } from '@common/interfaces/RouteInterface
 
 import { useFeatureFlags } from '@common/hooks/useFeatureFlag'
 import type { StringsMap } from 'stringTypes'
+import { useCommunity } from 'framework/LicenseStore/useCommunity'
 
 import SubscriptionOverview from './overview/SubscriptionOverview'
 import SubscriptionBanner from './SubscriptionBanner'
@@ -67,6 +68,7 @@ const SubscriptionTab = ({
   refetchGetLicense
 }: SubscriptionTabProps): ReactElement => {
   const { PLANS_ENABLED } = useFeatureFlags()
+  const isCommunity = useCommunity()
 
   const [selectedSubscriptionTab, setSelectedSubscriptionTab] = useState<SubscriptionTabInfo>(SUBSCRIPTION_TABS[0])
   const { getString } = useStrings()
@@ -116,8 +118,8 @@ const SubscriptionTab = ({
       )
     })
 
-    // show Plans tab only when feature flag is on
-    if (!PLANS_ENABLED) {
+    // show Plans tab only when feature flag is on, always show for community edition
+    if (!isCommunity && !PLANS_ENABLED) {
       tabs.splice(1, 1)
     }
 


### PR DESCRIPTION
##### Summary:

this is to fix community plans page always shows up

##### Jira Links:

https://harness.atlassian.net/browse/PLG-655

##### Screenshots:


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
