### PR TITLE
fix: [GTM-678]: Added query param to get accounts api

### DIFF
--- a/src/modules/33-auth-settings/pages/AccountOverview/views/AccountDetails.tsx
+++ b/src/modules/33-auth-settings/pages/AccountOverview/views/AccountDetails.tsx
@@ -31,7 +31,12 @@ const VERSIONS = {
 const AccountDetails: React.FC = () => {
   const { getString } = useStrings()
   const { accountId } = useParams<AccountPathProps>()
-  const { data, loading, refetch: refetchAcct, error } = useGetAccountNG({ accountIdentifier: accountId })
+  const {
+    data,
+    loading,
+    refetch: refetchAcct,
+    error
+  } = useGetAccountNG({ accountIdentifier: accountId, queryParams: { accountIdentifier: accountId } })
   const [updateAccountName, setUpdateAccountName] = React.useState(false)
 
   const { openDefaultExperienceModal } = useDefaultExperienceModal({ refetchAcct })

--- a/src/modules/33-auth-settings/pages/subscriptions/SubscriptionsPage.tsx
+++ b/src/modules/33-auth-settings/pages/subscriptions/SubscriptionsPage.tsx
@@ -137,7 +137,7 @@ const SubscriptionsPage: React.FC = () => {
     error: accountError,
     loading: isGetAccountLoading,
     refetch: refetchGetAccount
-  } = useGetAccountNG({ accountIdentifier: accountId })
+  } = useGetAccountNG({ accountIdentifier: accountId, queryParams: { accountIdentifier: accountId } })
 
   const getModuleLicenseQueryParams: GetModuleLicensesByAccountAndModuleTypeQueryParams = {
     moduleType: selectedModuleCard.module as GetModuleLicensesByAccountAndModuleTypeQueryParams['moduleType']


### PR DESCRIPTION
##### Summary:

Updated NG Get Accounts API to require a accountIdentifier query parameter.


##### Jira Links:

[PLG-678](https://harness.atlassian.net/browse/PLG-678)

##### Screenshots:

![image](https://user-images.githubusercontent.com/98421956/155774975-f70898d9-1650-430c-a651-a2929a3f4608.png)

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
