### PR TITLE
feat: [CVS-9182]: Supported multiple environments for monitored service API

### DIFF
--- a/src/modules/85-cv/pages/monitored-service/components/Configurations/components/Dependency/Dependency.tsx
+++ b/src/modules/85-cv/pages/monitored-service/components/Configurations/components/Dependency/Dependency.tsx
@@ -50,7 +50,11 @@ export default function Dependency({
     projectIdentifier,
     orgIdentifier,
     accountId,
-    environmentIdentifier: identifier ? value?.environmentRef : cachedInitialValues?.environmentRef || ''
+    environmentIdentifiers: identifier
+      ? value.environmentRefList
+      : value.type === 'Application'
+      ? [cachedInitialValues?.environmentRef as string]
+      : (cachedInitialValues?.environmentRef as unknown as string[]) ?? []
   })
 
   const {
@@ -60,6 +64,9 @@ export default function Dependency({
     refetch
   } = useGetMonitoredServiceList({
     queryParams,
+    queryParamStringifyOptions: {
+      arrayFormat: 'repeat'
+    },
     resolve: response => filterCurrentMonitoredServiceFromList(response, value.identifier)
   })
 

--- a/src/modules/85-cv/pages/monitored-service/components/Configurations/components/Dependency/__tests__/Dependency.mock.ts
+++ b/src/modules/85-cv/pages/monitored-service/components/Configurations/components/Dependency/__tests__/Dependency.mock.ts
@@ -5,7 +5,29 @@
  * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
  */
 
+import routes from '@common/RouteDefinitions'
+import { projectPathProps } from '@common/utils/routeUtils'
+import type { TestWrapperProps } from '@common/utils/testUtils'
 import type { MonitoredServiceForm } from '../../Service/Service.types'
+
+export const pathParams = {
+  accountId: 'account_id',
+  orgIdentifier: 'org_identifier',
+  projectIdentifier: 'project_identifier'
+}
+
+export const testWrapperProps: TestWrapperProps = {
+  path: routes.toCVAddMonitoringServicesSetup({ ...projectPathProps }),
+  pathParams
+}
+
+export const testWrapperEditProps: TestWrapperProps = {
+  path: routes.toCVAddMonitoringServicesEdit({ ...projectPathProps, identifier: ':identifier' }),
+  pathParams: {
+    ...pathParams,
+    identifier: 'manager_production'
+  }
+}
 
 export const monitoredServiceList = {
   status: 'SUCCESS',
@@ -248,6 +270,7 @@ export const monitoredServiceForm: MonitoredServiceForm = {
   description: '',
   serviceRef: 'manager',
   environmentRef: 'production',
+  environmentRefList: ['production'],
   tags: {},
   sources: {
     healthSources: [],
@@ -263,6 +286,13 @@ export const monitoredServiceForm: MonitoredServiceForm = {
     ]
   },
   dependencies: []
+}
+
+export const monitoredServiceOfTypeInfrastructure: MonitoredServiceForm = {
+  ...monitoredServiceForm,
+  isEdit: true,
+  environmentRef: 'production_one',
+  environmentRefList: ['production_one', 'production_two']
 }
 
 export const monitoredService = {

--- a/src/modules/85-cv/pages/monitored-service/components/Configurations/components/Dependency/__tests__/Dependency.test.tsx
+++ b/src/modules/85-cv/pages/monitored-service/components/Configurations/components/Dependency/__tests__/Dependency.test.tsx
@@ -9,7 +9,14 @@ import React from 'react'
 import { render, waitFor, fireEvent } from '@testing-library/react'
 import * as cvService from 'services/cv'
 import { TestWrapper } from '@common/utils/testUtils'
-import { monitoredServiceList, monitoredServiceForm } from './Dependency.mock'
+import {
+  monitoredServiceList,
+  monitoredServiceForm,
+  testWrapperProps,
+  testWrapperEditProps,
+  pathParams,
+  monitoredServiceOfTypeInfrastructure
+} from './Dependency.mock'
 import Dependency from '../Dependency'
 
 describe('Dependency compoennt', () => {
@@ -32,6 +39,7 @@ describe('Dependency compoennt', () => {
         dependencies: [],
         description: '',
         environmentRef: 'production',
+        environmentRefList: ['production'],
         identifier: 'manager_production',
         isEdit: false,
         name: 'manager_production',
@@ -66,5 +74,95 @@ describe('Dependency compoennt', () => {
     )
     await waitFor(() => expect(container.querySelector('[class*="leftSection"]')).not.toBeNull())
     await waitFor(() => expect(container.querySelector('[class*="spinner"]')).not.toBeNull())
+  })
+
+  test('Ensure API useGetMonitoredServiceList is called with environmentIdentifiers - Create - Application', () => {
+    jest.spyOn(cvService, 'useGetMonitoredServiceList').mockReturnValue({ data: monitoredServiceList } as any)
+
+    render(
+      <TestWrapper {...testWrapperProps}>
+        <Dependency onSuccess={jest.fn()} value={monitoredServiceForm} cachedInitialValues={monitoredServiceForm} />
+      </TestWrapper>
+    )
+
+    expect(cvService.useGetMonitoredServiceList).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        queryParams: { ...pathParams, environmentIdentifiers: ['production'], offset: 0, pageSize: 10 },
+        queryParamStringifyOptions: {
+          arrayFormat: 'repeat'
+        }
+      })
+    )
+  })
+
+  test('Ensure API useGetMonitoredServiceList is called with environmentIdentifiers - Application', () => {
+    jest.spyOn(cvService, 'useGetMonitoredServiceList').mockReturnValue({ data: monitoredServiceList } as any)
+
+    render(
+      <TestWrapper {...testWrapperEditProps}>
+        <Dependency onSuccess={jest.fn()} value={monitoredServiceForm} />
+      </TestWrapper>
+    )
+
+    expect(cvService.useGetMonitoredServiceList).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        queryParams: { ...pathParams, environmentIdentifiers: ['production'], offset: 0, pageSize: 10 },
+        queryParamStringifyOptions: {
+          arrayFormat: 'repeat'
+        }
+      })
+    )
+  })
+
+  test('Ensure API useGetMonitoredServiceList is called with environmentIdentifiers - Create - Infrastructure', () => {
+    jest.spyOn(cvService, 'useGetMonitoredServiceList').mockReturnValue({ data: monitoredServiceList } as any)
+
+    render(
+      <TestWrapper {...testWrapperEditProps}>
+        <Dependency
+          onSuccess={jest.fn()}
+          value={monitoredServiceOfTypeInfrastructure}
+          cachedInitialValues={monitoredServiceOfTypeInfrastructure}
+        />
+      </TestWrapper>
+    )
+
+    expect(cvService.useGetMonitoredServiceList).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        queryParams: {
+          ...pathParams,
+          environmentIdentifiers: ['production_one', 'production_two'],
+          offset: 0,
+          pageSize: 10
+        },
+        queryParamStringifyOptions: {
+          arrayFormat: 'repeat'
+        }
+      })
+    )
+  })
+
+  test('Ensure API useGetMonitoredServiceList is called with environmentIdentifiers - Infrastructure', () => {
+    jest.spyOn(cvService, 'useGetMonitoredServiceList').mockReturnValue({ data: monitoredServiceList } as any)
+
+    render(
+      <TestWrapper {...testWrapperEditProps}>
+        <Dependency onSuccess={jest.fn()} value={monitoredServiceOfTypeInfrastructure} />
+      </TestWrapper>
+    )
+
+    expect(cvService.useGetMonitoredServiceList).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        queryParams: {
+          ...pathParams,
+          environmentIdentifiers: ['production_one', 'production_two'],
+          offset: 0,
+          pageSize: 10
+        },
+        queryParamStringifyOptions: {
+          arrayFormat: 'repeat'
+        }
+      })
+    )
   })
 })

--- a/src/modules/85-cv/pages/monitored-service/components/Configurations/components/Service/Service.utils.ts
+++ b/src/modules/85-cv/pages/monitored-service/components/Configurations/components/Service/Service.utils.ts
@@ -25,6 +25,7 @@ export const getInitFormData = (
     tags = {},
     serviceRef = '',
     environmentRef = '',
+    environmentRefList = [],
     sources,
     dependencies = [],
     type
@@ -39,6 +40,7 @@ export const getInitFormData = (
     serviceRef,
     type: (type as MonitoredServiceForm['type']) || MonitoredServiceType.APPLICATION,
     environmentRef,
+    environmentRefList,
     sources,
     dependencies
   }


### PR DESCRIPTION
##### Summary:

Support multiple environments for monitored service API.

##### Jira Links:

https://harness.atlassian.net/browse/CVS-9182

##### Screenshots:

<!--- Add screenshots for your changes here -->

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
