### PR TITLE
fix: [CDS-34390]: added switch option for deployment graph view on service dashboard

### DIFF
--- a/src/modules/75-cd/components/Services/DeploymentsWidget/DeploymentsWidget.module.scss
+++ b/src/modules/75-cd/components/Services/DeploymentsWidget/DeploymentsWidget.module.scss
@@ -33,3 +33,28 @@
     border-bottom: 1px solid var(--grey-200);
   }
 }
+
+.toggleBtns {
+  align-items: center;
+  align-self: flex-start;
+  position: absolute;
+  right: 0%;
+
+  .chartIcon {
+    text-align: center;
+    cursor: pointer;
+    background: var(--grey-100) !important;
+    width: var(--spacing-8);
+    height: var(--spacing-6) !important;
+    min-height: unset !important;
+    box-shadow: none;
+    padding: unset !important;
+  }
+
+  .active {
+    background-color: var(--primary-2) !important;
+    cursor: default;
+    box-shadow: var(--button-shadow) !important;
+    color: var(--primary-6) !important;
+  }
+}

--- a/src/modules/75-cd/components/Services/DeploymentsWidget/DeploymentsWidget.module.scss
+++ b/src/modules/75-cd/components/Services/DeploymentsWidget/DeploymentsWidget.module.scss
@@ -38,7 +38,7 @@
   align-items: center;
   align-self: flex-start;
   position: absolute;
-  right: 0%;
+  right: 0;
 
   .chartIcon {
     text-align: center;
@@ -46,8 +46,7 @@
     background: var(--grey-100) !important;
     width: var(--spacing-8);
     height: var(--spacing-6) !important;
-    min-height: unset !important;
-    box-shadow: none;
+    min-height: unset;
     padding: unset !important;
   }
 

--- a/src/modules/75-cd/components/Services/DeploymentsWidget/DeploymentsWidget.module.scss
+++ b/src/modules/75-cd/components/Services/DeploymentsWidget/DeploymentsWidget.module.scss
@@ -57,3 +57,60 @@
     color: var(--primary-6) !important;
   }
 }
+
+.deploymentsChartContainer {
+  margin-right: var(--spacing-medium);
+  .summaryCardsContainer {
+    margin-left: 20px;
+    display: flex;
+    .summaryCard {
+      min-width: 142px;
+      min-height: 76px;
+      background-color: #fafbfc !important;
+      margin-right: var(--spacing-4) !important;
+      border-radius: 4px;
+      padding-left: var(--spacing-4) !important;
+      padding-right: var(--spacing-4) !important;
+
+      .cardTitle {
+        font-weight: 500;
+        font-size: 12px;
+        line-height: 16px;
+        letter-spacing: 0.2px;
+        color: var(--gray-700);
+        margin-top: 12px;
+      }
+      .frequencyContainer {
+        align-items: center;
+        margin-right: var(--spacing-medium);
+        .frequencyCount {
+          margin-top: 7px;
+          font-weight: 600;
+          font-size: 24px;
+          line-height: 32px;
+          display: flex;
+          align-items: center;
+          color: black;
+        }
+        .groupByValue {
+          padding-top: var(--spacing-small);
+          margin-left: var(--spacing-xsmall) !important;
+          text-transform: capitalize;
+        }
+      }
+      .trendContainer {
+        margin-top: 7px;
+        line-height: 14px;
+        .trend {
+          margin-left: 6px;
+          font-weight: 500;
+          font-size: 10px;
+          line-height: 14px;
+          display: flex;
+          align-items: center;
+          letter-spacing: 0.2px;
+        }
+      }
+    }
+  }
+}

--- a/src/modules/75-cd/components/Services/DeploymentsWidget/DeploymentsWidget.module.scss
+++ b/src/modules/75-cd/components/Services/DeploymentsWidget/DeploymentsWidget.module.scss
@@ -11,51 +11,6 @@
   border: 0px;
   box-shadow: none !important;
   padding: 0px !important;
-  .text {
-    font-size: 40px !important;
-  }
-  .tickerCard {
-    min-width: 100px !important;
-    background: var(--grey-50) !important;
-  }
-  .tickerContainerStyles {
-    width: fit-content;
-    .tickerValueStyles {
-      font-size: var(--font-size-xsmall);
-    }
-  }
-}
-
-.tooltipCard {
-  width: 100%;
-  padding-top: var(--spacing-small) !important;
-  .tooltipTimestamp {
-    border-bottom: 1px solid var(--grey-200);
-  }
-}
-
-.toggleBtns {
-  align-items: center;
-  align-self: flex-start;
-  position: absolute;
-  right: 0;
-
-  .chartIcon {
-    text-align: center;
-    cursor: pointer;
-    background: var(--grey-100) !important;
-    width: var(--spacing-8);
-    height: var(--spacing-6) !important;
-    min-height: unset;
-    padding: unset !important;
-  }
-
-  .active {
-    background-color: var(--primary-2) !important;
-    cursor: default;
-    box-shadow: var(--button-shadow) !important;
-    color: var(--primary-6) !important;
-  }
 }
 
 .deploymentsChartContainer {
@@ -101,15 +56,6 @@
       .trendContainer {
         margin-top: 7px;
         line-height: 14px;
-        .trend {
-          margin-left: 6px;
-          font-weight: 500;
-          font-size: 10px;
-          line-height: 14px;
-          display: flex;
-          align-items: center;
-          letter-spacing: 0.2px;
-        }
       }
     }
   }

--- a/src/modules/75-cd/components/Services/DeploymentsWidget/DeploymentsWidget.module.scss.d.ts
+++ b/src/modules/75-cd/components/Services/DeploymentsWidget/DeploymentsWidget.module.scss.d.ts
@@ -9,7 +9,14 @@
 declare const styles: {
   readonly active: string
   readonly card: string
+  readonly cardTitle: string
   readonly chartIcon: string
+  readonly deploymentsChartContainer: string
+  readonly frequencyContainer: string
+  readonly frequencyCount: string
+  readonly groupByValue: string
+  readonly summaryCard: string
+  readonly summaryCardsContainer: string
   readonly text: string
   readonly tickerCard: string
   readonly tickerContainerStyles: string
@@ -17,5 +24,7 @@ declare const styles: {
   readonly toggleBtns: string
   readonly tooltipCard: string
   readonly tooltipTimestamp: string
+  readonly trend: string
+  readonly trendContainer: string
 }
 export default styles

--- a/src/modules/75-cd/components/Services/DeploymentsWidget/DeploymentsWidget.module.scss.d.ts
+++ b/src/modules/75-cd/components/Services/DeploymentsWidget/DeploymentsWidget.module.scss.d.ts
@@ -7,11 +7,14 @@
  **/
 // this is an auto-generated file, do not update this manually
 declare const styles: {
+  readonly active: string
   readonly card: string
+  readonly chartIcon: string
   readonly text: string
   readonly tickerCard: string
   readonly tickerContainerStyles: string
   readonly tickerValueStyles: string
+  readonly toggleBtns: string
   readonly tooltipCard: string
   readonly tooltipTimestamp: string
 }

--- a/src/modules/75-cd/components/Services/DeploymentsWidget/DeploymentsWidget.module.scss.d.ts
+++ b/src/modules/75-cd/components/Services/DeploymentsWidget/DeploymentsWidget.module.scss.d.ts
@@ -7,24 +7,14 @@
  **/
 // this is an auto-generated file, do not update this manually
 declare const styles: {
-  readonly active: string
   readonly card: string
   readonly cardTitle: string
-  readonly chartIcon: string
   readonly deploymentsChartContainer: string
   readonly frequencyContainer: string
   readonly frequencyCount: string
   readonly groupByValue: string
   readonly summaryCard: string
   readonly summaryCardsContainer: string
-  readonly text: string
-  readonly tickerCard: string
-  readonly tickerContainerStyles: string
-  readonly tickerValueStyles: string
-  readonly toggleBtns: string
-  readonly tooltipCard: string
-  readonly tooltipTimestamp: string
-  readonly trend: string
   readonly trendContainer: string
 }
 export default styles

--- a/src/modules/75-cd/components/Services/DeploymentsWidget/DeploymentsWidget.tsx
+++ b/src/modules/75-cd/components/Services/DeploymentsWidget/DeploymentsWidget.tsx
@@ -151,7 +151,7 @@ export const DeploymentsWidget: React.FC<DeploymentWidgetProps> = props => {
       },
       {
         title: getString('pipeline.deploymentFrequency'),
-        count: numberFormatter(defaultTo(data?.frequency, 0)),
+        count: numberFormatter(Math.round(defaultTo(data?.frequency, 0))),
         trend: numberFormatter(data?.frequencyChangeRate) + '%'
       }
     ]

--- a/src/modules/75-cd/components/Services/DeploymentsWidget/DeploymentsWidget.tsx
+++ b/src/modules/75-cd/components/Services/DeploymentsWidget/DeploymentsWidget.tsx
@@ -167,14 +167,16 @@ export const DeploymentsWidget: React.FC<DeploymentWidgetProps> = props => {
         failureData.push(defaultTo(val.deployments?.failure, 0))
         custom.push(val)
       })
+      const successCount = successData.reduce((sum, i) => sum + i, 0)
+      const failureCount = failureData.reduce((sum, i) => sum + i, 0)
       const successArr = {
-        name: 'Success',
+        name: `Success (${successCount})`,
         data: successData,
         color: 'var(--success)',
         custom
       }
       const failureArr = {
-        name: 'Failed',
+        name: `Failed (${failureCount})`,
         data: failureData,
         color: 'var(--red-400)',
         custom

--- a/src/modules/75-cd/components/Services/DeploymentsWidget/DeploymentsWidget.tsx
+++ b/src/modules/75-cd/components/Services/DeploymentsWidget/DeploymentsWidget.tsx
@@ -15,10 +15,9 @@ import { Card, Color, Container, Layout, Text, PageError, Button } from '@wings-
 import { useStrings } from 'framework/strings'
 import { Ticker, TickerVerticalAlignment } from '@common/components/Ticker/Ticker'
 import { getBucketSizeForTimeRange } from '@common/components/TimeRangeSelector/TimeRangeSelector'
-import { StackedColumnChart } from '@common/components/StackedColumnChart/StackedColumnChart'
+import { StackedColumnChart, StackedColumnChartProps } from '@common/components/StackedColumnChart/StackedColumnChart'
 import { PageSpinner, TimeSeriesAreaChart } from '@common/components'
 import type { TimeSeriesAreaChartProps } from '@common/components/TimeSeriesAreaChart/TimeSeriesAreaChart'
-import type { StackedColumnChartProps } from '@common/components/StackedColumnChart/StackedColumnChart'
 import {
   DeploymentsTimeRangeContext,
   getFixed,

--- a/src/modules/75-cd/components/Services/DeploymentsWidget/DeploymentsWidget.tsx
+++ b/src/modules/75-cd/components/Services/DeploymentsWidget/DeploymentsWidget.tsx
@@ -204,7 +204,7 @@ export const DeploymentsWidget: React.FC<DeploymentWidgetProps> = props => {
           {
             name: getString('success'),
             data: success,
-            color: '#5fb34e'
+            color: 'var(--success)'
           },
           {
             name: getString('failed'),

--- a/src/modules/75-cd/components/Services/DeploymentsWidget/DeploymentsWidget.tsx
+++ b/src/modules/75-cd/components/Services/DeploymentsWidget/DeploymentsWidget.tsx
@@ -167,20 +167,19 @@ export const DeploymentsWidget: React.FC<DeploymentWidgetProps> = props => {
         failureData.push(defaultTo(val.deployments?.failure, 0))
         custom.push(val)
       })
-      return [
-        {
-          name: 'Success',
-          data: successData,
-          color: 'var(--success)',
-          custom
-        },
-        {
-          name: 'Failed',
-          data: failureData,
-          color: 'var(--red-400)',
-          custom
-        }
-      ]
+      const successArr = {
+        name: 'Success',
+        data: successData,
+        color: 'var(--success)',
+        custom
+      }
+      const failureArr = {
+        name: 'Failed',
+        data: failureData,
+        color: 'var(--red-400)',
+        custom
+      }
+      return [successArr, failureArr]
     }
   }, [serviceDeploymentsInfo])
 

--- a/src/modules/75-cd/components/Services/__tests__/__snapshots__/DeploymentsWidget.test.tsx.snap
+++ b/src/modules/75-cd/components/Services/__tests__/__snapshots__/DeploymentsWidget.test.tsx.snap
@@ -9,15 +9,63 @@ exports[`DeploymentsWidget should render DeploymentsWidget 1`] = `
       class="Layout--vertical StyledProps--main"
       style="height: 100%;"
     >
+      <p
+        class="StyledProps--font StyledProps--main StyledProps--font-weight-semi-bold StyledProps--color StyledProps--color-grey600"
+      >
+        deploymentsText
+      </p>
       <div
         class="StyledProps--font StyledProps--main"
         data-test="deploymentsWidgetContent"
       >
-        <p
-          class="StyledProps--font StyledProps--main StyledProps--font-weight-semi-bold StyledProps--color StyledProps--color-grey600"
+        <div
+          class="StyledProps--font StyledProps--main toggleBtns"
         >
-          deploymentsText
-        </p>
+          <button
+            class="bp3-button bp3-active bp3-minimal Button--button StyledProps--font StyledProps--main chartIcon active Button--with-current-color Button--iconOnly Button--without-shadow Button--withLeftIcon"
+            type="button"
+          >
+            <span
+              class="bp3-icon StyledProps--main StyledProps--color StyledProps--color-primary6"
+              data-icon="bar-chart"
+            >
+              <svg
+                fill="none"
+                height="12"
+                viewBox="0 0 14 11"
+                width="12"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M11.995 0v10.798H14V0h-2.005zM3.996 1.601v9.197h2.005V1.6H3.996zm4.003 1.601v7.596h1.998V3.202H7.999zM0 4.797v6h1.998v-6H0z"
+                  fill="currentColor"
+                />
+              </svg>
+            </span>
+          </button>
+          <button
+            class="bp3-button bp3-minimal Button--button StyledProps--font StyledProps--main chartIcon Button--with-current-color Button--iconOnly Button--without-shadow Button--withLeftIcon"
+            type="button"
+          >
+            <span
+              class="bp3-icon StyledProps--main StyledProps--color StyledProps--color-grey700"
+              data-icon="line-chart"
+            >
+              <svg
+                fill="none"
+                height="12"
+                viewBox="0 0 14 11"
+                width="12"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M7.758 10.265L5.703 1.807l-2.799 4.1H0v-.746h2.51L6.032 0l2.076 8.546 2.81-3.765H14v.747h-2.706l-3.536 4.737z"
+                  fill="currentColor"
+                />
+              </svg>
+            </span>
+          </button>
+        </div>
         <div
           class="Layout--horizontal StyledProps--main StyledProps--flex StyledProps--flex-alignItems-flex-end StyledProps--flex-justifyContent-flex-start"
         >

--- a/src/modules/75-cd/components/Services/__tests__/__snapshots__/DeploymentsWidget.test.tsx.snap
+++ b/src/modules/75-cd/components/Services/__tests__/__snapshots__/DeploymentsWidget.test.tsx.snap
@@ -149,7 +149,7 @@ exports[`DeploymentsWidget should display correct data 1`] = `
                       <p
                         class="StyledProps--font StyledProps--main frequencyCount StyledProps--color StyledProps--color-black StyledProps--font-size-large StyledProps--font-weight-bold"
                       >
-                        324.2
+                        324
                       </p>
                     </div>
                     <div
@@ -393,7 +393,7 @@ exports[`DeploymentsWidget should render DeploymentsWidget 1`] = `
                       <p
                         class="StyledProps--font StyledProps--main frequencyCount StyledProps--color StyledProps--color-black StyledProps--font-size-large StyledProps--font-weight-bold"
                       >
-                        324.2
+                        324
                       </p>
                     </div>
                     <div

--- a/src/modules/75-cd/components/Services/__tests__/__snapshots__/DeploymentsWidget.test.tsx.snap
+++ b/src/modules/75-cd/components/Services/__tests__/__snapshots__/DeploymentsWidget.test.tsx.snap
@@ -1,5 +1,249 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`DeploymentsWidget should display correct data 1`] = `
+<div>
+  <div
+    class="bp3-card bp3-elevation-0 Card--card card"
+  >
+    <div
+      class="Layout--vertical StyledProps--main"
+      style="height: 100%;"
+    >
+      <div
+        class="deploymentsChartContainer"
+      >
+        <div
+          class="Layout--vertical Layout--layout-spacing-large StyledProps--main"
+        >
+          <div
+            class="StyledProps--font StyledProps--main StyledProps--flex"
+          >
+            <div
+              class="Layout--horizontal Layout--layout-spacing-medium StyledProps--main"
+            >
+              <div
+                class="StyledProps--font StyledProps--main summaryCardsContainer"
+              >
+                <div
+                  class="StyledProps--font StyledProps--main summaryCard"
+                >
+                  <p
+                    class="StyledProps--font StyledProps--main cardTitle StyledProps--font-size-medium StyledProps--color StyledProps--color-grey700"
+                  >
+                    deploymentsText
+                  </p>
+                  <div
+                    class="Layout--horizontal StyledProps--main"
+                  >
+                    <div
+                      class="Layout--horizontal StyledProps--main frequencyContainer"
+                    >
+                      <p
+                        class="StyledProps--font StyledProps--main frequencyCount StyledProps--color StyledProps--color-black StyledProps--font-size-large StyledProps--font-weight-bold"
+                      >
+                        57
+                      </p>
+                    </div>
+                    <div
+                      class="StyledProps--font StyledProps--main trendContainer StyledProps--flex"
+                    >
+                      <div
+                        class="StyledProps--font StyledProps--main StyledProps--flex"
+                      >
+                        <span
+                          class="bp3-icon bp3-icon-caret-up StyledProps--main StyledProps--color StyledProps--color-green500"
+                          icon="caret-up"
+                        >
+                          <svg
+                            data-icon="caret-up"
+                            height="16"
+                            viewBox="0 0 16 16"
+                            width="16"
+                          >
+                            <desc>
+                              caret-up
+                            </desc>
+                            <path
+                              d="M11.87 9.17s.01 0 0 0l-3.5-4C8.28 5.07 8.15 5 8 5s-.28.07-.37.17l-3.5 4a.495.495 0 00.37.83h7a.495.495 0 00.37-.83z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <p
+                          class="StyledProps--font StyledProps--main StyledProps--font-xsmall StyledProps--color StyledProps--color-green500"
+                        >
+                          34.4%
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="StyledProps--font StyledProps--main summaryCard"
+                >
+                  <p
+                    class="StyledProps--font StyledProps--main cardTitle StyledProps--font-size-medium StyledProps--color StyledProps--color-grey700"
+                  >
+                    common.failureRate
+                  </p>
+                  <div
+                    class="Layout--horizontal StyledProps--main"
+                  >
+                    <div
+                      class="Layout--horizontal StyledProps--main frequencyContainer"
+                    >
+                      <p
+                        class="StyledProps--font StyledProps--main frequencyCount StyledProps--color StyledProps--color-black StyledProps--font-size-large StyledProps--font-weight-bold"
+                      >
+                        24.2%
+                      </p>
+                    </div>
+                    <div
+                      class="StyledProps--font StyledProps--main trendContainer StyledProps--flex"
+                    >
+                      <div
+                        class="StyledProps--font StyledProps--main StyledProps--flex"
+                      >
+                        <span
+                          class="bp3-icon bp3-icon-caret-up StyledProps--main StyledProps--color StyledProps--color-green500"
+                          icon="caret-up"
+                        >
+                          <svg
+                            data-icon="caret-up"
+                            height="16"
+                            viewBox="0 0 16 16"
+                            width="16"
+                          >
+                            <desc>
+                              caret-up
+                            </desc>
+                            <path
+                              d="M11.87 9.17s.01 0 0 0l-3.5-4C8.28 5.07 8.15 5 8 5s-.28.07-.37.17l-3.5 4a.495.495 0 00.37.83h7a.495.495 0 00.37-.83z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <p
+                          class="StyledProps--font StyledProps--main StyledProps--font-xsmall StyledProps--color StyledProps--color-green500"
+                        >
+                          45.7%
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="StyledProps--font StyledProps--main summaryCard"
+                >
+                  <p
+                    class="StyledProps--font StyledProps--main cardTitle StyledProps--font-size-medium StyledProps--color StyledProps--color-grey700"
+                  >
+                    pipeline.deploymentFrequency
+                  </p>
+                  <div
+                    class="Layout--horizontal StyledProps--main"
+                  >
+                    <div
+                      class="Layout--horizontal StyledProps--main frequencyContainer"
+                    >
+                      <p
+                        class="StyledProps--font StyledProps--main frequencyCount StyledProps--color StyledProps--color-black StyledProps--font-size-large StyledProps--font-weight-bold"
+                      >
+                        324.2
+                      </p>
+                    </div>
+                    <div
+                      class="StyledProps--font StyledProps--main trendContainer StyledProps--flex"
+                    >
+                      <div
+                        class="StyledProps--font StyledProps--main StyledProps--flex"
+                      >
+                        <span
+                          class="bp3-icon bp3-icon-caret-up StyledProps--main StyledProps--color StyledProps--color-green500"
+                          icon="caret-up"
+                        >
+                          <svg
+                            data-icon="caret-up"
+                            height="16"
+                            viewBox="0 0 16 16"
+                            width="16"
+                          >
+                            <desc>
+                              caret-up
+                            </desc>
+                            <path
+                              d="M11.87 9.17s.01 0 0 0l-3.5-4C8.28 5.07 8.15 5 8 5s-.28.07-.37.17l-3.5 4a.495.495 0 00.37.83h7a.495.495 0 00.37-.83z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <p
+                          class="StyledProps--font StyledProps--main StyledProps--font-xsmall StyledProps--color StyledProps--color-green500"
+                        >
+                          23.2%
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="StyledProps--font StyledProps--main toggleBtns StyledProps--flex"
+            >
+              <button
+                class="bp3-button bp3-active bp3-minimal Button--button StyledProps--font StyledProps--main chartIcon active Button--with-current-color Button--iconOnly Button--without-shadow Button--withLeftIcon"
+                type="button"
+              >
+                <span
+                  class="bp3-icon StyledProps--main StyledProps--color StyledProps--color-primary6"
+                  data-icon="bar-chart"
+                >
+                  <svg
+                    fill="none"
+                    height="12"
+                    viewBox="0 0 14 11"
+                    width="12"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M11.995 0v10.798H14V0h-2.005zM3.996 1.601v9.197h2.005V1.6H3.996zm4.003 1.601v7.596h1.998V3.202H7.999zM0 4.797v6h1.998v-6H0z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <button
+                class="bp3-button bp3-minimal Button--button StyledProps--font StyledProps--main chartIcon Button--with-current-color Button--iconOnly Button--without-shadow Button--withLeftIcon"
+                type="button"
+              >
+                <span
+                  class="bp3-icon StyledProps--main StyledProps--color StyledProps--color-grey700"
+                  data-icon="line-chart"
+                >
+                  <svg
+                    fill="none"
+                    height="12"
+                    viewBox="0 0 14 11"
+                    width="12"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M7.758 10.265L5.703 1.807l-2.799 4.1H0v-.746h2.51L6.032 0l2.076 8.546 2.81-3.765H14v.747h-2.706l-3.536 4.737z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`DeploymentsWidget should render DeploymentsWidget 1`] = `
 <div>
   <div
@@ -9,231 +253,232 @@ exports[`DeploymentsWidget should render DeploymentsWidget 1`] = `
       class="Layout--vertical StyledProps--main"
       style="height: 100%;"
     >
-      <p
-        class="StyledProps--font StyledProps--main StyledProps--font-weight-semi-bold StyledProps--color StyledProps--color-grey600"
-      >
-        deploymentsText
-      </p>
       <div
-        class="StyledProps--font StyledProps--main"
-        data-test="deploymentsWidgetContent"
+        class="deploymentsChartContainer"
       >
         <div
-          class="StyledProps--font StyledProps--main toggleBtns"
-        >
-          <button
-            class="bp3-button bp3-active bp3-minimal Button--button StyledProps--font StyledProps--main chartIcon active Button--with-current-color Button--iconOnly Button--without-shadow Button--withLeftIcon"
-            type="button"
-          >
-            <span
-              class="bp3-icon StyledProps--main StyledProps--color StyledProps--color-primary6"
-              data-icon="bar-chart"
-            >
-              <svg
-                fill="none"
-                height="12"
-                viewBox="0 0 14 11"
-                width="12"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M11.995 0v10.798H14V0h-2.005zM3.996 1.601v9.197h2.005V1.6H3.996zm4.003 1.601v7.596h1.998V3.202H7.999zM0 4.797v6h1.998v-6H0z"
-                  fill="currentColor"
-                />
-              </svg>
-            </span>
-          </button>
-          <button
-            class="bp3-button bp3-minimal Button--button StyledProps--font StyledProps--main chartIcon Button--with-current-color Button--iconOnly Button--without-shadow Button--withLeftIcon"
-            type="button"
-          >
-            <span
-              class="bp3-icon StyledProps--main StyledProps--color StyledProps--color-grey700"
-              data-icon="line-chart"
-            >
-              <svg
-                fill="none"
-                height="12"
-                viewBox="0 0 14 11"
-                width="12"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M7.758 10.265L5.703 1.807l-2.799 4.1H0v-.746h2.51L6.032 0l2.076 8.546 2.81-3.765H14v.747h-2.706l-3.536 4.737z"
-                  fill="currentColor"
-                />
-              </svg>
-            </span>
-          </button>
-        </div>
-        <div
-          class="Layout--horizontal StyledProps--main StyledProps--flex StyledProps--flex-alignItems-flex-end StyledProps--flex-justifyContent-flex-start"
+          class="Layout--vertical Layout--layout-spacing-large StyledProps--main"
         >
           <div
-            class="Layout--horizontal StyledProps--main"
-            style="width: 240px;"
+            class="StyledProps--font StyledProps--main StyledProps--flex"
           >
             <div
-              class="tickerContainer"
-              data-test="ticker"
+              class="Layout--horizontal Layout--layout-spacing-medium StyledProps--main"
             >
               <div
-                class="Layout--vertical StyledProps--main"
-              >
-                <p
-                  class="StyledProps--font StyledProps--main text StyledProps--color StyledProps--color-black StyledProps--font-weight-semi-bold"
-                  data-test="tickerText"
-                >
-                  57
-                </p>
-                <p
-                  class="StyledProps--font StyledProps--main StyledProps--font-size-xsmall StyledProps--font-weight-semi-bold StyledProps--color StyledProps--color-grey400"
-                >
-                  cd.serviceDashboard.in
-                </p>
-              </div>
-              <div
-                class="ticker tickerCenterAlign"
+                class="StyledProps--font StyledProps--main summaryCardsContainer"
               >
                 <div
-                  class="iconContainer"
-                >
-                  <span
-                    class="bp3-icon StyledProps--main StyledProps--color StyledProps--color-green600"
-                    data-icon="main-caret-up"
-                  >
-                    <svg
-                      height="6"
-                      viewBox="0 0 14 9"
-                      width="6"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M13.7 7.2L7.9.4C7.7.2 7.4 0 7 0s-.7.2-.9.4L.3 7.2c-.2.2-.3.4-.3.7C0 8.5.5 9 1.2 9h11.7c.6 0 1.1-.5 1.1-1.1 0-.3-.1-.5-.3-.7z"
-                        fill="#4d5969"
-                      />
-                    </svg>
-                  </span>
-                </div>
-                <div
-                  class="tickerValue"
-                  data-test="tickerValue"
+                  class="StyledProps--font StyledProps--main summaryCard"
                 >
                   <p
-                    class="StyledProps--font StyledProps--main StyledProps--font-size-xsmall StyledProps--color StyledProps--color-green600"
+                    class="StyledProps--font StyledProps--main cardTitle StyledProps--font-size-medium StyledProps--color StyledProps--color-grey700"
                   >
-                    34.4%
+                    deploymentsText
                   </p>
+                  <div
+                    class="Layout--horizontal StyledProps--main"
+                  >
+                    <div
+                      class="Layout--horizontal StyledProps--main frequencyContainer"
+                    >
+                      <p
+                        class="StyledProps--font StyledProps--main frequencyCount StyledProps--color StyledProps--color-black StyledProps--font-size-large StyledProps--font-weight-bold"
+                      >
+                        57
+                      </p>
+                    </div>
+                    <div
+                      class="StyledProps--font StyledProps--main trendContainer StyledProps--flex"
+                    >
+                      <div
+                        class="StyledProps--font StyledProps--main StyledProps--flex"
+                      >
+                        <span
+                          class="bp3-icon bp3-icon-caret-up StyledProps--main StyledProps--color StyledProps--color-green500"
+                          icon="caret-up"
+                        >
+                          <svg
+                            data-icon="caret-up"
+                            height="16"
+                            viewBox="0 0 16 16"
+                            width="16"
+                          >
+                            <desc>
+                              caret-up
+                            </desc>
+                            <path
+                              d="M11.87 9.17s.01 0 0 0l-3.5-4C8.28 5.07 8.15 5 8 5s-.28.07-.37.17l-3.5 4a.495.495 0 00.37.83h7a.495.495 0 00.37-.83z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <p
+                          class="StyledProps--font StyledProps--main StyledProps--font-xsmall StyledProps--color StyledProps--color-green500"
+                        >
+                          34.4%
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="StyledProps--font StyledProps--main summaryCard"
+                >
+                  <p
+                    class="StyledProps--font StyledProps--main cardTitle StyledProps--font-size-medium StyledProps--color StyledProps--color-grey700"
+                  >
+                    common.failureRate
+                  </p>
+                  <div
+                    class="Layout--horizontal StyledProps--main"
+                  >
+                    <div
+                      class="Layout--horizontal StyledProps--main frequencyContainer"
+                    >
+                      <p
+                        class="StyledProps--font StyledProps--main frequencyCount StyledProps--color StyledProps--color-black StyledProps--font-size-large StyledProps--font-weight-bold"
+                      >
+                        24.2%
+                      </p>
+                    </div>
+                    <div
+                      class="StyledProps--font StyledProps--main trendContainer StyledProps--flex"
+                    >
+                      <div
+                        class="StyledProps--font StyledProps--main StyledProps--flex"
+                      >
+                        <span
+                          class="bp3-icon bp3-icon-caret-up StyledProps--main StyledProps--color StyledProps--color-green500"
+                          icon="caret-up"
+                        >
+                          <svg
+                            data-icon="caret-up"
+                            height="16"
+                            viewBox="0 0 16 16"
+                            width="16"
+                          >
+                            <desc>
+                              caret-up
+                            </desc>
+                            <path
+                              d="M11.87 9.17s.01 0 0 0l-3.5-4C8.28 5.07 8.15 5 8 5s-.28.07-.37.17l-3.5 4a.495.495 0 00.37.83h7a.495.495 0 00.37-.83z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <p
+                          class="StyledProps--font StyledProps--main StyledProps--font-xsmall StyledProps--color StyledProps--color-green500"
+                        >
+                          45.7%
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="StyledProps--font StyledProps--main summaryCard"
+                >
+                  <p
+                    class="StyledProps--font StyledProps--main cardTitle StyledProps--font-size-medium StyledProps--color StyledProps--color-grey700"
+                  >
+                    pipeline.deploymentFrequency
+                  </p>
+                  <div
+                    class="Layout--horizontal StyledProps--main"
+                  >
+                    <div
+                      class="Layout--horizontal StyledProps--main frequencyContainer"
+                    >
+                      <p
+                        class="StyledProps--font StyledProps--main frequencyCount StyledProps--color StyledProps--color-black StyledProps--font-size-large StyledProps--font-weight-bold"
+                      >
+                        324.2
+                      </p>
+                    </div>
+                    <div
+                      class="StyledProps--font StyledProps--main trendContainer StyledProps--flex"
+                    >
+                      <div
+                        class="StyledProps--font StyledProps--main StyledProps--flex"
+                      >
+                        <span
+                          class="bp3-icon bp3-icon-caret-up StyledProps--main StyledProps--color StyledProps--color-green500"
+                          icon="caret-up"
+                        >
+                          <svg
+                            data-icon="caret-up"
+                            height="16"
+                            viewBox="0 0 16 16"
+                            width="16"
+                          >
+                            <desc>
+                              caret-up
+                            </desc>
+                            <path
+                              d="M11.87 9.17s.01 0 0 0l-3.5-4C8.28 5.07 8.15 5 8 5s-.28.07-.37.17l-3.5 4a.495.495 0 00.37.83h7a.495.495 0 00.37-.83z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <p
+                          class="StyledProps--font StyledProps--main StyledProps--font-xsmall StyledProps--color StyledProps--color-green500"
+                        >
+                          23.2%
+                        </p>
+                      </div>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-          <div
-            class="Layout--vertical StyledProps--main tickerCard StyledProps--padding-small StyledProps--margin-right-medium"
-          >
-            <p
-              class="StyledProps--font StyledProps--main StyledProps--font-size-xsmall StyledProps--font-weight-semi-bold StyledProps--margin-bottom-small StyledProps--color StyledProps--color-grey600"
-            >
-              common.failureRate
-            </p>
             <div
-              class="tickerContainer tickerContainerStyles"
-              data-test="ticker"
+              class="StyledProps--font StyledProps--main toggleBtns StyledProps--flex"
             >
-              <p
-                class="StyledProps--font StyledProps--main StyledProps--color StyledProps--color-black StyledProps--font-weight-semi-bold StyledProps--font-size-medium StyledProps--margin-right-xsmall"
-                data-test="tickerText"
+              <button
+                class="bp3-button bp3-active bp3-minimal Button--button StyledProps--font StyledProps--main chartIcon active Button--with-current-color Button--iconOnly Button--without-shadow Button--withLeftIcon"
+                type="button"
               >
-                24.2
-              </p>
-              <div
-                class="ticker tickerCenterAlign"
+                <span
+                  class="bp3-icon StyledProps--main StyledProps--color StyledProps--color-primary6"
+                  data-icon="bar-chart"
+                >
+                  <svg
+                    fill="none"
+                    height="12"
+                    viewBox="0 0 14 11"
+                    width="12"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M11.995 0v10.798H14V0h-2.005zM3.996 1.601v9.197h2.005V1.6H3.996zm4.003 1.601v7.596h1.998V3.202H7.999zM0 4.797v6h1.998v-6H0z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <button
+                class="bp3-button bp3-minimal Button--button StyledProps--font StyledProps--main chartIcon Button--with-current-color Button--iconOnly Button--without-shadow Button--withLeftIcon"
+                type="button"
               >
-                <div
-                  class="iconContainer"
+                <span
+                  class="bp3-icon StyledProps--main StyledProps--color StyledProps--color-grey700"
+                  data-icon="line-chart"
                 >
-                  <span
-                    class="bp3-icon StyledProps--main StyledProps--color StyledProps--color-red500"
-                    data-icon="main-caret-up"
+                  <svg
+                    fill="none"
+                    height="12"
+                    viewBox="0 0 14 11"
+                    width="12"
+                    xmlns="http://www.w3.org/2000/svg"
                   >
-                    <svg
-                      height="6"
-                      viewBox="0 0 14 9"
-                      width="6"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M13.7 7.2L7.9.4C7.7.2 7.4 0 7 0s-.7.2-.9.4L.3 7.2c-.2.2-.3.4-.3.7C0 8.5.5 9 1.2 9h11.7c.6 0 1.1-.5 1.1-1.1 0-.3-.1-.5-.3-.7z"
-                        fill="#4d5969"
-                      />
-                    </svg>
-                  </span>
-                </div>
-                <div
-                  class="tickerValue"
-                  data-test="tickerValue"
-                >
-                  <p
-                    class="StyledProps--font StyledProps--main StyledProps--font-size-xsmall StyledProps--color StyledProps--color-red500"
-                  >
-                    45.7%
-                  </p>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            class="Layout--vertical StyledProps--main tickerCard StyledProps--padding-small StyledProps--margin-right-medium"
-          >
-            <p
-              class="StyledProps--font StyledProps--main StyledProps--font-size-xsmall StyledProps--font-weight-semi-bold StyledProps--margin-bottom-small StyledProps--color StyledProps--color-grey600"
-            >
-              cd.serviceDashboard.frequency
-            </p>
-            <div
-              class="tickerContainer tickerContainerStyles"
-              data-test="ticker"
-            >
-              <p
-                class="StyledProps--font StyledProps--main StyledProps--color StyledProps--color-black StyledProps--font-weight-semi-bold StyledProps--font-size-medium StyledProps--margin-right-xsmall"
-                data-test="tickerText"
-              >
-                324.2
-              </p>
-              <div
-                class="ticker tickerCenterAlign"
-              >
-                <div
-                  class="iconContainer"
-                >
-                  <span
-                    class="bp3-icon StyledProps--main StyledProps--color StyledProps--color-green600"
-                    data-icon="main-caret-up"
-                  >
-                    <svg
-                      height="6"
-                      viewBox="0 0 14 9"
-                      width="6"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M13.7 7.2L7.9.4C7.7.2 7.4 0 7 0s-.7.2-.9.4L.3 7.2c-.2.2-.3.4-.3.7C0 8.5.5 9 1.2 9h11.7c.6 0 1.1-.5 1.1-1.1 0-.3-.1-.5-.3-.7z"
-                        fill="#4d5969"
-                      />
-                    </svg>
-                  </span>
-                </div>
-                <div
-                  class="tickerValue"
-                  data-test="tickerValue"
-                >
-                  <p
-                    class="StyledProps--font StyledProps--main StyledProps--font-size-xsmall StyledProps--color StyledProps--color-green600"
-                  >
-                    23.2%
-                  </p>
-                </div>
-              </div>
+                    <path
+                      d="M7.758 10.265L5.703 1.807l-2.799 4.1H0v-.746h2.51L6.032 0l2.076 8.546 2.81-3.765H14v.747h-2.706l-3.536 4.737z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </span>
+              </button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
##### Summary:

Added graph view toggle for service dashboard and re-design the deployment widget

##### Jira Links:

https://harness.atlassian.net/browse/CDS-34390

##### Screenshots:

<img width="853" alt="Screenshot 2022-03-07 at 10 28 11 AM" src="https://user-images.githubusercontent.com/98325173/156970692-78f3c87b-018d-4c90-80ae-762bd87b8408.png">


https://user-images.githubusercontent.com/98325173/156970822-579c4854-b5b1-4bc7-b21f-39613c135f4e.mov








You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
