### PR TITLE
fix: [CI-3314]: Fix incorrect filter structure sent for Repository name filter

### DIFF
--- a/cypress/support/70-pipeline/constants.ts
+++ b/cypress/support/70-pipeline/constants.ts
@@ -1,3 +1,10 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
 const projectId = 'project1'
 const accountId = 'accountId'
 const orgIdentifier = 'default'
@@ -82,7 +89,7 @@ export const pipelinesListCallResponse = {
             infrastructureTypes: ['KubernetesDirect']
           },
           ci: {
-            repoNames: ['CCD']
+            repoName: 'harness-core-ui'
           }
         },
         stageNames: ['Stage 5', 'Stage 6', 'Stage 3', 'Stage 4', 'Stage 1', 'Stage 2'],

--- a/cypress/support/70-pipeline/constants.ts
+++ b/cypress/support/70-pipeline/constants.ts
@@ -89,7 +89,7 @@ export const pipelinesListCallResponse = {
             infrastructureTypes: ['KubernetesDirect']
           },
           ci: {
-            repoName: 'harness-core-ui'
+            repoNames: ['CCD']
           }
         },
         stageNames: ['Stage 5', 'Stage 6', 'Stage 3', 'Stage 4', 'Stage 1', 'Stage 2'],

--- a/src/modules/70-pipeline/pages/pipeline-deployment-list/PipelineDeploymentListHeader/ExecutionFilters/ExecutionFilters.tsx
+++ b/src/modules/70-pipeline/pages/pipeline-deployment-list/PipelineDeploymentListHeader/ExecutionFilters/ExecutionFilters.tsx
@@ -144,7 +144,7 @@ export function ExecutionFilters(): React.ReactElement {
         ['branch', getString('pipelineSteps.deploy.inputSet.branch')],
         ['tag', getString('tagLabel')],
         ['buildType', getString('filters.executions.buildType')],
-        ['repoNames', getString('common.repositoryName')],
+        ['repoName', getString('common.repositoryName')],
         ['serviceDefinitionTypes', getString('deploymentTypeText')],
         ['infrastructureType', getString('infrastructureTypeText')],
         ['serviceIdentifiers', getString('services')],
@@ -275,7 +275,7 @@ export function ExecutionFilters(): React.ReactElement {
         initialFilter={{
           formValues: {
             pipelineName,
-            repositoryName: repoName?.[0] || undefined,
+            repositoryName: repoName,
             status: getMultiSelectFormOptions(status),
             branch,
             tag,

--- a/src/modules/70-pipeline/pages/pipeline-deployment-list/__tests__/filters.json
+++ b/src/modules/70-pipeline/pages/pipeline-deployment-list/__tests__/filters.json
@@ -32,8 +32,9 @@
             "ci": {
               "ciExecutionInfoDTO": {
                 "event": "pullRequest",
-                "pullRequest": { "sourceBranch": "fromB", "targetBranch": "toB" }
-              }
+                "pullRequest": { "sourceBranch": "feature-branch", "targetBranch": "develop" }
+              },
+              "repoName": "harness-test-repo"
             }
           },
           "tags": {},

--- a/src/modules/70-pipeline/utils/PipelineExecutionFilterRequestUtils.ts
+++ b/src/modules/70-pipeline/utils/PipelineExecutionFilterRequestUtils.ts
@@ -160,7 +160,7 @@ export const getCIModuleProperties = (buildType: BUILD_TYPE, contextInfo: BuildT
       break
   }
 
-  return Object.assign(moduleProperties, { repoName: repositoryName })
+  return repositoryName ? Object.assign(moduleProperties, { repoName: repositoryName }) : moduleProperties
 }
 
 export const enum BUILD_TYPE {

--- a/src/modules/70-pipeline/utils/PipelineExecutionFilterRequestUtils.ts
+++ b/src/modules/70-pipeline/utils/PipelineExecutionFilterRequestUtils.ts
@@ -144,7 +144,7 @@ export const getCIModuleProperties = (buildType: BUILD_TYPE, contextInfo: BuildT
       moduleProperties = {
         ciExecutionInfoDTO: {
           event: 'pullRequest',
-          pullRequest: { sourceRepo: repositoryName, sourceBranch: sourceBranch, targetBranch: targetBranch }
+          pullRequest: { sourceBranch: sourceBranch, targetBranch: targetBranch }
         } as CIWebhookInfoDTO
       }
       break
@@ -160,7 +160,7 @@ export const getCIModuleProperties = (buildType: BUILD_TYPE, contextInfo: BuildT
       break
   }
 
-  return Object.assign(moduleProperties, { repoName: repositoryName ? [repositoryName] : undefined })
+  return Object.assign(moduleProperties, { repoName: repositoryName })
 }
 
 export const enum BUILD_TYPE {

--- a/src/modules/70-pipeline/utils/PipelineExecutionFilterRequestUtils.ts
+++ b/src/modules/70-pipeline/utils/PipelineExecutionFilterRequestUtils.ts
@@ -13,8 +13,6 @@ import { EXECUTION_STATUS } from '@pipeline/utils/statusHelpers'
 import type { FilterDataInterface, FilterInterface } from '@common/components/Filter/Constants'
 import { StringUtils } from '@common/exports'
 import type { CIWebhookInfoDTO } from 'services/ci'
-import type { FilterProperties } from 'services/cd-ng'
-import { isObjectEmpty, removeNullAndEmpty } from '@common/components/Filter/utils/FilterUtils'
 
 export interface DeploymentTypeContext {
   deploymentType?: MultiSelectOption[]
@@ -167,18 +165,6 @@ export const enum BUILD_TYPE {
   PULL_OR_MERGE_REQUEST = 'PULL_OR_MERGE_REQUEST',
   BRANCH = 'BRANCH',
   TAG = 'TAG'
-}
-
-export const getFilterWithValidFields = (
-  formData: PipelineExecutionFormType | undefined,
-  filterProperties: FilterProperties | undefined
-): Partial<PipelineExecutionFormType> | Partial<FilterProperties> | undefined => {
-  if (!isObjectEmpty(filterProperties || {})) {
-    return removeNullAndEmpty(omit(filterProperties, 'filterType'))
-  } else if (!isObjectEmpty(formData || {})) {
-    return removeNullAndEmpty(formData || {})
-  }
-  return {}
 }
 
 export const getBuildType = (moduleProperties: {

--- a/src/modules/70-pipeline/utils/PipelineExecutionFilterRequestUtils.ts
+++ b/src/modules/70-pipeline/utils/PipelineExecutionFilterRequestUtils.ts
@@ -136,7 +136,7 @@ export const createRequestBodyPayload = ({
   }
 }
 
-export const getCIModuleProperties = (buildType: BUILD_TYPE, contextInfo: BuildTypeContext): any => {
+export const getCIModuleProperties = (buildType: BUILD_TYPE, contextInfo: BuildTypeContext): Record<string, any> => {
   const { repositoryName, sourceBranch, targetBranch, branch, tag } = contextInfo
   let moduleProperties = {}
   switch (buildType) {

--- a/src/modules/70-pipeline/utils/__tests__/PipelineExecutionFilterRequestUtils.test.ts
+++ b/src/modules/70-pipeline/utils/__tests__/PipelineExecutionFilterRequestUtils.test.ts
@@ -21,7 +21,7 @@ describe('Test util methods', () => {
       branch: 'develop'
     })
     expect(Object.prototype.hasOwnProperty.call(modulePropertiesForBranch, 'branch')).toBeTruthy()
-    const modulePropertiesForTag = getCIModuleProperties(BUILD_TYPE.BRANCH, {
+    const modulePropertiesForTag = getCIModuleProperties(BUILD_TYPE.TAG, {
       tag: 'release'
     })
     expect(Object.prototype.hasOwnProperty.call(modulePropertiesForTag, 'tag')).toBeTruthy()

--- a/src/modules/70-pipeline/utils/__tests__/PipelineExecutionFilterRequestUtils.test.ts
+++ b/src/modules/70-pipeline/utils/__tests__/PipelineExecutionFilterRequestUtils.test.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import { BUILD_TYPE, getCIModuleProperties } from '../PipelineExecutionFilterRequestUtils'
+
+describe('Test util methods', () => {
+  test('Test getCIModuleProperties method', () => {
+    const moduleProperties = getCIModuleProperties(BUILD_TYPE.PULL_OR_MERGE_REQUEST, {
+      buildType: BUILD_TYPE.PULL_OR_MERGE_REQUEST,
+      repositoryName: 'harness-core-ui',
+      sourceBranch: 'feature-branch',
+      targetBranch: 'develop'
+    })
+    expect(Object.prototype.hasOwnProperty.call(moduleProperties, 'ciExecutionInfoDTO')).toBeTruthy()
+    expect(Object.prototype.hasOwnProperty.call(moduleProperties, 'repoName')).toBeTruthy()
+  })
+})

--- a/src/modules/70-pipeline/utils/__tests__/PipelineExecutionFilterRequestUtils.test.ts
+++ b/src/modules/70-pipeline/utils/__tests__/PipelineExecutionFilterRequestUtils.test.ts
@@ -21,5 +21,9 @@ describe('Test util methods', () => {
       branch: 'develop'
     })
     expect(Object.prototype.hasOwnProperty.call(modulePropertiesForBranch, 'branch')).toBeTruthy()
+    const modulePropertiesForTag = getCIModuleProperties(BUILD_TYPE.BRANCH, {
+      tag: 'release'
+    })
+    expect(Object.prototype.hasOwnProperty.call(modulePropertiesForTag, 'tag')).toBeTruthy()
   })
 })

--- a/src/modules/70-pipeline/utils/__tests__/PipelineExecutionFilterRequestUtils.test.ts
+++ b/src/modules/70-pipeline/utils/__tests__/PipelineExecutionFilterRequestUtils.test.ts
@@ -9,13 +9,17 @@ import { BUILD_TYPE, getCIModuleProperties } from '../PipelineExecutionFilterReq
 
 describe('Test util methods', () => {
   test('Test getCIModuleProperties method', () => {
-    const moduleProperties = getCIModuleProperties(BUILD_TYPE.PULL_OR_MERGE_REQUEST, {
+    const modulePropertiesForPullRequest = getCIModuleProperties(BUILD_TYPE.PULL_OR_MERGE_REQUEST, {
       buildType: BUILD_TYPE.PULL_OR_MERGE_REQUEST,
       repositoryName: 'harness-core-ui',
       sourceBranch: 'feature-branch',
       targetBranch: 'develop'
     })
-    expect(Object.prototype.hasOwnProperty.call(moduleProperties, 'ciExecutionInfoDTO')).toBeTruthy()
-    expect(Object.prototype.hasOwnProperty.call(moduleProperties, 'repoName')).toBeTruthy()
+    expect(Object.prototype.hasOwnProperty.call(modulePropertiesForPullRequest, 'ciExecutionInfoDTO')).toBeTruthy()
+    expect(Object.prototype.hasOwnProperty.call(modulePropertiesForPullRequest, 'repoName')).toBeTruthy()
+    const modulePropertiesForBranch = getCIModuleProperties(BUILD_TYPE.BRANCH, {
+      branch: 'develop'
+    })
+    expect(Object.prototype.hasOwnProperty.call(modulePropertiesForBranch, 'branch')).toBeTruthy()
   })
 })

--- a/src/modules/70-pipeline/utils/__tests__/PipelineExecutionFilterRequestUtils.test.ts
+++ b/src/modules/70-pipeline/utils/__tests__/PipelineExecutionFilterRequestUtils.test.ts
@@ -5,25 +5,61 @@
  * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
  */
 
-import { BUILD_TYPE, getCIModuleProperties } from '../PipelineExecutionFilterRequestUtils'
+import { BUILD_TYPE, getCIModuleProperties, getValidFilterArguments } from '../PipelineExecutionFilterRequestUtils'
 
 describe('Test util methods', () => {
   test('Test getCIModuleProperties method', () => {
-    const modulePropertiesForPullRequest = getCIModuleProperties(BUILD_TYPE.PULL_OR_MERGE_REQUEST, {
-      buildType: BUILD_TYPE.PULL_OR_MERGE_REQUEST,
-      repositoryName: 'harness-core-ui',
-      sourceBranch: 'feature-branch',
-      targetBranch: 'develop'
+    expect(
+      getCIModuleProperties(BUILD_TYPE.PULL_OR_MERGE_REQUEST, {
+        buildType: BUILD_TYPE.PULL_OR_MERGE_REQUEST,
+        repositoryName: 'harness-core-ui',
+        sourceBranch: 'feature-branch',
+        targetBranch: 'develop'
+      })
+    ).toEqual({
+      ciExecutionInfoDTO: {
+        event: 'pullRequest',
+        pullRequest: { sourceBranch: 'feature-branch', targetBranch: 'develop' }
+      },
+      repoName: 'harness-core-ui'
     })
-    expect(Object.prototype.hasOwnProperty.call(modulePropertiesForPullRequest, 'ciExecutionInfoDTO')).toBeTruthy()
-    expect(Object.prototype.hasOwnProperty.call(modulePropertiesForPullRequest, 'repoName')).toBeTruthy()
-    const modulePropertiesForBranch = getCIModuleProperties(BUILD_TYPE.BRANCH, {
-      branch: 'develop'
-    })
-    expect(Object.prototype.hasOwnProperty.call(modulePropertiesForBranch, 'branch')).toBeTruthy()
-    const modulePropertiesForTag = getCIModuleProperties(BUILD_TYPE.TAG, {
+
+    expect(
+      getCIModuleProperties(BUILD_TYPE.BRANCH, {
+        branch: 'develop'
+      })
+    ).toEqual({ branch: 'develop' })
+
+    expect(
+      getCIModuleProperties(BUILD_TYPE.TAG, {
+        tag: 'release'
+      })
+    ).toEqual({
       tag: 'release'
     })
-    expect(Object.prototype.hasOwnProperty.call(modulePropertiesForTag, 'tag')).toBeTruthy()
+  })
+
+  test('Test method getValidFilterArguments', () => {
+    expect(
+      getValidFilterArguments({
+        pipelineName: 'test-pipeline',
+        repositoryName: 'harness-core-ui',
+        sourceBranch: 'develop',
+        targetBranch: 'master',
+        buildType: 'PULL_OR_MERGE_REQUEST'
+      })
+    ).toEqual({
+      pipelineName: 'test-pipeline',
+      moduleProperties: {
+        ci: {
+          ciExecutionInfoDTO: {
+            event: 'pullRequest',
+            pullRequest: { sourceBranch: 'develop', targetBranch: 'master' }
+          },
+          repoName: 'harness-core-ui'
+        },
+        cd: {}
+      }
+    })
   })
 })


### PR DESCRIPTION
##### Summary:

Bug fix for : https://harness.atlassian.net/browse/CI-3314

Fixed repository name handling in the overall filter payload.

<!--- Add summary of your changes here -->

##### Jira Links:

<!--- Add jira links for your changes here -->

##### Screenshots:

<!--- Add screenshots for your changes here -->

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
