### PR TITLE
fix: [PIE-2699]: dropdown values not visible

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@harness/monaco-yaml": "^1.0.0",
     "@harness/ng-tooltip": "^1.30.68",
     "@harness/telemetry": "^1.0.37",
-    "@harness/uicore": "2.22.0",
+    "@harness/uicore": "2.23.0",
     "@harness/use-modal": "1.1.0",
     "@popperjs/core": "^2.4.2",
     "@projectstorm/react-diagrams-core": "^6.6.0",

--- a/src/modules/10-common/components/GitFilters/__tests__/__snapshots__/GitFilters.test.tsx.snap
+++ b/src/modules/10-common/components/GitFilters/__tests__/__snapshots__/GitFilters.test.tsx.snap
@@ -72,7 +72,7 @@ exports[`Git filter test for repo and branch selecion Test for changing repo and
           style="position: absolute; will-change: transform; top: 0px; left: 0px; transform: translate3d(NaNpx, NaNpx, 0);"
         >
           <div
-            class="bp3-popover bp3-minimal bp3-select-popover"
+            class="bp3-popover bp3-minimal bp3-select-popover Select--popover"
             style="transform-origin: center top;"
           >
             <div

--- a/src/modules/35-connectors/components/CreateConnector/CEK8sConnector/__tests__/__snapshots__/CreateCEK8sConnector.test.tsx.snap
+++ b/src/modules/35-connectors/components/CreateConnector/CEK8sConnector/__tests__/__snapshots__/CreateCEK8sConnector.test.tsx.snap
@@ -223,7 +223,7 @@ exports[`Create CE K8s Connector Wizard Proceed with following steps 1`] = `
                                   style="position: absolute; will-change: transform; top: 0px; left: 0px; transform: translate3d(NaNpx, NaNpx, 0);"
                                 >
                                   <div
-                                    class="bp3-popover bp3-minimal bp3-select-popover"
+                                    class="bp3-popover bp3-minimal bp3-select-popover Select--popover"
                                     style="transform-origin: center top;"
                                   >
                                     <div

--- a/src/modules/35-connectors/components/CreateConnector/HashiCorpVault/__test__/__snapshots__/VaultConnectorFormFields.test.tsx.snap
+++ b/src/modules/35-connectors/components/CreateConnector/HashiCorpVault/__test__/__snapshots__/VaultConnectorFormFields.test.tsx.snap
@@ -333,7 +333,7 @@ exports[`Check AWS Auth should render form in edit for the aws Iam 1`] = `
                         style="position: absolute; top: 0px; left: 0px; transform: translate3d(NaNpx, NaNpx, 0); will-change: transform;"
                       >
                         <div
-                          class="bp3-popover bp3-minimal bp3-select-popover"
+                          class="bp3-popover bp3-minimal bp3-select-popover Select--popover"
                           style="transform-origin: center top;"
                         >
                           <div
@@ -593,7 +593,7 @@ exports[`Check AWS Auth should render form in edit for the aws Iam 1`] = `
                         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
                       >
                         <div
-                          class="bp3-popover bp3-minimal bp3-select-popover"
+                          class="bp3-popover bp3-minimal bp3-select-popover Select--popover"
                         >
                           <div
                             class="bp3-popover-content"

--- a/src/modules/35-connectors/components/CreateConnector/SumoLogicConnector/__tests__/__snapshots__/CreateSumoLogicConnector.test.tsx.snap
+++ b/src/modules/35-connectors/components/CreateConnector/SumoLogicConnector/__tests__/__snapshots__/CreateSumoLogicConnector.test.tsx.snap
@@ -103,7 +103,7 @@ exports[`Create Sumo Logic connector Wizard Ensure create flow works 1`] = `
                       style="position: absolute; will-change: transform; top: 0px; left: 0px; transform: translate3d(NaNpx, NaNpx, 0);"
                     >
                       <div
-                        class="bp3-popover bp3-minimal bp3-select-popover"
+                        class="bp3-popover bp3-minimal bp3-select-popover Select--popover"
                         style="transform-origin: center top;"
                       >
                         <div

--- a/src/modules/72-triggers/pages/triggers/__tests__/__snapshots__/SchedulePanel.test.tsx.snap
+++ b/src/modules/72-triggers/pages/triggers/__tests__/__snapshots__/SchedulePanel.test.tsx.snap
@@ -250,7 +250,7 @@ exports[`SchedulePanel Triggers tests Interactivity: Schedule Tabs Hourly select
                             style="position: absolute; will-change: transform; top: 0px; left: 0px; transform: translate3d(NaNpx, NaNpx, 0);"
                           >
                             <div
-                              class="bp3-popover bp3-minimal bp3-select-popover"
+                              class="bp3-popover bp3-minimal bp3-select-popover Select--popover"
                               style="transform-origin: center top;"
                             >
                               <div
@@ -1270,7 +1270,7 @@ exports[`SchedulePanel Triggers tests Interactivity: Schedule Tabs Minutes selec
                               style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
                             >
                               <div
-                                class="bp3-popover bp3-minimal bp3-select-popover"
+                                class="bp3-popover bp3-minimal bp3-select-popover Select--popover"
                               >
                                 <div
                                   class="bp3-popover-content"

--- a/src/modules/75-ce/components/COEcsSelector/__tests__/__snapshots__/COEcsSelector.test.tsx.snap
+++ b/src/modules/75-ce/components/COEcsSelector/__tests__/__snapshots__/COEcsSelector.test.tsx.snap
@@ -621,7 +621,7 @@ exports[`ECS Service Selector Modal should fill in region and cluster and displa
                 style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
               >
                 <div
-                  class="bp3-popover bp3-minimal bp3-select-popover"
+                  class="bp3-popover bp3-minimal bp3-select-popover Select--popover"
                 >
                   <div
                     class="bp3-popover-content"
@@ -698,7 +698,7 @@ exports[`ECS Service Selector Modal should fill in region and cluster and displa
                 style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
               >
                 <div
-                  class="bp3-popover bp3-minimal bp3-select-popover"
+                  class="bp3-popover bp3-minimal bp3-select-popover Select--popover"
                 >
                   <div
                     class="bp3-popover-content"

--- a/src/modules/75-ce/components/COGatewayConfig/__tests__/__snapshots__/COHealthCheckTable.test.tsx.snap
+++ b/src/modules/75-ce/components/COGatewayConfig/__tests__/__snapshots__/COHealthCheckTable.test.tsx.snap
@@ -307,7 +307,7 @@ exports[`HealthCheck table tests update table values 1`] = `
                     style="position: absolute; will-change: transform; top: 0px; left: 0px; transform: translate3d(NaNpx, NaNpx, 0);"
                   >
                     <div
-                      class="bp3-popover bp3-minimal bp3-select-popover"
+                      class="bp3-popover bp3-minimal bp3-select-popover Select--popover"
                       style="transform-origin: center top;"
                     >
                       <div

--- a/src/modules/75-ce/components/COGatewayConfig/__tests__/__snapshots__/CORoutingTable.test.tsx.snap
+++ b/src/modules/75-ce/components/COGatewayConfig/__tests__/__snapshots__/CORoutingTable.test.tsx.snap
@@ -240,7 +240,7 @@ exports[`Routing Table Tests fill in details for a route: updated route 1`] = `
                       style="position: absolute; will-change: transform; top: 0px; left: 0px; transform: translate3d(NaNpx, NaNpx, 0);"
                     >
                       <div
-                        class="bp3-popover bp3-minimal bp3-select-popover"
+                        class="bp3-popover bp3-minimal bp3-select-popover Select--popover"
                         style="transform-origin: center top;"
                       >
                         <div
@@ -580,7 +580,7 @@ exports[`Routing Table Tests render additional columns for redirection rule 1`] 
                       style="position: absolute; will-change: transform; top: 0px; left: 0px; transform: translate3d(NaNpx, NaNpx, 0);"
                     >
                       <div
-                        class="bp3-popover bp3-minimal bp3-select-popover"
+                        class="bp3-popover bp3-minimal bp3-select-popover Select--popover"
                         style="transform-origin: center top;"
                       >
                         <div

--- a/src/modules/75-ce/components/CORdsSelector/__tests__/__snapshots__/CORdsSelector.test.tsx.snap
+++ b/src/modules/75-ce/components/CORdsSelector/__tests__/__snapshots__/CORdsSelector.test.tsx.snap
@@ -344,7 +344,7 @@ exports[`RDS DB Selector Modal should fill in region display list of databases 1
                 style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
               >
                 <div
-                  class="bp3-popover bp3-minimal bp3-select-popover"
+                  class="bp3-popover bp3-minimal bp3-select-popover Select--popover"
                 >
                   <div
                     class="bp3-popover-content"

--- a/src/modules/75-ci/components/PipelineSteps/RunStep/__test__/RunStep.test.tsx
+++ b/src/modules/75-ci/components/PipelineSteps/RunStep/__test__/RunStep.test.tsx
@@ -78,7 +78,7 @@ describe('Run Step', () => {
       expect(shellOptionsDropdownSelect).toBeTruthy()
       await waitFor(() => {
         fireEvent.click(shellOptionsDropdownSelect)
-        const menuItemLabels = container.querySelectorAll('[class*="menuItemLabel"]')
+        const menuItemLabels = document.querySelectorAll('[class*="menuItemLabel"]')
         expect(menuItemLabels.length).toEqual(2)
         expect(menuItemLabels[0].innerHTML).toEqual('common.bash')
         expect(menuItemLabels[1].innerHTML).toEqual('common.shell')

--- a/src/modules/75-ci/components/PipelineSteps/RunStep/__test__/RunStepForVMs.test.tsx
+++ b/src/modules/75-ci/components/PipelineSteps/RunStep/__test__/RunStepForVMs.test.tsx
@@ -67,7 +67,7 @@ describe('Run Step view', () => {
       expect(shellOptionsDropdownSelect).toBeTruthy()
       await waitFor(() => {
         fireEvent.click(shellOptionsDropdownSelect)
-        const menuItemLabels = container.querySelectorAll('[class*="menuItemLabel"]')
+        const menuItemLabels = document.querySelectorAll('[class*="menuItemLabel"]')
         expect(menuItemLabels.length).toEqual(4)
         expect(menuItemLabels[0].innerHTML).toEqual('common.bash')
         expect(menuItemLabels[1].innerHTML).toEqual('common.shell')

--- a/src/modules/75-ci/components/PipelineSteps/RunTestsStep/__test__/RunTestsStep.test.tsx
+++ b/src/modules/75-ci/components/PipelineSteps/RunTestsStep/__test__/RunTestsStep.test.tsx
@@ -74,7 +74,7 @@ describe('RunTests Step', () => {
 
       await waitFor(() => {
         fireEvent.click(dropdownSelects[1])
-        const menuItemLabels = container.querySelectorAll('[class*="menuItemLabel"]')
+        const menuItemLabels = document.querySelectorAll('[class*="menuItemLabel"]')
         expect(menuItemLabels.length).toEqual(1)
         // Only Java option should be visible
         expect(menuItemLabels[0].innerHTML).toEqual('Java')

--- a/src/modules/75-ci/components/PipelineSteps/RunTestsStep/__test__/RunTestsStepForVMs.test.tsx
+++ b/src/modules/75-ci/components/PipelineSteps/RunTestsStep/__test__/RunTestsStepForVMs.test.tsx
@@ -42,7 +42,7 @@ describe('RunTests Step', () => {
 
       await waitFor(() => {
         fireEvent.click(dropdownSelects[0])
-        const menuItemLabels = container.querySelectorAll('[class*="menuItemLabel"]')
+        const menuItemLabels = document.querySelectorAll('[class*="menuItemLabel"]')
         expect(menuItemLabels.length).toEqual(2)
         // Csharp option should only be visible for AWS VMs Build Infra
         expect(menuItemLabels[0].innerHTML).toEqual('Csharp')

--- a/yarn.lock
+++ b/yarn.lock
@@ -2502,10 +2502,10 @@
   resolved "https://npm.pkg.github.com/download/@harness/telemetry/1.0.37/fbc5025fb5969920627473304e041288420f44d63aa9cce82e1d06416bb2cf07#800efb2a98fc01bde907543f2509f7009573a1d7"
   integrity sha512-oUwcx7FSbKD0VTs/5Ng/mrYLEGj8FDtpsDhLniVgnsY02i15HszImvAEx6o32Pur3TcF1BKL/MRFu4W6lSKiPA==
 
-"@harness/uicore@2.22.0":
-  version "2.22.0"
-  resolved "https://npm.pkg.github.com/download/@harness/uicore/2.22.0/e5781df9a18d528b349c2b65ea465d4c06137c833431af4154841ca8d0a8b54d#af05026d7886924d0312a9b2761bab81c8e86f18"
-  integrity sha512-fVMfEm2POrScnhgP2XYm3bwYouL+7VO6wDfS7Q9mV60lHSaFfBsNOlsEwlOB5vQGybOor7s+Stx8oE9/Q7kp9Q==
+"@harness/uicore@2.23.0":
+  version "2.23.0"
+  resolved "https://npm.pkg.github.com/download/@harness/uicore/2.23.0/5df8d249168dd3931b8c449c28270cf14b670bba7b5f0463914285f8c71b472c#0fb6350989e8ddcf5dad2521bacffbc2ac32a5cf"
+  integrity sha512-jG2F3oGWM6cad0HIx4JydAYA4F6WUCmEbakfhvNh4key3gHOdmZTEfXh8AAtoBPQBa3+t0be+J2JJcDFNgjt5w==
 
 "@harness/use-modal@1.1.0":
   version "1.1.0"


### PR DESCRIPTION
##### Summary:

Dropdown values were rendering inside the parent instead of being painted over

##### Jira Links:

https://harness.atlassian.net/browse/PIE-2699

##### Screenshots:

Before:

https://user-images.githubusercontent.com/96711906/155439369-985a80d2-f58c-4272-8854-18f5b8f478b1.mov

After:

https://user-images.githubusercontent.com/96711906/155546683-6690ff37-738a-47c8-bf86-7c4e10706249.mov

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
