### PR TITLE
fix: [CDS-25562]: Runtime inputs are not allowed under optional configuration. Reverted the change

### DIFF
--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraCreate/JiraCreateStepMode.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraCreate/JiraCreateStepMode.tsx
@@ -538,7 +538,7 @@ function FormContent({
                                   placeholder={getString('common.valuePlaceholder')}
                                   disabled={isApprovalStepFieldDisabled(readonly)}
                                   multiTextInputProps={{
-                                    allowableTypes: allowableTypes.filter(item => item !== MultiTypeInputType.RUNTIME),
+                                    allowableTypes: [MultiTypeInputType.FIXED, MultiTypeInputType.EXPRESSION],
                                     expressions
                                   }}
                                 />

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraUpdate/JiraUpdateStepMode.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraUpdate/JiraUpdateStepMode.tsx
@@ -418,7 +418,7 @@ function FormContent({
                               label=""
                               placeholder={getString('common.valuePlaceholder')}
                               multiTextInputProps={{
-                                allowableTypes: allowableTypes.filter(item => item !== MultiTypeInputType.RUNTIME),
+                                allowableTypes: [MultiTypeInputType.FIXED, MultiTypeInputType.EXPRESSION],
                                 expressions
                               }}
                               disabled={isApprovalStepFieldDisabled(readonly)}


### PR DESCRIPTION
fix: [CDS-25562]: Runtime inputs are not allowed under optional configuration. 
Enum iteration is reverted

##### Summary:

<!--- Add summary of your changes here -->

##### Jira Links:

<!--- Add jira links for your changes here -->

##### Screenshots:

<!--- Add screenshots for your changes here -->

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`


[CDS-25562]: https://harness.atlassian.net/browse/CDS-25562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ