### PR TITLE
fix: [PIE-2766]: Error strip is fixed at top

### DIFF
--- a/src/modules/70-pipeline/components/ErrorsStrip/ErrorsStrip.module.scss
+++ b/src/modules/70-pipeline/components/ErrorsStrip/ErrorsStrip.module.scss
@@ -35,7 +35,5 @@
 }
 
 .sticky {
-  top: 97px;
   width: 100% !important;
-  z-index: 10;
 }

--- a/src/modules/70-pipeline/components/ErrorsStrip/ErrorsStrip.module.scss
+++ b/src/modules/70-pipeline/components/ErrorsStrip/ErrorsStrip.module.scss
@@ -35,7 +35,6 @@
 }
 
 .sticky {
-  position: fixed;
   top: 97px;
   width: 100% !important;
   z-index: 10;


### PR DESCRIPTION
Summary:

Earlier, error strip moved with scrolling.
Now, it is fixed at top.

Jira Links:

https://harness.atlassian.net/browse/PIE-2766

 Screenshots:


https://user-images.githubusercontent.com/98508399/155072704-7120f841-7d93-47e5-a49c-237e7deac529.mov


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
