### PR TITLE
fix: [PIE-2091]: added handling for lengthy text spillover in input s…

### DIFF
--- a/src/modules/70-pipeline/components/InputSetForm/InputSetForm.module.scss
+++ b/src/modules/70-pipeline/components/InputSetForm/InputSetForm.module.scss
@@ -30,6 +30,14 @@
   cursor: move;
 }
 
+.pageHeaderStyles {
+  > div {
+    &:first-child {
+      flex-grow: 1;
+    }
+  }
+}
+
 .dragging {
   background-color: var(--yellow-450) !important;
 }

--- a/src/modules/70-pipeline/components/InputSetForm/InputSetForm.module.scss.d.ts
+++ b/src/modules/70-pipeline/components/InputSetForm/InputSetForm.module.scss.d.ts
@@ -23,6 +23,7 @@ declare const styles: {
   readonly inputsetGrid: string
   readonly nameiddescription: string
   readonly optionBtns: string
+  readonly pageHeaderStyles: string
   readonly treeSidebar: string
 }
 export default styles

--- a/src/modules/70-pipeline/components/InputSetForm/InputSetForm.tsx
+++ b/src/modules/70-pipeline/components/InputSetForm/InputSetForm.tsx
@@ -15,7 +15,8 @@ import {
   FormikForm,
   Layout,
   NestedAccordionProvider,
-  Heading,
+  FontVariation,
+  Text,
   Color,
   ButtonVariation,
   PageHeader,
@@ -697,13 +698,14 @@ export function InputSetFormWrapper(props: InputSetFormWrapperProps): React.Reac
     <React.Fragment>
       <GitSyncStoreProvider>
         <PageHeader
+          className={css.pageHeaderStyles}
           title={
-            <Layout.Horizontal>
-              <Heading level={2} color={Color.GREY_800} font={{ weight: 'bold' }}>
+            <Layout.Horizontal width="42%">
+              <Text lineClamp={1} color={Color.GREY_800} font={{ weight: 'bold', variation: FontVariation.H4 }}>
                 {isEdit
                   ? getString('inputSets.editTitle', { name: inputSet.name })
                   : getString('inputSets.newInputSetLabel')}
-              </Heading>
+              </Text>
               {isGitSyncEnabled && isEdit && (
                 <GitPopover data={inputSet.gitDetails || {}} iconProps={{ margin: { left: 'small', top: 'xsmall' } }} />
               )}

--- a/src/modules/70-pipeline/components/InputSetForm/__tests__/__snapshots__/InputSetForm.test.tsx.snap
+++ b/src/modules/70-pipeline/components/InputSetForm/__tests__/__snapshots__/InputSetForm.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Render Forms - Snapshot Testing render Edit Input Set Form view 1`] = `
 <div>
   <div
-    class="Layout--horizontal StyledProps--main PageHeader--container PageHeader--standard StyledProps--flex StyledProps--padding-left-xlarge StyledProps--padding-right-xlarge StyledProps--background-white"
+    class="Layout--horizontal StyledProps--main PageHeader--container PageHeader--standard pageHeaderStyles StyledProps--flex StyledProps--padding-left-xlarge StyledProps--padding-right-xlarge StyledProps--background-white"
   >
     <div
       class="Layout--vertical StyledProps--main"
@@ -144,13 +144,14 @@ exports[`Render Forms - Snapshot Testing render Edit Input Set Form view 1`] = `
       </div>
       <div
         class="Layout--horizontal StyledProps--main"
+        style="width: 42%;"
       >
-        <h2
-          class="StyledProps--font StyledProps--font-h2 StyledProps--main StyledProps--color StyledProps--color-grey800 StyledProps--font-weight-bold"
-          level="2"
+        <p
+          class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--color StyledProps--color-grey800 StyledProps--font-weight-bold StyledProps--font-variation-h4"
+          style="--text-line-clamp: 1;"
         >
           inputSets.editTitle
-        </h2>
+        </p>
         <div
           class="optionBtns"
         >
@@ -267,7 +268,7 @@ exports[`Render Forms - Snapshot Testing render Edit Input Set Form view 1`] = `
 exports[`Render Forms - Snapshot Testing render Edit Input Set Form view: expanded 1`] = `
 <div>
   <div
-    class="Layout--horizontal StyledProps--main PageHeader--container PageHeader--standard StyledProps--flex StyledProps--padding-left-xlarge StyledProps--padding-right-xlarge StyledProps--background-white"
+    class="Layout--horizontal StyledProps--main PageHeader--container PageHeader--standard pageHeaderStyles StyledProps--flex StyledProps--padding-left-xlarge StyledProps--padding-right-xlarge StyledProps--background-white"
   >
     <div
       class="Layout--vertical StyledProps--main"
@@ -408,13 +409,14 @@ exports[`Render Forms - Snapshot Testing render Edit Input Set Form view: expand
       </div>
       <div
         class="Layout--horizontal StyledProps--main"
+        style="width: 42%;"
       >
-        <h2
-          class="StyledProps--font StyledProps--font-h2 StyledProps--main StyledProps--color StyledProps--color-grey800 StyledProps--font-weight-bold"
-          level="2"
+        <p
+          class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--color StyledProps--color-grey800 StyledProps--font-weight-bold StyledProps--font-variation-h4"
+          style="--text-line-clamp: 1;"
         >
           inputSets.editTitle
-        </h2>
+        </p>
         <div
           class="optionBtns"
         >
@@ -1685,7 +1687,7 @@ exports[`Render Forms - Snapshot Testing render Edit Overlay Input Set Form view
 exports[`Render Forms - Snapshot Testing render Input Set Form view 1`] = `
 <div>
   <div
-    class="Layout--horizontal StyledProps--main PageHeader--container PageHeader--standard StyledProps--flex StyledProps--padding-left-xlarge StyledProps--padding-right-xlarge StyledProps--background-white"
+    class="Layout--horizontal StyledProps--main PageHeader--container PageHeader--standard pageHeaderStyles StyledProps--flex StyledProps--padding-left-xlarge StyledProps--padding-right-xlarge StyledProps--background-white"
   >
     <div
       class="Layout--vertical StyledProps--main"
@@ -1826,13 +1828,14 @@ exports[`Render Forms - Snapshot Testing render Input Set Form view 1`] = `
       </div>
       <div
         class="Layout--horizontal StyledProps--main"
+        style="width: 42%;"
       >
-        <h2
-          class="StyledProps--font StyledProps--font-h2 StyledProps--main StyledProps--color StyledProps--color-grey800 StyledProps--font-weight-bold"
-          level="2"
+        <p
+          class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--color StyledProps--color-grey800 StyledProps--font-weight-bold StyledProps--font-variation-h4"
+          style="--text-line-clamp: 1;"
         >
           inputSets.newInputSetLabel
-        </h2>
+        </p>
         <div
           class="optionBtns"
         >

--- a/src/modules/70-pipeline/pages/inputSet-list/InputSetListView.tsx
+++ b/src/modules/70-pipeline/pages/inputSet-list/InputSetListView.tsx
@@ -85,13 +85,22 @@ const RenderColumnInputSet: Renderer<CellProps<InputSetLocal>> = ({ row }) => {
         color={data.inputSetType === 'INPUT_SET' ? Color.BLACK : Color.BLUE_500}
         size={30}
       />
-      <Layout.Horizontal flex={{ alignItems: 'center' }} spacing="small">
+      <Layout.Horizontal
+        flex={{ alignItems: 'center' }}
+        spacing="small"
+        style={{ flexShrink: 1 }}
+        padding={{ right: 'medium' }}
+      >
         <div>
           <Layout.Horizontal spacing="small" data-testid={data.identifier}>
-            <Text color={Color.BLACK}>{data.name}</Text>
+            <Text lineClamp={1} color={Color.BLACK}>
+              {data.name}
+            </Text>
             {data.tags && Object.keys(data.tags || {}).length ? <TagsPopover tags={data.tags} /> : null}
           </Layout.Horizontal>
-          <Text color={Color.GREY_400}>{getString('idLabel', { id: data.identifier })}</Text>
+          <Text lineClamp={1} color={Color.GREY_400}>
+            {getString('idLabel', { id: data.identifier })}
+          </Text>
         </div>
         {isInputSetInvalid(data) && (
           <Container padding={{ left: 'large' }}>
@@ -114,7 +123,7 @@ const RenderColumnInputSet: Renderer<CellProps<InputSetLocal>> = ({ row }) => {
 const RenderColumnDescription: Renderer<CellProps<InputSetLocal>> = ({ row }) => {
   const data = row.original
   return (
-    <Text lineClamp={2} color={Color.GREY_400}>
+    <Text padding={{ right: 'medium' }} lineClamp={2} color={Color.GREY_400}>
       {data.description}
     </Text>
   )
@@ -265,7 +274,7 @@ export const InputSetListView: React.FC<InputSetListViewProps> = ({
   const columns: CustomColumn<InputSetLocal>[] = React.useMemo(
     () => [
       {
-        Header: getString('inputSets.inputSetLabel').toUpperCase(),
+        Header: getString('pipeline.inputSets.inputSetNameLabel').toUpperCase(),
         accessor: 'name',
         width: isGitSyncEnabled ? '25%' : '30%',
         Cell: RenderColumnInputSet

--- a/src/modules/70-pipeline/pages/inputSet-list/__tests__/__snapshots__/InputSetList.test.tsx.snap
+++ b/src/modules/70-pipeline/pages/inputSet-list/__tests__/__snapshots__/InputSetList.test.tsx.snap
@@ -104,7 +104,7 @@ exports[`Input Set List tests render Input Set List view 1`] = `
           <p
             class="StyledProps--font StyledProps--main StyledProps--font-variation-table-headers"
           >
-            INPUTSETS.INPUTSETLABEL
+            PIPELINE.INPUTSETS.INPUTSETNAMELABEL
           </p>
         </div>
         <div
@@ -194,7 +194,8 @@ exports[`Input Set List tests render Input Set List view 1`] = `
                 </svg>
               </span>
               <div
-                class="Layout--horizontal Layout--layout-spacing-small StyledProps--main StyledProps--flex StyledProps--flex-alignItems-center"
+                class="Layout--horizontal Layout--layout-spacing-small StyledProps--main StyledProps--flex StyledProps--flex-alignItems-center StyledProps--padding-right-medium"
+                style="flex-shrink: 1;"
               >
                 <div>
                   <div
@@ -202,13 +203,15 @@ exports[`Input Set List tests render Input Set List view 1`] = `
                     data-testid="OverLayInput"
                   >
                     <p
-                      class="StyledProps--font StyledProps--main StyledProps--color StyledProps--color-black"
+                      class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--color StyledProps--color-black"
+                      style="--text-line-clamp: 1;"
                     >
                       OverLayInput
                     </p>
                   </div>
                   <p
-                    class="StyledProps--font StyledProps--main StyledProps--color StyledProps--color-grey400"
+                    class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--color StyledProps--color-grey400"
+                    style="--text-line-clamp: 1;"
                   >
                     idLabel
                   </p>
@@ -259,7 +262,7 @@ exports[`Input Set List tests render Input Set List view 1`] = `
             style="width: 35%;"
           >
             <p
-              class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--color StyledProps--color-grey400"
+              class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--padding-right-medium StyledProps--color StyledProps--color-grey400"
               style="--text-line-clamp: 2;"
             >
               OverLayInput
@@ -392,7 +395,8 @@ exports[`Input Set List tests render Input Set List view 1`] = `
                 </svg>
               </span>
               <div
-                class="Layout--horizontal Layout--layout-spacing-small StyledProps--main StyledProps--flex StyledProps--flex-alignItems-center"
+                class="Layout--horizontal Layout--layout-spacing-small StyledProps--main StyledProps--flex StyledProps--flex-alignItems-center StyledProps--padding-right-medium"
+                style="flex-shrink: 1;"
               >
                 <div>
                   <div
@@ -400,13 +404,15 @@ exports[`Input Set List tests render Input Set List view 1`] = `
                     data-testid="asd"
                   >
                     <p
-                      class="StyledProps--font StyledProps--main StyledProps--color StyledProps--color-black"
+                      class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--color StyledProps--color-black"
+                      style="--text-line-clamp: 1;"
                     >
                       asd
                     </p>
                   </div>
                   <p
-                    class="StyledProps--font StyledProps--main StyledProps--color StyledProps--color-grey400"
+                    class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--color StyledProps--color-grey400"
+                    style="--text-line-clamp: 1;"
                   >
                     idLabel
                   </p>
@@ -457,7 +463,7 @@ exports[`Input Set List tests render Input Set List view 1`] = `
             style="width: 35%;"
           >
             <p
-              class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--color StyledProps--color-grey400"
+              class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--padding-right-medium StyledProps--color StyledProps--color-grey400"
               style="--text-line-clamp: 2;"
             >
               asd

--- a/src/modules/70-pipeline/strings/strings.en.yaml
+++ b/src/modules/70-pipeline/strings/strings.en.yaml
@@ -665,6 +665,7 @@ testsReports:
     requiresEnterprisePlan: Requires Enterprise Plan to access Test Intelligence
 uniqueIdentifier: Identifier must be unique
 inputSets:
+  inputSetNameLabel: Input Set Name
   applyInputSet: Apply Input Set
   applyInputSets: Apply Input Sets
   applyingInputSets: Applying Input Sets

--- a/src/stringTypes.ts
+++ b/src/stringTypes.ts
@@ -2410,6 +2410,7 @@ export interface StringsMap {
   'pipeline.inputSets.applyInputSets': string
   'pipeline.inputSets.applyingInputSet': string
   'pipeline.inputSets.applyingInputSets': string
+  'pipeline.inputSets.inputSetNameLabel': string
   'pipeline.inputSets.inputSetPlaceholder': string
   'pipeline.inputSets.noRuntimeInputsCurrently': string
   'pipeline.inputSets.noRuntimeInputsWhileExecution': string


### PR DESCRIPTION
…et list and form view

##### Summary:

- Adds handling for overflow behaviour in input set list view - name, id, description
- Changes the column heading form INPUT SET to INPUT SET NAME
- Adds handling for overflow behaviour in input set form view for lengthy heading

##### Jira Links:

https://harness.atlassian.net/browse/PIE-2091

<!--- Add jira links for your changes here -->

##### Screenshots:

**Before fix ---->**

<img width="1792" alt="Screenshot 2022-01-16 at 11 15 12 PM" src="https://user-images.githubusercontent.com/96409598/149738011-357e6787-a2a4-478c-b5ea-8d6c3217519d.png">


**After fix ------>**


<img width="1792" alt="Screenshot 2022-01-17 at 2 01 51 PM" src="https://user-images.githubusercontent.com/96409598/149737959-2e24b5ad-4806-4a24-8692-7e13509fe763.png">



https://user-images.githubusercontent.com/96409598/150082355-7d95607e-2157-415e-b31f-33d32cb950ae.mov







https://user-images.githubusercontent.com/96409598/149737983-cabd40be-a7cd-4a46-85e7-9c39cd075c75.mov


https://user-images.githubusercontent.com/96409598/149738042-42ee7e13-76f7-4248-a417-73d3e59f992d.mov


<img width="1792" alt="Screenshot 2022-01-14 at 12 23 24 AM" src="https://user-images.githubusercontent.com/96409598/149738062-634b6882-bf2f-4ab8-ad96-a537f7d4ae5c.png">



https://user-images.githubusercontent.com/96409598/149738096-2b40b98f-0861-4280-99fc-54bff1b55fef.mov




<!--- Add screenshots for your changes here -->

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
