### PR TITLE
fix: [PIE-25770]: resizable and draggable support added

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "react-contenteditable": "^3.3.5",
     "react-dom": "^17.0.2",
     "react-draggable": "^4.4.2",
+    "react-rnd": "^10.3.5",
     "react-lottie-player": "^1.4.0",
     "react-monaco-editor": "^0.34.0",
     "react-popper": "^2.2.3",

--- a/src/modules/10-common/components/DraggableAndResizableWrapper/DraggableAndResizableWrapper.tsx
+++ b/src/modules/10-common/components/DraggableAndResizableWrapper/DraggableAndResizableWrapper.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { Rnd, RndResizeCallback, Props as ReactRndProps } from 'react-rnd'
+import { Container } from '@wings-software/uicore'
+
+interface DraggableAndResizableWrapperProps {
+  className?: string
+  onResize?: RndResizeCallback
+  rndOverrideProps?: ReactRndProps
+}
+
+export const DraggableAndResizableWrapper = (
+  props: React.PropsWithChildren<DraggableAndResizableWrapperProps>,
+  draggableAndResizeableContainerRef: React.ForwardedRef<null | HTMLDivElement>
+) => {
+  const { className, onResize, rndOverrideProps } = props
+
+  return (
+    <Rnd
+      bounds="window"
+      enableResizing={{
+        top: true,
+        bottom: true,
+        left: true,
+        right: true,
+        topRight: false,
+        bottomRight: false,
+        bottomLeft: false,
+        topLeft: false
+      }}
+      {...rndOverrideProps}
+      className={className}
+      onResize={onResize}
+    >
+      <Container style={{ height: '100%' }} ref={draggableAndResizeableContainerRef}>
+        {props.children}
+      </Container>
+    </Rnd>
+  )
+}
+
+export const DraggableAndResizableWrapperWithRef = React.forwardRef(
+  DraggableAndResizableWrapper
+) as React.ForwardRefExoticComponent<
+  React.PropsWithChildren<DraggableAndResizableWrapperProps> & React.RefAttributes<HTMLDivElement | null>
+>

--- a/src/modules/10-common/components/DraggableAndResizableWrapper/DraggableAndResizableWrapper.tsx
+++ b/src/modules/10-common/components/DraggableAndResizableWrapper/DraggableAndResizableWrapper.tsx
@@ -6,10 +6,11 @@ interface DraggableAndResizableWrapperProps {
   className?: string
   onResize?: RndResizeCallback
   rndOverrideProps?: ReactRndProps
+  children?: React.ReactNode
 }
 
 export const DraggableAndResizableWrapper = (
-  props: React.PropsWithChildren<DraggableAndResizableWrapperProps>,
+  props: DraggableAndResizableWrapperProps,
   draggableAndResizeableContainerRef: React.ForwardedRef<null | HTMLDivElement>
 ) => {
   const { className, onResize, rndOverrideProps } = props
@@ -38,8 +39,4 @@ export const DraggableAndResizableWrapper = (
   )
 }
 
-export const DraggableAndResizableWrapperWithRef = React.forwardRef(
-  DraggableAndResizableWrapper
-) as React.ForwardRefExoticComponent<
-  React.PropsWithChildren<DraggableAndResizableWrapperProps> & React.RefAttributes<HTMLDivElement | null>
->
+export const DraggableAndResizableWrapperWithRef = React.forwardRef(DraggableAndResizableWrapper)

--- a/src/modules/10-common/components/DraggableAndResizableWrapper/__tests__/DraggableAndResizableWrapper.test.tsx
+++ b/src/modules/10-common/components/DraggableAndResizableWrapper/__tests__/DraggableAndResizableWrapper.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { DraggableAndResizableWrapperWithRef } from '../DraggableAndResizableWrapper'
+
+const RND_OVERRIDE_PROPS = {
+  default: {
+    x: 50,
+    y: 30,
+    width: 480,
+    height: 500
+  }
+}
+
+describe('Draggable and Resizable test', () => {
+  test('snapshot testing 1', () => {
+    const ref = React.createRef() as React.ForwardedRef<null | HTMLDivElement>
+    const { container } = render(
+      <DraggableAndResizableWrapperWithRef rndOverrideProps={RND_OVERRIDE_PROPS} ref={ref}>
+        <div>Draggable and resizable div</div>
+      </DraggableAndResizableWrapperWithRef>
+    )
+    expect(container).toMatchSnapshot()
+  })
+
+  test('snapshot testing with additional props', () => {
+    const ref = React.createRef() as React.ForwardedRef<null | HTMLDivElement>
+    const { container } = render(
+      <DraggableAndResizableWrapperWithRef
+        className="draggableAndResizableWrapper"
+        rndOverrideProps={{ ...RND_OVERRIDE_PROPS, minWidth: 250, minHeight: 250, bounds: '#parent-id' }}
+        ref={ref}
+      >
+        <div>Draggable and resizable div</div>
+      </DraggableAndResizableWrapperWithRef>
+    )
+    expect(container).toMatchSnapshot()
+  })
+})

--- a/src/modules/10-common/components/DraggableAndResizableWrapper/__tests__/__snapshots__/DraggableAndResizableWrapper.test.tsx.snap
+++ b/src/modules/10-common/components/DraggableAndResizableWrapper/__tests__/__snapshots__/DraggableAndResizableWrapper.test.tsx.snap
@@ -1,0 +1,73 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Draggable and Resizable test snapshot testing 1 1`] = `
+<div>
+  <div
+    class="react-draggable"
+    style="position: absolute; user-select: auto; width: 480px; height: 500px; display: inline-block; top: 0px; left: 0px; cursor: move; transform: translate(100px,60px); max-width: 9007199254740991px; max-height: 9007199254740991px; box-sizing: border-box; flex-shrink: 0;"
+  >
+    <div
+      class="StyledProps--font StyledProps--main"
+      style="height: 100%;"
+    >
+      <div>
+        Draggable and resizable div
+      </div>
+    </div>
+    <div>
+      <div
+        class=""
+        style="position: absolute; user-select: none; width: 100%; height: 10px; top: -5px; left: 0px; cursor: row-resize;"
+      />
+      <div
+        class=""
+        style="position: absolute; user-select: none; width: 100%; height: 10px; bottom: -5px; left: 0px; cursor: row-resize;"
+      />
+      <div
+        class=""
+        style="position: absolute; user-select: none; width: 10px; height: 100%; top: 0px; left: -5px; cursor: col-resize;"
+      />
+      <div
+        class=""
+        style="position: absolute; user-select: none; width: 10px; height: 100%; top: 0px; right: -5px; cursor: col-resize;"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Draggable and Resizable test snapshot testing with additional props 1`] = `
+<div>
+  <div
+    class="draggableAndResizableWrapper react-draggable"
+    style="position: absolute; user-select: auto; width: 480px; height: 500px; display: inline-block; top: 0px; left: 0px; cursor: move; transform: translate(100px,60px); max-width: 9007199254740991px; max-height: 9007199254740991px; min-width: 250px; min-height: 250px; box-sizing: border-box; flex-shrink: 0;"
+  >
+    <div
+      class="StyledProps--font StyledProps--main"
+      style="height: 100%;"
+    >
+      <div>
+        Draggable and resizable div
+      </div>
+    </div>
+    <div>
+      <div
+        class=""
+        style="position: absolute; user-select: none; width: 100%; height: 10px; top: -5px; left: 0px; cursor: row-resize;"
+      />
+      <div
+        class=""
+        style="position: absolute; user-select: none; width: 100%; height: 10px; bottom: -5px; left: 0px; cursor: row-resize;"
+      />
+      <div
+        class=""
+        style="position: absolute; user-select: none; width: 10px; height: 100%; top: 0px; left: -5px; cursor: col-resize;"
+      />
+      <div
+        class=""
+        style="position: absolute; user-select: none; width: 10px; height: 100%; top: 0px; right: -5px; cursor: col-resize;"
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/src/modules/70-pipeline/components/PipelineStudio/StepCommands/StepCommands.module.scss
+++ b/src/modules/70-pipeline/components/PipelineStudio/StepCommands/StepCommands.module.scss
@@ -16,41 +16,6 @@
   position: relative;
   background-color: var(--form-bg);
 
-  :global {
-    .bp3-dialog-container {
-      align-items: flex-start !important;
-    }
-    .bp3-dialog-header {
-      padding: var(--spacing-6);
-      margin: 0 !important;
-
-      .bp3-heading {
-        font-weight: 600 !important;
-      }
-
-      .bp3-dialog-close-button svg {
-        height: var(--spacing-6) !important;
-        width: var(--spacing-6) !important;
-      }
-    }
-    .bp3-dialog {
-      background-color: var(--white) !important;
-      width: 80%;
-      margin-top: 44px;
-      margin-right: 5%;
-      max-height: 500px;
-      padding-bottom: 0 !important;
-      overflow-y: hidden;
-      border-top-left-radius: var(--spacing-3) !important;
-      border-top-right-radius: var(--spacing-3) !important;
-      box-shadow: 0 0 0 1px rgb(16 22 26 / 10%), 0 4px 8px rgb(16 22 26 / 20%), 0 18px 46px 6px rgb(16 22 26 / 20%) !important;
-    }
-
-    .bp3-overlay-backdrop {
-      visibility: hidden !important;
-    }
-  }
-
   &.withoutTabs {
     height: 100%;
   }

--- a/src/modules/70-pipeline/components/PipelineStudio/StepCommands/StepCommands.tsx
+++ b/src/modules/70-pipeline/components/PipelineStudio/StepCommands/StepCommands.tsx
@@ -48,6 +48,20 @@ enum StepCommandTabs {
   Advanced = 'Advanced'
 }
 
+const PREVIEW_DIALOG_INITIAL_HEIGHT = 400
+
+const RND_OVERRIDE_PROPS = {
+  default: {
+    x: 50,
+    y: 30,
+    width: 480,
+    height: PREVIEW_DIALOG_INITIAL_HEIGHT
+  },
+  minWidth: 250,
+  minHeight: 250,
+  bounds: '#step-commands-container'
+}
+
 export function StepCommands(
   props: StepCommandsProps & { checkDuplicateStep?: () => boolean },
   ref: StepCommandsRef
@@ -215,13 +229,15 @@ export function StepCommands(
   }
 
   return (
-    <div className={cx(css.stepCommand, className)}>
+    <div id="step-commands-container" className={cx(css.stepCommand, className)}>
       {stepType === StepType.Template && onUseTemplate && onRemoveTemplate ? (
         <Layout.Vertical margin={'xlarge'} spacing={'xxlarge'}>
           <TemplateBar
             templateLinkConfig={(step as TemplateStepNode).template}
             onOpenTemplateSelector={onUseTemplate}
             onRemoveTemplate={onRemoveTemplate}
+            rndOverrideProps={RND_OVERRIDE_PROPS}
+            previewDialogInitialHeight={PREVIEW_DIALOG_INITIAL_HEIGHT}
           />
           <Container>{getStepWidgetWithFormikRef()}</Container>
         </Layout.Vertical>

--- a/src/modules/70-pipeline/components/PipelineStudio/StepCommands/__tests__/__snapshots__/StepCommands.test.tsx.snap
+++ b/src/modules/70-pipeline/components/PipelineStudio/StepCommands/__tests__/__snapshots__/StepCommands.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`<StepCommands /> tests able to switch tab 1`] = `
 <div>
   <div
     class="stepCommand"
+    id="step-commands-container"
   >
     <div
       class="stepTabs"
@@ -71,6 +72,7 @@ exports[`<StepCommands /> tests renders ok 1`] = `
 <div>
   <div
     class="stepCommand"
+    id="step-commands-container"
   >
     <div
       class="stepTabs"

--- a/src/modules/70-pipeline/components/PipelineStudio/TemplateBar/TemplateBar.module.scss
+++ b/src/modules/70-pipeline/components/PipelineStudio/TemplateBar/TemplateBar.module.scss
@@ -83,9 +83,52 @@
 
 .templateYamlPreviewContainer {
   overflow-y: scroll;
+  height: 100%;
   :global {
     .react-monaco-editor-container {
       padding-top: var(--spacing-3) !important;
+    }
+  }
+}
+
+.templateYaml {
+  height: 100%;
+}
+
+.draggableAndResizableContainer {
+  z-index: 1;
+  margin: 0 !important;
+  :global {
+    .bp3-overlay-scroll-container {
+      overflow: visible !important;
+    }
+    .bp3-dialog-container {
+      align-items: flex-start !important;
+    }
+    .bp3-dialog-header {
+      padding: var(--spacing-6);
+      margin: 0 !important;
+
+      .bp3-heading {
+        font-weight: 600 !important;
+      }
+
+      .bp3-dialog-close-button svg {
+        height: var(--spacing-6) !important;
+        width: var(--spacing-6) !important;
+      }
+    }
+    .bp3-dialog {
+      background-color: var(--white) !important;
+      margin: 0 !important;
+      padding-bottom: 0 !important;
+      width: 100% !important;
+      border-top-left-radius: var(--spacing-3) !important;
+      border-top-right-radius: var(--spacing-3) !important;
+      box-shadow: 0 0 0 1px rgb(16 22 26 / 10%), 0 4px 8px rgb(16 22 26 / 20%), 0 18px 46px 6px rgb(16 22 26 / 20%) !important;
+    }
+    .bp3-overlay-backdrop {
+      visibility: hidden !important;
     }
   }
 }

--- a/src/modules/70-pipeline/components/PipelineStudio/TemplateBar/TemplateBar.module.scss.d.ts
+++ b/src/modules/70-pipeline/components/PipelineStudio/TemplateBar/TemplateBar.module.scss.d.ts
@@ -11,9 +11,11 @@ declare const styles: {
   readonly active: string
   readonly container: string
   readonly disabled: string
+  readonly draggableAndResizableContainer: string
   readonly main: string
   readonly menuItem: string
   readonly popover: string
+  readonly templateYaml: string
   readonly templateYamlPreviewContainer: string
 }
 export default styles

--- a/src/modules/70-pipeline/components/PipelineStudio/TemplateYaml/TemplateYaml.tsx
+++ b/src/modules/70-pipeline/components/PipelineStudio/TemplateYaml/TemplateYaml.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react'
+import cx from 'classnames'
 import { Color, Container, Text, Layout } from '@wings-software/uicore'
 import { defaultTo } from 'lodash-es'
 import MonacoEditor from '@common/components/MonacoEditor/MonacoEditor'
@@ -16,9 +17,14 @@ import css from './TemplateYaml.module.scss'
 export interface TemplateYamlProps {
   templateYaml: string
   withoutHeader?: boolean
+  containerClassName?: string
 }
 
-export const TemplateYaml: React.FC<TemplateYamlProps> = ({ templateYaml, withoutHeader = false }) => {
+export const TemplateYaml: React.FC<TemplateYamlProps> = ({
+  templateYaml,
+  withoutHeader = false,
+  containerClassName
+}) => {
   const [height, setHeight] = React.useState<number>()
 
   React.useEffect(() => {
@@ -27,7 +33,7 @@ export const TemplateYaml: React.FC<TemplateYamlProps> = ({ templateYaml, withou
   }, [templateYaml])
 
   return (
-    <Container className={css.container}>
+    <Container className={cx(css.container, containerClassName)}>
       <Layout.Vertical spacing={'medium'}>
         {!withoutHeader ? (
           <Container

--- a/src/modules/72-templates-library/components/TemplateStageSpecifications/TemplateStageSpecifications.module.scss
+++ b/src/modules/72-templates-library/components/TemplateStageSpecifications/TemplateStageSpecifications.module.scss
@@ -57,24 +57,4 @@
       }
     }
   }
-  :global {
-    .bp3-dialog-container {
-      align-items: flex-start !important;
-    }
-    .bp3-dialog-header {
-      padding: var(--spacing-6);
-    }
-    .bp3-dialog {
-      background-color: var(--white) !important;
-      width: 55%;
-      margin-top: 64px;
-      margin-right: 15%;
-      max-height: 450px;
-      overflow-y: hidden;
-      padding-bottom: 0 !important;
-    }
-    .bp3-overlay-backdrop {
-      visibility: hidden !important;
-    }
-  }
 }

--- a/src/modules/72-templates-library/components/TemplateStageSpecifications/TemplateStageSpecifications.tsx
+++ b/src/modules/72-templates-library/components/TemplateStageSpecifications/TemplateStageSpecifications.tsx
@@ -47,6 +47,18 @@ export interface TemplateStageValues extends StageElementConfig {
   allValues?: StageElementConfig
 }
 
+const RND_OVERRIDE_PROPS = {
+  default: {
+    x: 360,
+    y: 65,
+    width: 650,
+    height: 450
+  },
+  minWidth: 450,
+  minHeight: 450,
+  bounds: '.Pane2'
+}
+
 export const TemplateStageSpecifications = (): JSX.Element => {
   const {
     state: {
@@ -184,6 +196,7 @@ export const TemplateStageSpecifications = (): JSX.Element => {
             onRemoveTemplate={onRemoveTemplate}
             onOpenTemplateSelector={onOpenTemplateSelector}
             className={css.templateBar}
+            rndOverrideProps={RND_OVERRIDE_PROPS}
           />
         )}
         <Formik<TemplateStageValues>

--- a/yarn.lock
+++ b/yarn.lock
@@ -9860,6 +9860,11 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc= sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
 
+fast-memoize@^2.5.1:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/fast-memoize/-/fast-memoize-2.5.2.tgz#79e3bb6a4ec867ea40ba0e7146816f6cdce9b57e"
+  integrity sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==
+
 fast-redact@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/fast-redact/-/fast-redact-3.0.1.tgz#d6015b971e933d03529b01333ba7f22c29961e92"
@@ -16424,6 +16429,13 @@ rdf-canonize@^1.0.2:
     node-forge "^0.10.0"
     semver "^6.3.0"
 
+re-resizable@6.9.1:
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/re-resizable/-/re-resizable-6.9.1.tgz#6be082b55d02364ca4bfee139e04feebdf52441c"
+  integrity sha512-KRYAgr9/j1PJ3K+t+MBhlQ+qkkoLDJ1rs0z1heIWvYbCW/9Vq4djDU+QumJ3hQbwwtzXF6OInla6rOx6hhgRhQ==
+  dependencies:
+    fast-memoize "^2.5.1"
+
 react-beautiful-dnd@^13.0.0:
   version "13.0.0"
   resolved "https://registry.yarnpkg.com/react-beautiful-dnd/-/react-beautiful-dnd-13.0.0.tgz#f70cc8ff82b84bc718f8af157c9f95757a6c3b40"
@@ -16515,7 +16527,7 @@ react-dom@^17.0.2:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
-react-draggable@^4.4.2, react-draggable@^4.4.3:
+react-draggable@4.4.3, react-draggable@^4.4.2, react-draggable@^4.4.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-4.4.3.tgz#0727f2cae5813e36b0e4962bf11b2f9ef2b406f3"
   integrity "sha1-ByfyyuWBPjaw5JYr8RsvnvK0BvM= sha512-jV4TE59MBuWm7gb6Ns3Q1mxX8Azffb7oTtDtBgFkxRvhDp38YAARmRplrj0+XGkhOJB5XziArX+4HUUABtyZ0w=="
@@ -16667,6 +16679,15 @@ react-refresh@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
   integrity "sha1-ch1GV2ctQAxePHXQY8SoX7LV1o8= sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg=="
+
+react-rnd@^10.3.5:
+  version "10.3.5"
+  resolved "https://registry.yarnpkg.com/react-rnd/-/react-rnd-10.3.5.tgz#b66e5e06f1eb6823e72eb4b552081b4b9241b139"
+  integrity sha512-LWJP+l5bp76sDPKrKM8pwGJifI6i3B5jHK4ONACczVMbR8ycNGA75ORRqpRuXGyKawUs68s1od05q8cqWgQXgw==
+  dependencies:
+    re-resizable "6.9.1"
+    react-draggable "4.4.3"
+    tslib "2.3.0"
 
 react-router-dom@^5.2.0:
   version "5.2.0"
@@ -19298,6 +19319,11 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
+tslib@2.3.0, tslib@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
+  integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
+
 tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.3:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
@@ -19312,11 +19338,6 @@ tslib@^2, tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
   integrity "sha1-+yxHWXfjXiQTEe3iaTzuHsZpj1w= sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
-
-tslib@^2.2.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
-  integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
 
 tslib@~1.10.0:
   version "1.10.0"


### PR DESCRIPTION
##### Summary:

Adds support for resizable and draggable components

##### Jira Links:

https://harness.atlassian.net/browse/CDS-25770

##### Screenshots:


https://user-images.githubusercontent.com/96409598/154804145-c40df51c-590d-4fc3-a8a8-5d1c76da8ef6.mov





https://user-images.githubusercontent.com/96409598/154804148-6aea4227-e6ee-4fe8-b2b4-0da295750deb.mov


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
