### PR TITLE
fix: [CDS-34221]: fix crash when creating new artifactory connector a…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nextgenui",
   "description": "Harness Inc",
-  "version": "0.288.5",
+  "version": "0.288.0",
   "author": "Harness Inc",
   "license": "Harness Inc",
   "homepage": "http://app.harness.io/",
@@ -48,7 +48,7 @@
     "generate-certificate": "sh scripts/generate-certificate.sh",
     "build-docker": "sh scripts/docker-build.sh",
     "lighthouse": "node scripts/lighthouse/lighthouse.js",
-    "custom-coverage": "npx new-files-coverage-check --e !**/*.test.tsx !**/*.test.ts !**/*.snap !**/*.js !**/*.scss !**/*.mock.ts !**/*.spec.ts !**/*.d.ts !**/*.json !**/*.types.ts !**/*.yaml !**cypress/**"
+    "custom-coverage": "npx new-files-coverage-check --e !**/*.test.tsx !**/*.test.ts !**/*.snap !**/*.js !**/*.scss !**/*.mock.ts !**/*.spec.ts !**/*.d.ts !**/*.json !**/*.types.ts !**/*.yml !**/*.yaml !**cypress/**"
   },
   "dependencies": {
     "@blueprintjs/core": "3.26.1",
@@ -59,7 +59,7 @@
     "@harness/monaco-yaml": "^1.0.0",
     "@harness/ng-tooltip": "^1.30.68",
     "@harness/telemetry": "^1.0.37",
-    "@harness/uicore": "^2.18.0",
+    "@harness/uicore": "2.23.0",
     "@harness/use-modal": "1.1.0",
     "@popperjs/core": "^2.4.2",
     "@projectstorm/react-diagrams-core": "^6.6.0",
@@ -100,7 +100,8 @@
     "react-monaco-editor": "^0.34.0",
     "react-popper": "^2.2.3",
     "react-qr-code": "^1.1.1",
-    "react-router-dom": "^5.2.0",
+    "react-router": "^5.2.1",
+    "react-router-dom": "^5.2.1",
     "react-split-pane": "^0.1.92",
     "react-table": "^7.1.0",
     "react-table-sticky": "^1.1.3",
@@ -128,13 +129,13 @@
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
     "@stoplight/prism-cli": "^4.3.1",
     "@stoplight/prism-http": "^4.3.1",
-    "@storybook/addon-actions": "^6.3.1",
-    "@storybook/addon-docs": "^6.3.1",
-    "@storybook/addon-essentials": "^6.3.1",
-    "@storybook/addon-links": "^6.3.1",
-    "@storybook/builder-webpack5": "^6.3.1",
-    "@storybook/manager-webpack5": "^6.3.1",
-    "@storybook/react": "^6.3.1",
+    "@storybook/addon-actions": "^6.4.19",
+    "@storybook/addon-docs": "^6.4.19",
+    "@storybook/addon-essentials": "^6.4.19",
+    "@storybook/addon-links": "^6.4.19",
+    "@storybook/builder-webpack5": "^6.4.19",
+    "@storybook/manager-webpack5": "^6.4.19",
+    "@storybook/react": "^6.4.19",
     "@swc/core": "^1.2.139",
     "@swc/helpers": "^0.3.3",
     "@testing-library/cypress": "^8.0.0",
@@ -240,7 +241,8 @@
     "@types/testing-library__react": "^10.0.0",
     "@types/testing-library__dom": "^7.0.0",
     "anser": "2.0.1",
-    "create-react-context": "0.3.0"
+    "create-react-context": "0.3.0",
+    "webpack": "5.65.0"
   },
   "engines": {
     "node": ">=14.16.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nextgenui",
   "description": "Harness Inc",
-  "version": "0.288.1",
+  "version": "0.288.2",
   "author": "Harness Inc",
   "license": "Harness Inc",
   "homepage": "http://app.harness.io/",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nextgenui",
   "description": "Harness Inc",
-  "version": "0.288.3",
+  "version": "0.288.4",
   "author": "Harness Inc",
   "license": "Harness Inc",
   "homepage": "http://app.harness.io/",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nextgenui",
   "description": "Harness Inc",
-  "version": "0.288.4",
+  "version": "0.288.5",
   "author": "Harness Inc",
   "license": "Harness Inc",
   "homepage": "http://app.harness.io/",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nextgenui",
   "description": "Harness Inc",
-  "version": "0.288.2",
+  "version": "0.288.3",
   "author": "Harness Inc",
   "license": "Harness Inc",
   "homepage": "http://app.harness.io/",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nextgenui",
   "description": "Harness Inc",
-  "version": "0.288.0",
+  "version": "0.288.1",
   "author": "Harness Inc",
   "license": "Harness Inc",
   "homepage": "http://app.harness.io/",
@@ -59,7 +59,7 @@
     "@harness/monaco-yaml": "^1.0.0",
     "@harness/ng-tooltip": "^1.30.68",
     "@harness/telemetry": "^1.0.37",
-    "@harness/uicore": "^2.17.0",
+    "@harness/uicore": "^2.18.0",
     "@harness/use-modal": "1.1.0",
     "@popperjs/core": "^2.4.2",
     "@projectstorm/react-diagrams-core": "^6.6.0",

--- a/src/modules/10-common/utils/StringUtils.ts
+++ b/src/modules/10-common/utils/StringUtils.ts
@@ -55,7 +55,7 @@ export const regexPositiveNumbers = /^[1-9]+[0-9]*$/
 
 export const regexIdentifier = /^[a-zA-Z_.][0-9a-zA-Z_$]*$/
 
-export const keyRegexIdentifier = /^[a-zA-Z_][0-9a-zA-Z_$]+(\.[0-9a-zA-Z_$]+)*$/
+export const keyRegexIdentifier = /^([a-zA-Z_])([0-9a-zA-Z_$]*)+((\.[0-9a-zA-Z_$]+)*)$/
 
 export const k8sLabelRegex = /[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/
 

--- a/src/modules/70-pipeline/components/PipelineVariablesContext/PipelineVariablesContext.tsx
+++ b/src/modules/70-pipeline/components/PipelineVariablesContext/PipelineVariablesContext.tsx
@@ -139,7 +139,9 @@ export function PipelineVariablesContextProvider(
   })
 
   React.useEffect(() => {
-    setResolvedPipeline(parse(defaultTo(resolvedPipelineResponse?.data?.mergedPipelineYaml, '')))
+    if (resolvedPipelineResponse?.data?.mergedPipelineYaml) {
+      setResolvedPipeline(parse(resolvedPipelineResponse.data.mergedPipelineYaml))
+    }
   }, [resolvedPipelineResponse])
 
   React.useEffect(() => {

--- a/src/modules/75-cd/components/PipelineSteps/Common/Terraform/Editview/TerraformArtifactoryFormHelper.ts
+++ b/src/modules/75-cd/components/PipelineSteps/Common/Terraform/Editview/TerraformArtifactoryFormHelper.ts
@@ -6,7 +6,7 @@
  */
 import { getMultiTypeFromValue, MultiTypeInputType } from '@wings-software/uicore'
 import * as Yup from 'yup'
-import { cloneDeep, unset, size, isUndefined } from 'lodash-es'
+import { cloneDeep, unset, size, isUndefined, set } from 'lodash-es'
 import { IdentifierSchema } from '@common/utils/Validation'
 import { TerraformStoreTypes, PathInterface } from '../TerraformInterfaces'
 
@@ -25,9 +25,9 @@ export const formatInitialValues = (isConfig: boolean, prevStepData: any, isTerr
             store: {
               spec: {
                 repositoryName:
-                  prevStepData.formValues?.spec?.configuration?.configFiles?.store.spec?.repositoryName || '',
+                  prevStepData?.formValues?.spec?.configuration?.configFiles?.store?.spec?.repositoryName || '',
                 artifactPaths: formatPaths(
-                  prevStepData.formValues?.spec?.configuration?.configFiles?.store.spec?.artifactPaths || ['']
+                  prevStepData?.formValues?.spec?.configuration?.configFiles?.store?.spec?.artifactPaths || ['']
                 )
               }
             }
@@ -45,9 +45,9 @@ export const formatInitialValues = (isConfig: boolean, prevStepData: any, isTerr
             store: {
               spec: {
                 repositoryName:
-                  prevStepData.formValues?.spec?.configuration?.spec?.configFiles?.store.spec?.repositoryName || '',
+                  prevStepData?.formValues?.spec?.configuration?.spec?.configFiles?.store?.spec?.repositoryName || '',
                 artifactPaths: formatPaths(
-                  prevStepData.formValues?.spec?.configuration?.spec?.configFiles?.store.spec?.artifactPaths || ['']
+                  prevStepData?.formValues?.spec?.configuration?.spec?.configFiles?.store?.spec?.artifactPaths || ['']
                 )
               }
             }
@@ -187,7 +187,7 @@ export const formatOnSubmitData = (values: any, prevStepData: any, connectorValu
 /* istanbul ignore next */
 export const formatArtifactoryData = (prevStepData: any, data: any, configObject: any, formik: any) => {
   if (prevStepData.identifier && prevStepData.identifier !== data?.identifier) {
-    configObject.store.spec.connectorRef = prevStepData?.identifier
+    set(configObject, 'store.spec.connectorRef', prevStepData?.identifier)
   }
 
   if (configObject?.store?.spec?.gitFetchType) {

--- a/src/modules/75-cf/pages/feature-flags/FeatureFlagsPage.tsx
+++ b/src/modules/75-cf/pages/feature-flags/FeatureFlagsPage.tsx
@@ -52,6 +52,7 @@ import {
   CF_DEFAULT_PAGE_SIZE,
   FeatureFlagActivationStatus,
   featureFlagHasCustomRules,
+  getDefaultVariation,
   getErrorMessage,
   isFeatureFlagOn,
   rewriteCurrentLocationWithActiveEnvironment,
@@ -314,9 +315,9 @@ const RenderColumnDetails: Renderer<CellProps<Feature>> = ({ row }) => {
   const { getString } = useStrings()
   const isOn = isFeatureFlagOn(data)
   const hasCustomRules = featureFlagHasCustomRules(data)
-  const index = data.variations.findIndex(
-    d => d.identifier === (isOn ? data.envProperties?.defaultServe.variation : data.envProperties?.offVariation)
-  )
+
+  const defaultVariation = getDefaultVariation(data)
+
   const isFlagTypeBoolean = data.kind === FlagTypeVariations.booleanFlag
   const typeToString = useFeatureFlagTypeToStringMapping()
 
@@ -336,8 +337,8 @@ const RenderColumnDetails: Renderer<CellProps<Feature>> = ({ row }) => {
       {!hasCustomRules && (
         <Container style={{ display: 'flex', alignItems: 'center' }}>
           <VariationWithIcon
-            variation={data.variations[index]}
-            index={index}
+            variation={defaultVariation}
+            index={data.variations.indexOf(defaultVariation)}
             textStyle={{
               fontSize: '12px',
               lineHeight: '24px',
@@ -345,7 +346,7 @@ const RenderColumnDetails: Renderer<CellProps<Feature>> = ({ row }) => {
               paddingLeft: 'var(--spacing-xsmall)'
             }}
             textElement={getString(isOn ? 'cf.featureFlags.defaultServedOn' : 'cf.featureFlags.defaultServedOff', {
-              defaultVariation: data.variations[index].name || data.variations[index].value
+              defaultVariation: defaultVariation.name || defaultVariation.value
             })}
           />
         </Container>

--- a/src/modules/75-cf/utils/CFUtils.ts
+++ b/src/modules/75-cf/utils/CFUtils.ts
@@ -387,3 +387,21 @@ export enum CFEntityType {
   TARGET = 'target',
   TARGET_GROUP = 'segment'
 }
+
+export const getDefaultVariation = (flag: Feature): Variation => {
+  if (!isFeatureFlagOn(flag)) {
+    return flag.variations.find(({ identifier }) => identifier === flag.defaultOffVariation) as Variation
+  }
+
+  if (flag.envProperties?.defaultServe?.variation) {
+    const variation = flag.variations.find(
+      ({ identifier }) => identifier === flag.envProperties?.defaultServe?.variation
+    )
+
+    if (variation) {
+      return variation
+    }
+  }
+
+  return flag.variations.find(({ identifier }) => identifier === flag.defaultOnVariation) as Variation
+}

--- a/src/modules/75-cf/utils/__tests__/CFUtils.test.tsx
+++ b/src/modules/75-cf/utils/__tests__/CFUtils.test.tsx
@@ -5,6 +5,7 @@
  * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
  */
 
+import { set, cloneDeep, omit } from 'lodash-es'
 import type { Feature } from 'services/cf'
 import * as CFUtils from '../CFUtils'
 
@@ -37,6 +38,49 @@ describe('CFUtils', () => {
       expect(CFUtils.formatToCompactNumber(1000000)).toEqual('1M')
       expect(CFUtils.formatToCompactNumber(10000000)).toEqual('10M')
       expect(CFUtils.formatToCompactNumber(100000000)).toEqual('100M')
+    })
+  })
+
+  describe('getDefaultVariation', () => {
+    const mockFlag = {
+      variations: [
+        { identifier: 'OFF_VARIATION', name: 'Off Variation', value: 'offVariation' },
+        { identifier: 'ON_VARIATION', name: 'On Variation', value: 'onVariation' },
+        { identifier: 'ENV_VARIATION', name: 'Env Variation', value: 'envVariation' }
+      ],
+      defaultOffVariation: 'OFF_VARIATION',
+      defaultOnVariation: 'ON_VARIATION',
+      envProperties: {
+        state: 'on',
+        defaultServe: {
+          variation: 'ENV_VARIATION'
+        }
+      }
+    } as Feature
+
+    test('it should return the default off variation when the flag is off', async () => {
+      const flag = cloneDeep(mockFlag)
+      set(flag, 'envProperties.state', 'off')
+
+      expect(CFUtils.getDefaultVariation(flag)).toEqual(flag.variations[0])
+    })
+
+    test('it should return the env default serve variation when the flag is on', async () => {
+      const flag = cloneDeep(mockFlag)
+
+      expect(CFUtils.getDefaultVariation(flag)).toEqual(flag.variations[2])
+    })
+
+    test('it should return the default on variation when the flag is on and there is no default serve variation', async () => {
+      const flag = omit(mockFlag, 'envProperties.defaultServe.variation')
+
+      expect(CFUtils.getDefaultVariation(flag)).toEqual(flag.variations[1])
+    })
+
+    test('it should return the default on variation when the flag is on and there is no default serve', async () => {
+      const flag = omit(mockFlag, 'envProperties.defaultServe')
+
+      expect(CFUtils.getDefaultVariation(flag)).toEqual(flag.variations[1])
     })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2495,10 +2495,10 @@
   resolved "https://npm.pkg.github.com/download/@harness/telemetry/1.0.37/fbc5025fb5969920627473304e041288420f44d63aa9cce82e1d06416bb2cf07#800efb2a98fc01bde907543f2509f7009573a1d7"
   integrity sha512-oUwcx7FSbKD0VTs/5Ng/mrYLEGj8FDtpsDhLniVgnsY02i15HszImvAEx6o32Pur3TcF1BKL/MRFu4W6lSKiPA==
 
-"@harness/uicore@^2.17.0":
-  version "2.17.0"
-  resolved "https://npm.pkg.github.com/download/@harness/uicore/2.17.0/532ef3a9649d63ef68b99d94613d43cfdf1a2918880f17f3fcf337e68fe45c4d#adb6fe593755b282ad33cdb8fa332802699d151c"
-  integrity sha512-PmiuwOuVCZmNghMr8baubHs1jFxb/PEBr6PYBPUra3s+gpFofrGvx5TeaolU3xLxWDOcPW69gZ8pbjH2+1/FSQ==
+"@harness/uicore@^2.18.0":
+  version "2.18.0"
+  resolved "https://npm.pkg.github.com/download/@harness/uicore/2.18.0/7ecd077f7f7c2bfab42c11dc1341f8daf10b56d77abab8ca04e11536b2b85018#7ec6c3b2e7c778d035fadc0715dbf31d6079d88a"
+  integrity sha512-v2zs6BkUtjjBUZTPlKdCns8/eUvPolNpu4ea5dF3G4oA0rY3SSpYSg0+8uj0hy7k4KXxJpMCqUtqSrRujHeGwA==
 
 "@harness/use-modal@1.1.0":
   version "1.1.0"


### PR DESCRIPTION
When creating a new artifactory connector after creating a new pipeline the UI crashes. This happens because the yaml/json is empty so fields are being checked that are undefined. 

The fix that we have added now uses optionals so that it is ok if the object is undefined. When saving the object we now use lodash set to create/update the properties so that will not error on save.
 
##### Screenshots:
Current error:
![before](https://user-images.githubusercontent.com/93519492/155701976-dbcb3839-b8ae-4f32-8a24-6a295c7e76c7.gif)

With fix:
![after](https://user-images.githubusercontent.com/93519492/155701997-4622630c-bf31-4786-bbad-29bdebc2d908.gif)

<!--- Add screenshots for your changes here -->

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
