### PR TITLE
feat: [SRM-9399]: Add Errors to SRM Live Monitoring

### DIFF
--- a/src/modules/85-cv/components/ErrorTrackingAnalysis/ErrorTrackingAnalysis.constants.ts
+++ b/src/modules/85-cv/components/ErrorTrackingAnalysis/ErrorTrackingAnalysis.constants.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Harness Inc. All rights reserved.
+ * Copyright 2022 Harness Inc. All rights reserved.
  * Use of this source code is governed by the PolyForm Shield 1.0.0 license
  * that can be found in the licenses directory at the root of this repository, also available at
  * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.

--- a/src/modules/85-cv/components/ErrorTrackingAnalysis/ErrorTrackingAnalysis.constants.ts
+++ b/src/modules/85-cv/components/ErrorTrackingAnalysis/ErrorTrackingAnalysis.constants.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2021 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+export const PAGE_SIZE = 7

--- a/src/modules/85-cv/components/ErrorTrackingAnalysis/ErrorTrackingAnalysis.module.scss
+++ b/src/modules/85-cv/components/ErrorTrackingAnalysis/ErrorTrackingAnalysis.module.scss
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+.container {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+
+  .logsAnalysisFilters {
+    max-width: 250px;
+  }
+
+  .clusterChart {
+    width: 100%;
+    height: 185px;
+    margin-bottom: var(--spacing-large);
+  }
+}
+
+.loadingContainer {
+  flex-grow: 1;
+}
+
+.noData {
+  margin-top: var(--spacing-none) !important;
+}
+
+.noDataContainer {
+  height: 100% !important;
+}
+
+.logClusterNoDataImage {
+  height: 100px;
+  width: 200px;
+}
+
+.logsAnalysisNoData {
+  height: 100% !important;
+  margin-top: 140px !important;
+}

--- a/src/modules/85-cv/components/ErrorTrackingAnalysis/ErrorTrackingAnalysis.module.scss.d.ts
+++ b/src/modules/85-cv/components/ErrorTrackingAnalysis/ErrorTrackingAnalysis.module.scss.d.ts
@@ -1,0 +1,19 @@
+/* eslint-disable */
+/**
+ * Copyright 2021 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ **/
+// this is an auto-generated file, do not update this manually
+declare const styles: {
+  readonly clusterChart: string
+  readonly container: string
+  readonly loadingContainer: string
+  readonly logClusterNoDataImage: string
+  readonly logsAnalysisFilters: string
+  readonly logsAnalysisNoData: string
+  readonly noData: string
+  readonly noDataContainer: string
+}
+export default styles

--- a/src/modules/85-cv/components/ErrorTrackingAnalysis/ErrorTrackingAnalysis.tsx
+++ b/src/modules/85-cv/components/ErrorTrackingAnalysis/ErrorTrackingAnalysis.tsx
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import React, { useMemo, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import {
+  Color,
+  Container,
+  Icon,
+  Pagination,
+  Select,
+  Heading,
+  NoDataCard,
+  Layout,
+  PageError,
+  Card,
+  FontVariation
+} from '@wings-software/uicore'
+import { useStrings } from 'framework/strings'
+import { useGetAllErrorTrackingData, useGetAllLogsClusterData } from 'services/cv'
+import type { ProjectPathProps } from '@common/interfaces/RouteInterfaces'
+import { getErrorMessage } from '@cv/utils/CommonUtils'
+import { HealthSourceDropDown } from '@cv/components/HealthSourceDropDown/HealthSourceDropDown'
+import noDataImage from '@cv/assets/noData.svg'
+import { LogAnalysisRow } from '../LogsAnalysis/components/LogAnalysisRow/LogAnalysisRow'
+import { getClusterTypes, getErrorTrackingAnalysisTableData } from './ErrorTrackingAnalysis.utils'
+import {
+  ErrorTrackingAnalysisContentProps,
+  ErrorTrackingAnalysisProps,
+  ErrorTrackingEvents
+} from './ErrorTrackingAnalysis.types'
+import { PAGE_SIZE } from './ErrorTrackingAnalysis.constants'
+import ClusterChart from '../LogsAnalysis/components/ClusterChart/ClusterChart'
+import { VerificationType } from '../HealthSourceDropDown/HealthSourceDropDown.constants'
+import css from './ErrorTrackingAnalysis.module.scss'
+
+const ClusterChartContainer: React.FC<ErrorTrackingAnalysisContentProps> = ({
+  monitoredServiceIdentifier,
+  startTime,
+  endTime,
+  logEvent,
+  healthSource
+}) => {
+  const { getString } = useStrings()
+  const { orgIdentifier, projectIdentifier, accountId } = useParams<ProjectPathProps>()
+
+  const { data, loading, error, refetch } = useGetAllLogsClusterData({
+    queryParams: {
+      accountId,
+      orgIdentifier,
+      projectIdentifier,
+      monitoredServiceIdentifier,
+      startTime,
+      endTime,
+      ...(logEvent ? { clusterTypes: [logEvent] } : {}),
+      healthSources: healthSource ? [healthSource] : undefined
+    },
+    queryParamStringifyOptions: {
+      arrayFormat: 'repeat'
+    }
+  })
+
+  if (loading) {
+    return (
+      <Container flex={{ justifyContent: 'center' }} margin={{ top: 'xxxlarge' }}>
+        <Icon name="steps-spinner" color={Color.GREY_400} size={30} />
+      </Container>
+    )
+  }
+
+  if (error) {
+    return <PageError message={getErrorMessage(error)} onClick={() => refetch()} />
+  }
+
+  if (!data?.resource?.length) {
+    return (
+      <NoDataCard
+        image={noDataImage}
+        imageClassName={css.logClusterNoDataImage}
+        className={css.noData}
+        containerClassName={css.noDataContainer}
+        message={getString('cv.monitoredServices.noAvailableData')}
+      />
+    )
+  }
+
+  return <ClusterChart data={data.resource} />
+}
+
+const ErrorTrackingAnalysisContent: React.FC<ErrorTrackingAnalysisContentProps> = ({
+  monitoredServiceIdentifier,
+  startTime,
+  endTime,
+  logEvent,
+  healthSource
+}) => {
+  const { getString } = useStrings()
+  const { orgIdentifier, projectIdentifier, accountId } = useParams<ProjectPathProps>()
+
+  const queryParams = useMemo(() => {
+    return {
+      page: 0,
+      size: PAGE_SIZE,
+      accountId,
+      orgIdentifier,
+      projectIdentifier,
+      monitoredServiceIdentifier,
+      startTime,
+      endTime,
+      ...(logEvent ? { clusterTypes: [logEvent] } : {}),
+      healthSources: healthSource ? [healthSource] : undefined
+    }
+  }, [
+    accountId,
+    endTime,
+    healthSource,
+    logEvent,
+    orgIdentifier,
+    projectIdentifier,
+    monitoredServiceIdentifier,
+    startTime
+  ])
+
+  const { data, refetch, loading, error } = useGetAllErrorTrackingData({
+    queryParams,
+    queryParamStringifyOptions: {
+      arrayFormat: 'repeat'
+    }
+  })
+
+  if (loading) {
+    return (
+      <Container flex={{ justifyContent: 'center' }} className={css.loadingContainer}>
+        <Icon name="steps-spinner" color={Color.GREY_400} size={30} />
+      </Container>
+    )
+  }
+
+  if (error) {
+    return <PageError message={getErrorMessage(error)} onClick={() => refetch()} />
+  }
+
+  if (!data?.resource?.content?.length) {
+    return (
+      <NoDataCard
+        message={getString('cv.monitoredServices.noAvailableData')}
+        image={noDataImage}
+        containerClassName={css.logsAnalysisNoData}
+      />
+    )
+  }
+
+  const { pageSize = 0, totalPages = 0, totalItems = 0, pageIndex = 0 } = data.resource
+
+  return (
+    <>
+      <LogAnalysisRow data={getErrorTrackingAnalysisTableData(data.resource.content)} isErrorTracking={true} />
+      <Pagination
+        pageSize={pageSize}
+        pageCount={totalPages}
+        itemCount={totalItems}
+        pageIndex={pageIndex}
+        gotoPage={index => refetch({ queryParams: { ...queryParams, page: index } })}
+      />
+    </>
+  )
+}
+
+const ErrorTrackingAnalysis: React.FC<ErrorTrackingAnalysisProps> = ({
+  monitoredServiceIdentifier,
+  startTime,
+  endTime
+}) => {
+  const { getString } = useStrings()
+
+  const [logEvent, setLogEvent] = useState<ErrorTrackingEvents>(ErrorTrackingEvents.UNKNOWN)
+  const [healthSource, setHealthSource] = useState<string>()
+
+  const clusterTypes = getClusterTypes(getString)
+
+  return (
+    <div className={css.container}>
+      <Layout.Horizontal spacing="medium" margin={{ bottom: 'medium' }}>
+        <Select
+          items={clusterTypes}
+          defaultSelectedItem={clusterTypes[2]}
+          className={css.logsAnalysisFilters}
+          inputProps={{ placeholder: getString('pipeline.verification.logs.filterByClusterType') }}
+          onChange={item => setLogEvent(item.value as ErrorTrackingEvents)}
+        />
+        <HealthSourceDropDown
+          onChange={setHealthSource}
+          className={css.logsAnalysisFilters}
+          monitoredServiceIdentifier={monitoredServiceIdentifier}
+          verificationType={VerificationType.LOG}
+        />
+      </Layout.Horizontal>
+
+      <Card className={css.clusterChart}>
+        <Heading level={2} font={{ variation: FontVariation.CARD_TITLE }}>
+          {getString('pipeline.verification.logs.logCluster')}
+        </Heading>
+        <ClusterChartContainer
+          monitoredServiceIdentifier={monitoredServiceIdentifier}
+          startTime={startTime}
+          endTime={endTime}
+          logEvent={logEvent}
+          healthSource={healthSource}
+        />
+      </Card>
+
+      <ErrorTrackingAnalysisContent
+        monitoredServiceIdentifier={monitoredServiceIdentifier}
+        startTime={startTime}
+        endTime={endTime}
+        logEvent={logEvent}
+        healthSource={healthSource}
+      />
+    </div>
+  )
+}
+
+export default ErrorTrackingAnalysis

--- a/src/modules/85-cv/components/ErrorTrackingAnalysis/ErrorTrackingAnalysis.types.ts
+++ b/src/modules/85-cv/components/ErrorTrackingAnalysis/ErrorTrackingAnalysis.types.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import type { SeriesLineOptions } from 'highcharts'
+import type { LogData } from 'services/cv'
+
+export type ErrorTrackingAnalysisRowData = {
+  clusterType: LogData['tag']
+  message: string
+  count: number
+  messageFrequency: SeriesLineOptions[]
+  riskScore: number
+  riskStatus: LogData['riskStatus']
+}
+
+export interface ErrorTrackingAnalysisProps {
+  monitoredServiceIdentifier: string
+  startTime: number
+  endTime: number
+}
+
+export enum ErrorTrackingEvents {
+  KNOWN = 'KNOWN',
+  UNKNOWN = 'UNKNOWN',
+  UNEXPECTED = 'UNEXPECTED'
+}
+
+export interface ErrorTrackingAnalysisContentProps extends ErrorTrackingAnalysisProps {
+  logEvent: ErrorTrackingEvents
+  healthSource?: string
+}

--- a/src/modules/85-cv/components/ErrorTrackingAnalysis/ErrorTrackingAnalysis.utils.ts
+++ b/src/modules/85-cv/components/ErrorTrackingAnalysis/ErrorTrackingAnalysis.utils.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import type { SelectOption } from '@pipeline/components/PipelineSteps/Steps/StepsTypes'
+import type { UseStringsReturn } from 'framework/strings'
+import type { AnalyzedLogDataDTO } from 'services/cv'
+import { getRiskColorValue } from '@cv/utils/CommonUtils'
+import { ErrorTrackingAnalysisRowData, ErrorTrackingEvents } from './ErrorTrackingAnalysis.types'
+
+export const getClusterTypes = (getString: UseStringsReturn['getString']): SelectOption[] => {
+  return [
+    { label: getString('pipeline.verification.logs.allEvents'), value: '' },
+    { label: getString('pipeline.verification.logs.knownEvent'), value: ErrorTrackingEvents.KNOWN },
+    { label: getString('pipeline.verification.logs.unknownEvent'), value: ErrorTrackingEvents.UNKNOWN },
+    { label: getString('pipeline.verification.logs.unexpectedFrequency'), value: ErrorTrackingEvents.UNEXPECTED }
+  ]
+}
+
+export function getErrorTrackingAnalysisTableData(logsData: AnalyzedLogDataDTO[]): ErrorTrackingAnalysisRowData[] {
+  return (
+    logsData.map(log => ({
+      clusterType: log.logData?.tag,
+      count: log.logData?.count ?? 0,
+      message: log.logData?.text ?? '',
+      messageFrequency: [
+        {
+          name: 'trendData',
+          type: 'line',
+          color: getRiskColorValue(log.logData?.riskStatus),
+          data: log.logData?.trend?.map(t => t.count ?? 0)
+        }
+      ],
+      riskScore: log.logData?.riskScore ?? 0,
+      riskStatus: log.logData?.riskStatus
+    })) ?? []
+  )
+}

--- a/src/modules/85-cv/components/ErrorTrackingAnalysis/__tests__/ErrorTrackingAnalysis.mocks.ts
+++ b/src/modules/85-cv/components/ErrorTrackingAnalysis/__tests__/ErrorTrackingAnalysis.mocks.ts
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import type { AnalyzedLogDataDTO } from 'services/cv'
+import { RiskValues, getRiskColorValue } from '@cv/utils/CommonUtils'
+
+export const mockedLogAnalysisData = {
+  resource: {
+    totalPages: 1,
+    totalItems: 1,
+    pageItemCount: 1,
+    pageSize: 10,
+    content: [
+      {
+        projectIdentifier: 'Harshil',
+        orgIdentifier: 'default',
+        environmentIdentifier: 'Environment_102',
+        serviceIdentifier: 'Service_102',
+        logData: {
+          text: 'prod-setup-205416',
+          label: 0,
+          count: 1,
+          trend: [
+            {
+              timestamp: 1630567200000,
+              count: 1
+            }
+          ],
+          tag: 'KNOWN'
+        }
+      },
+      {
+        projectIdentifier: 'Harshil',
+        orgIdentifier: 'default',
+        environmentIdentifier: 'Environment_102',
+        serviceIdentifier: 'Service_102',
+        logData: {
+          text: 'prod-setup-205416',
+          label: 0,
+          count: 1,
+          trend: [
+            {
+              timestamp: 1630567200000,
+              count: 1
+            }
+          ],
+          tag: 'UNKNOWN'
+        }
+      },
+      {
+        projectIdentifier: 'Harshil',
+        orgIdentifier: 'default',
+        environmentIdentifier: 'Environment_102',
+        serviceIdentifier: 'Service_102',
+        logData: {
+          text: 'prod-setup-205416',
+          label: 0,
+          count: 1,
+          trend: [
+            {
+              timestamp: 1630567200000,
+              count: 1
+            }
+          ],
+          tag: 'UNEXPECTED'
+        }
+      }
+    ],
+    pageIndex: 0,
+    empty: false
+  }
+}
+
+export const mockedLogsData: AnalyzedLogDataDTO[] = [
+  {
+    projectIdentifier: 'Harshil',
+    orgIdentifier: 'CV',
+    environmentIdentifier: 'prod',
+    serviceIdentifier: 'service240',
+    logData: {
+      text: 'verification-svc',
+      label: 0,
+      count: 9000,
+      riskScore: 0,
+      riskStatus: RiskValues.HEALTHY,
+      trend: [
+        {
+          timestamp: 1632045240000,
+          count: 1000
+        },
+        {
+          timestamp: 1632045540000,
+          count: 1000
+        },
+        {
+          timestamp: 1632043440000,
+          count: 1000
+        },
+        {
+          timestamp: 1632044340000,
+          count: 1000
+        },
+        {
+          timestamp: 1632045840000,
+          count: 1000
+        },
+        {
+          timestamp: 1632043740000,
+          count: 1000
+        },
+        {
+          timestamp: 1632044640000,
+          count: 1000
+        },
+        {
+          timestamp: 1632044040000,
+          count: 1000
+        },
+        {
+          timestamp: 1632044940000,
+          count: 1000
+        }
+      ],
+      tag: 'KNOWN'
+    }
+  }
+]
+
+export const mockedLogData = {
+  projectIdentifier: 'Harshil',
+  orgIdentifier: 'CV',
+  environmentIdentifier: 'prod',
+  serviceIdentifier: 'service240',
+  logData: {
+    text: 'verification-svc',
+    label: 0,
+    count: 9000,
+    riskScore: 0,
+    riskStatus: RiskValues.HEALTHY,
+    trend: [
+      {
+        timestamp: 1632045240000,
+        count: 1000
+      },
+      {
+        timestamp: 1632045540000,
+        count: 1000
+      },
+      {
+        timestamp: 1632043440000,
+        count: 1000
+      },
+      {
+        timestamp: 1632044340000,
+        count: 1000
+      },
+      {
+        timestamp: 1632045840000,
+        count: 1000
+      },
+      {
+        timestamp: 1632043740000,
+        count: 1000
+      },
+      {
+        timestamp: 1632044640000,
+        count: 1000
+      },
+      {
+        timestamp: 1632044040000,
+        count: 1000
+      },
+      {
+        timestamp: 1632044940000,
+        count: 1000
+      }
+    ],
+    tag: 'KNOWN'
+  }
+}
+
+export const mockedLogsTableData = [
+  {
+    clusterType: 'KNOWN',
+    count: 9000,
+    message: 'verification-svc',
+    messageFrequency: [
+      {
+        name: 'trendData',
+        type: 'line',
+        color: getRiskColorValue(RiskValues.HEALTHY),
+        data: [1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000]
+      }
+    ],
+    riskScore: 0,
+    riskStatus: RiskValues.HEALTHY
+  }
+]

--- a/src/modules/85-cv/components/ErrorTrackingAnalysis/__tests__/ErrorTrackingAnalysis.mocks.ts
+++ b/src/modules/85-cv/components/ErrorTrackingAnalysis/__tests__/ErrorTrackingAnalysis.mocks.ts
@@ -8,7 +8,7 @@
 import type { AnalyzedLogDataDTO } from 'services/cv'
 import { RiskValues, getRiskColorValue } from '@cv/utils/CommonUtils'
 
-export const mockedLogAnalysisData = {
+export const mockedErrorTrackingAnalysisData = {
   resource: {
     totalPages: 1,
     totalItems: 1,
@@ -198,5 +198,32 @@ export const mockedLogsTableData = [
     ],
     riskScore: 0,
     riskStatus: RiskValues.HEALTHY
+  }
+]
+
+export const mockedLogsData2: AnalyzedLogDataDTO[] = [
+  {
+    projectIdentifier: 'Harshil',
+    orgIdentifier: 'CV',
+    environmentIdentifier: 'prod',
+    serviceIdentifier: 'service240'
+  }
+]
+
+export const mockedLogsTableData2 = [
+  {
+    clusterType: undefined,
+    count: 0,
+    message: '',
+    messageFrequency: [
+      {
+        name: 'trendData',
+        type: 'line',
+        color: getRiskColorValue(RiskValues.NO_DATA),
+        data: undefined
+      }
+    ],
+    riskScore: 0,
+    riskStatus: undefined
   }
 ]

--- a/src/modules/85-cv/components/ErrorTrackingAnalysis/__tests__/ErrorTrackingAnalysis.test.tsx
+++ b/src/modules/85-cv/components/ErrorTrackingAnalysis/__tests__/ErrorTrackingAnalysis.test.tsx
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import React from 'react'
+import userEvent from '@testing-library/user-event'
+import { render, waitFor, screen, fireEvent, act } from '@testing-library/react'
+import type * as cvServices from 'services/cv'
+import { TestWrapper } from '@common/utils/testUtils'
+import ErrorTrackingAnalysis from '@cv/components/ErrorTrackingAnalysis/ErrorTrackingAnalysis'
+import {
+  mockedClustersData,
+  mockedHealthSourcesData
+} from '@cv/pages/monitored-service/components/ServiceHealth/components/MetricsAndLogs/__tests__/MetricsAndLogs.mock'
+import { ErrorTrackingAnalysisProps, ErrorTrackingEvents } from '../ErrorTrackingAnalysis.types'
+import { mockedLogAnalysisData as mockedErrorTrackingAnalysisData } from './ErrorTrackingAnalysis.mocks'
+
+const WrapperComponent = (props: ErrorTrackingAnalysisProps): JSX.Element => {
+  return (
+    <TestWrapper>
+      <ErrorTrackingAnalysis {...props} />
+    </TestWrapper>
+  )
+}
+
+jest.mock('highcharts-react-official', () => () => <></>)
+const fetchLogAnalysis = jest.fn()
+const fetchClusterData = jest.fn()
+let useGetAllLogsClusterDataQueryParams: cvServices.GetAllLogsClusterDataQueryParams | undefined
+let useGetAllLogsDataQueryParams: cvServices.GetAllLogsDataQueryParams | undefined
+
+jest.mock('services/cv', () => ({
+  useGetAllErrorTrackingLogsData: jest.fn().mockImplementation(props => {
+    useGetAllLogsDataQueryParams = props.queryParams
+    return { data: mockedErrorTrackingAnalysisData, loading: false, error: null, refetch: fetchLogAnalysis }
+  }),
+  useGetAllHealthSourcesForMonitoredServiceIdentifier: jest.fn().mockImplementation(() => {
+    return { data: mockedHealthSourcesData, error: null, loading: false }
+  }),
+  useGetAllLogsClusterData: jest.fn().mockImplementation(props => {
+    useGetAllLogsClusterDataQueryParams = props.queryParams
+    return { data: mockedClustersData, error: null, loading: false, refetch: fetchClusterData }
+  })
+}))
+
+describe('Unit tests for ErrorTrackingAnalysisContainer', () => {
+  const props = {
+    monitoredServiceIdentifier: 'monitored_service_identifier',
+    serviceIdentifier: 'service-identifier',
+    environmentIdentifier: 'env-identifier',
+    startTime: 1630594988077,
+    endTime: 1630595011443
+  }
+  test('Verify if ErrorTrackingAnalysisContainer renders', async () => {
+    const { container } = render(<WrapperComponent {...props} />)
+    expect(container).toMatchSnapshot()
+  })
+
+  test('Verify if Error Tracking Cluster Chart and Error Tracking Record Table is rendered correctly', async () => {
+    render(<WrapperComponent {...props} />)
+
+    // Verify if number of records returned by the api for the first page matches with the number of records shown in the Logs Table
+    await waitFor(() =>
+      expect(screen.getAllByTestId('logs-data-row')).toHaveLength(
+        mockedErrorTrackingAnalysisData.resource.content.length
+      )
+    )
+  })
+
+  test('Verify if Filtering by cluster type works correctly', async () => {
+    const { container, getByText, getAllByText } = render(<WrapperComponent {...props} />)
+
+    const clusterTypeFilterDropdown = container.querySelector(
+      'input[placeholder="pipeline.verification.logs.filterByClusterType"]'
+    ) as HTMLInputElement
+
+    expect(clusterTypeFilterDropdown).toBeTruthy()
+
+    // verify default filter is unknownEvent
+    expect(clusterTypeFilterDropdown.value).toBe('pipeline.verification.logs.unknownEvent')
+
+    // Clicking the filter dropdown
+    const selectCaret = container
+      .querySelector(`[placeholder="pipeline.verification.logs.filterByClusterType"] + [class*="bp3-input-action"]`)
+      ?.querySelector('[data-icon="chevron-down"]')
+    await waitFor(() => {
+      fireEvent.click(selectCaret!)
+    })
+
+    // Selecting Known event cluster type
+    const typeToSelect = await getByText('pipeline.verification.logs.knownEvent')
+    act(() => {
+      fireEvent.click(typeToSelect)
+    })
+    expect(clusterTypeFilterDropdown.value).toBe('pipeline.verification.logs.knownEvent')
+
+    // Verifying if correct number of records are shown for Known event type.
+    const knownClusterTypeMockedData = mockedErrorTrackingAnalysisData.resource.content.filter(
+      el => el.logData.tag === 'KNOWN'
+    )
+    await waitFor(() => expect(getAllByText('Known')).toHaveLength(knownClusterTypeMockedData.length))
+
+    // Selecting UnKnown event cluster type
+    const unknownEventTypeSelected = await getByText('pipeline.verification.logs.unknownEvent')
+    act(() => {
+      fireEvent.click(unknownEventTypeSelected)
+    })
+    expect(clusterTypeFilterDropdown.value).toBe('pipeline.verification.logs.unknownEvent')
+
+    // Verifying if correct number of records are shown for unKnown event type.
+    const unknownClusterTypeMockedData = mockedErrorTrackingAnalysisData.resource.content.filter(
+      el => el.logData.tag === 'UNKNOWN'
+    )
+    await waitFor(() => expect(getAllByText('Unknown')).toHaveLength(unknownClusterTypeMockedData.length))
+  })
+
+  test('it should not pass field clusterTypes to BE for event type All', () => {
+    render(<WrapperComponent {...props} />)
+
+    const clusterTypeFilterDropdown = screen.getByPlaceholderText(
+      'pipeline.verification.logs.filterByClusterType'
+    ) as HTMLInputElement
+
+    expect(clusterTypeFilterDropdown.value).toBe('pipeline.verification.logs.unknownEvent')
+    expect(useGetAllLogsClusterDataQueryParams?.clusterTypes).toEqual([ErrorTrackingEvents.UNKNOWN])
+    expect(useGetAllLogsDataQueryParams?.clusterTypes).toEqual([ErrorTrackingEvents.UNKNOWN])
+
+    userEvent.click(clusterTypeFilterDropdown)
+    userEvent.click(screen.getByText('pipeline.verification.logs.allEvents'))
+
+    expect(clusterTypeFilterDropdown.value).toBe('pipeline.verification.logs.allEvents')
+    expect(useGetAllLogsClusterDataQueryParams).not.toHaveProperty('clusterTypes')
+    expect(useGetAllLogsDataQueryParams).not.toHaveProperty('clusterTypes')
+  })
+})

--- a/src/modules/85-cv/components/ErrorTrackingAnalysis/__tests__/ErrorTrackingAnalysis.test.tsx
+++ b/src/modules/85-cv/components/ErrorTrackingAnalysis/__tests__/ErrorTrackingAnalysis.test.tsx
@@ -8,7 +8,7 @@
 import React from 'react'
 import userEvent from '@testing-library/user-event'
 import { render, waitFor, screen, fireEvent, act } from '@testing-library/react'
-import type * as cvServices from 'services/cv'
+import * as cvServices from 'services/cv'
 import { TestWrapper } from '@common/utils/testUtils'
 import ErrorTrackingAnalysis from '@cv/components/ErrorTrackingAnalysis/ErrorTrackingAnalysis'
 import {
@@ -16,7 +16,7 @@ import {
   mockedHealthSourcesData
 } from '@cv/pages/monitored-service/components/ServiceHealth/components/MetricsAndLogs/__tests__/MetricsAndLogs.mock'
 import { ErrorTrackingAnalysisProps, ErrorTrackingEvents } from '../ErrorTrackingAnalysis.types'
-import { mockedLogAnalysisData as mockedErrorTrackingAnalysisData } from './ErrorTrackingAnalysis.mocks'
+import { mockedErrorTrackingAnalysisData } from './ErrorTrackingAnalysis.mocks'
 
 const WrapperComponent = (props: ErrorTrackingAnalysisProps): JSX.Element => {
   return (
@@ -29,38 +29,47 @@ const WrapperComponent = (props: ErrorTrackingAnalysisProps): JSX.Element => {
 jest.mock('highcharts-react-official', () => () => <></>)
 const fetchLogAnalysis = jest.fn()
 const fetchClusterData = jest.fn()
-let useGetAllLogsClusterDataQueryParams: cvServices.GetAllLogsClusterDataQueryParams | undefined
-let useGetAllLogsDataQueryParams: cvServices.GetAllLogsDataQueryParams | undefined
 
-jest.mock('services/cv', () => ({
-  useGetAllErrorTrackingData: jest.fn().mockImplementation(props => {
-    useGetAllLogsDataQueryParams = props.queryParams
-    return { data: mockedErrorTrackingAnalysisData, loading: false, error: null, refetch: fetchLogAnalysis }
-  }),
-  useGetAllHealthSourcesForMonitoredServiceIdentifier: jest.fn().mockImplementation(() => {
-    return { data: mockedHealthSourcesData, error: null, loading: false }
-  }),
-  useGetAllLogsClusterData: jest.fn().mockImplementation(props => {
-    useGetAllLogsClusterDataQueryParams = props.queryParams
-    return { data: mockedClustersData, error: null, loading: false, refetch: fetchClusterData }
-  })
-}))
+const mockProps = {
+  monitoredServiceIdentifier: 'monitored_service_identifier',
+  serviceIdentifier: 'service-identifier',
+  environmentIdentifier: 'env-identifier',
+  startTime: 1630594988077,
+  endTime: 1630595011443
+}
 
 describe('Unit tests for ErrorTrackingAnalysisContainer', () => {
-  const props = {
-    monitoredServiceIdentifier: 'monitored_service_identifier',
-    serviceIdentifier: 'service-identifier',
-    environmentIdentifier: 'env-identifier',
-    startTime: 1630594988077,
-    endTime: 1630595011443
-  }
-  test('Verify if ErrorTrackingAnalysisContainer renders', async () => {
-    const { container } = render(<WrapperComponent {...props} />)
+  test('Verify if ErrorTrackingAnalysisContainer renders', () => {
+    jest.spyOn(cvServices, 'useGetAllErrorTrackingData').mockImplementation((): any => {
+      return { data: mockedErrorTrackingAnalysisData, loading: false, error: null, refetch: fetchLogAnalysis }
+    })
+
+    jest.spyOn(cvServices, 'useGetAllHealthSourcesForMonitoredServiceIdentifier').mockImplementation((): any => {
+      return { data: mockedHealthSourcesData, error: null, loading: false }
+    })
+
+    jest.spyOn(cvServices, 'useGetAllLogsClusterData').mockImplementation((): any => {
+      return { data: mockedClustersData, error: null, loading: false, refetch: fetchClusterData }
+    })
+
+    const { container } = render(<WrapperComponent {...mockProps} />)
     expect(container).toMatchSnapshot()
   })
 
   test('Verify if Error Tracking Cluster Chart and Error Tracking Record Table is rendered correctly', async () => {
-    render(<WrapperComponent {...props} />)
+    jest.spyOn(cvServices, 'useGetAllErrorTrackingData').mockImplementation((): any => {
+      return { data: mockedErrorTrackingAnalysisData, loading: false, error: null, refetch: fetchLogAnalysis }
+    })
+
+    jest.spyOn(cvServices, 'useGetAllHealthSourcesForMonitoredServiceIdentifier').mockImplementation((): any => {
+      return { data: mockedHealthSourcesData, error: null, loading: false }
+    })
+
+    jest.spyOn(cvServices, 'useGetAllLogsClusterData').mockImplementation((): any => {
+      return { data: mockedClustersData, error: null, loading: false, refetch: fetchClusterData }
+    })
+
+    render(<WrapperComponent {...mockProps} />)
 
     // Verify if number of records returned by the api for the first page matches with the number of records shown in the Logs Table
     await waitFor(() =>
@@ -71,7 +80,18 @@ describe('Unit tests for ErrorTrackingAnalysisContainer', () => {
   })
 
   test('Verify if Filtering by cluster type works correctly', async () => {
-    const { container, getByText, getAllByText } = render(<WrapperComponent {...props} />)
+    jest.spyOn(cvServices, 'useGetAllErrorTrackingData').mockImplementation((): any => {
+      return { data: mockedErrorTrackingAnalysisData, loading: false, error: null, refetch: fetchLogAnalysis }
+    })
+
+    jest.spyOn(cvServices, 'useGetAllHealthSourcesForMonitoredServiceIdentifier').mockImplementation((): any => {
+      return { data: mockedHealthSourcesData, error: null, loading: false }
+    })
+
+    jest.spyOn(cvServices, 'useGetAllLogsClusterData').mockImplementation((): any => {
+      return { data: mockedClustersData, error: null, loading: false, refetch: fetchClusterData }
+    })
+    const { container, getByText, getAllByText } = render(<WrapperComponent {...mockProps} />)
 
     const clusterTypeFilterDropdown = container.querySelector(
       'input[placeholder="pipeline.verification.logs.filterByClusterType"]'
@@ -118,7 +138,28 @@ describe('Unit tests for ErrorTrackingAnalysisContainer', () => {
   })
 
   test('it should not pass field clusterTypes to BE for event type All', () => {
-    render(<WrapperComponent {...props} />)
+    let useGetAllLogsClusterDataQueryParams: cvServices.GetAllLogsClusterDataQueryParams | undefined
+    let useGetAllLogsDataQueryParams: cvServices.GetAllLogsDataQueryParams | undefined
+
+    jest
+      .spyOn(cvServices, 'useGetAllErrorTrackingData')
+      .mockImplementation((props: cvServices.UseGetAllErrorTrackingDataProps): any => {
+        useGetAllLogsDataQueryParams = props.queryParams
+        return { data: mockedErrorTrackingAnalysisData, loading: false, error: null, refetch: fetchLogAnalysis }
+      })
+
+    jest.spyOn(cvServices, 'useGetAllHealthSourcesForMonitoredServiceIdentifier').mockImplementation((): any => {
+      return { data: mockedHealthSourcesData, error: null, loading: false }
+    })
+
+    jest
+      .spyOn(cvServices, 'useGetAllLogsClusterData')
+      .mockImplementation((props: cvServices.UseGetAllLogsClusterDataProps): any => {
+        useGetAllLogsClusterDataQueryParams = props.queryParams
+        return { data: mockedClustersData, error: null, loading: false, refetch: fetchClusterData }
+      })
+
+    render(<WrapperComponent {...mockProps} />)
 
     const clusterTypeFilterDropdown = screen.getByPlaceholderText(
       'pipeline.verification.logs.filterByClusterType'
@@ -134,5 +175,100 @@ describe('Unit tests for ErrorTrackingAnalysisContainer', () => {
     expect(clusterTypeFilterDropdown.value).toBe('pipeline.verification.logs.allEvents')
     expect(useGetAllLogsClusterDataQueryParams).not.toHaveProperty('clusterTypes')
     expect(useGetAllLogsDataQueryParams).not.toHaveProperty('clusterTypes')
+  })
+
+  test('Unit tests for ErrorTrackingAnalysisContainer no data', () => {
+    jest.spyOn(cvServices, 'useGetAllErrorTrackingData').mockImplementation((): any => {
+      return { data: undefined, loading: false, error: null, refetch: fetchLogAnalysis }
+    })
+
+    jest.spyOn(cvServices, 'useGetAllHealthSourcesForMonitoredServiceIdentifier').mockImplementation((): any => {
+      return { data: mockedHealthSourcesData, error: null, loading: false }
+    })
+
+    jest.spyOn(cvServices, 'useGetAllLogsClusterData').mockImplementation((): any => {
+      return { data: mockedClustersData, error: null, loading: false, refetch: fetchClusterData }
+    })
+
+    render(<WrapperComponent {...mockProps} />)
+
+    expect(screen.getByText('cv.monitoredServices.noAvailableData'))
+  })
+
+  test('Unit tests for ErrorTrackingAnalysisContainer error in response', async () => {
+    jest.spyOn(cvServices, 'useGetAllErrorTrackingData').mockImplementation((): any => {
+      return { data: undefined, loading: false, error: { message: 'There is a problem' }, refetch: fetchLogAnalysis }
+    })
+
+    jest.spyOn(cvServices, 'useGetAllHealthSourcesForMonitoredServiceIdentifier').mockImplementation((): any => {
+      return { data: mockedHealthSourcesData, error: null, loading: false }
+    })
+
+    jest.spyOn(cvServices, 'useGetAllLogsClusterData').mockImplementation((): any => {
+      return { data: mockedClustersData, error: null, loading: false, refetch: fetchClusterData }
+    })
+
+    render(<WrapperComponent {...mockProps} />)
+
+    expect(screen.getByText('There is a problem')).toBeDefined()
+
+    const retryButton = await waitFor(() => screen.getByText('Retry'))
+
+    expect(retryButton).toBeDefined()
+
+    userEvent.click(retryButton)
+
+    await waitFor(() => expect(screen.getByText('Retry')).toBeDefined())
+    expect(fetchLogAnalysis).toBeCalled()
+  })
+
+  test('Unit tests for ErrorTrackingClusterContainer no data', () => {
+    jest.spyOn(cvServices, 'useGetAllErrorTrackingData').mockImplementation((): any => {
+      return { data: mockedErrorTrackingAnalysisData, loading: false, error: null, refetch: fetchLogAnalysis }
+    })
+
+    jest.spyOn(cvServices, 'useGetAllHealthSourcesForMonitoredServiceIdentifier').mockImplementation((): any => {
+      return { data: mockedHealthSourcesData, error: null, loading: false }
+    })
+
+    jest.spyOn(cvServices, 'useGetAllLogsClusterData').mockImplementation((): any => {
+      return { data: undefined, error: null, loading: false, refetch: fetchClusterData }
+    })
+
+    render(<WrapperComponent {...mockProps} />)
+
+    expect(screen.getByText('cv.monitoredServices.noAvailableData')).toBeDefined()
+  })
+
+  test('Unit tests for ErrorTrackingClusterContainer error in response', async () => {
+    jest.spyOn(cvServices, 'useGetAllErrorTrackingData').mockImplementation((): any => {
+      return { data: mockedErrorTrackingAnalysisData, loading: false, error: null, refetch: fetchLogAnalysis }
+    })
+
+    jest.spyOn(cvServices, 'useGetAllHealthSourcesForMonitoredServiceIdentifier').mockImplementation((): any => {
+      return { data: mockedHealthSourcesData, error: null, loading: false }
+    })
+
+    jest.spyOn(cvServices, 'useGetAllLogsClusterData').mockImplementation((): any => {
+      return {
+        data: undefined,
+        error: { message: 'a new problem has occurred' },
+        loading: false,
+        refetch: fetchClusterData
+      }
+    })
+
+    render(<WrapperComponent {...mockProps} />)
+
+    expect(screen.getByText('a new problem has occurred')).toBeDefined()
+
+    const retryButton = await waitFor(() => screen.getByText('Retry'))
+
+    expect(retryButton).toBeDefined()
+
+    userEvent.click(retryButton)
+
+    await waitFor(() => expect(screen.getByText('Retry')).toBeDefined())
+    expect(fetchClusterData).toBeCalled()
   })
 })

--- a/src/modules/85-cv/components/ErrorTrackingAnalysis/__tests__/ErrorTrackingAnalysis.test.tsx
+++ b/src/modules/85-cv/components/ErrorTrackingAnalysis/__tests__/ErrorTrackingAnalysis.test.tsx
@@ -33,7 +33,7 @@ let useGetAllLogsClusterDataQueryParams: cvServices.GetAllLogsClusterDataQueryPa
 let useGetAllLogsDataQueryParams: cvServices.GetAllLogsDataQueryParams | undefined
 
 jest.mock('services/cv', () => ({
-  useGetAllErrorTrackingLogsData: jest.fn().mockImplementation(props => {
+  useGetAllErrorTrackingData: jest.fn().mockImplementation(props => {
     useGetAllLogsDataQueryParams = props.queryParams
     return { data: mockedErrorTrackingAnalysisData, loading: false, error: null, refetch: fetchLogAnalysis }
   }),

--- a/src/modules/85-cv/components/ErrorTrackingAnalysis/__tests__/ErrorTrackingAnalysis.utils.test.tsx
+++ b/src/modules/85-cv/components/ErrorTrackingAnalysis/__tests__/ErrorTrackingAnalysis.utils.test.tsx
@@ -8,7 +8,12 @@
 import type { StringKeys } from 'framework/strings'
 import { getClusterTypes, getErrorTrackingAnalysisTableData } from '../ErrorTrackingAnalysis.utils'
 import { ErrorTrackingEvents } from '../ErrorTrackingAnalysis.types'
-import { mockedLogsData, mockedLogsTableData } from './ErrorTrackingAnalysis.mocks'
+import {
+  mockedLogsData,
+  mockedLogsTableData,
+  mockedLogsData2,
+  mockedLogsTableData2
+} from './ErrorTrackingAnalysis.mocks'
 
 function getString(key: StringKeys): StringKeys {
   return key
@@ -24,7 +29,11 @@ describe('Unit tests for LogAnalysis utils', () => {
     ])
   })
 
-  test('Verify if getLogAnalysisTableData method gives the correct logs analysis Table data', async () => {
+  test('Verify if getErrorTrackingAnalysisTableData method gives the correct logs analysis Table data', async () => {
     expect(getErrorTrackingAnalysisTableData(mockedLogsData)).toEqual(mockedLogsTableData)
+  })
+
+  test('Verify if getErroTrackingAnalysisTableData method gives the correct logs analysis Table data2', async () => {
+    expect(getErrorTrackingAnalysisTableData(mockedLogsData2)).toEqual(mockedLogsTableData2)
   })
 })

--- a/src/modules/85-cv/components/ErrorTrackingAnalysis/__tests__/ErrorTrackingAnalysis.utils.test.tsx
+++ b/src/modules/85-cv/components/ErrorTrackingAnalysis/__tests__/ErrorTrackingAnalysis.utils.test.tsx
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import type { StringKeys } from 'framework/strings'
+import { getClusterTypes, getErrorTrackingAnalysisTableData } from '../ErrorTrackingAnalysis.utils'
+import { ErrorTrackingEvents } from '../ErrorTrackingAnalysis.types'
+import { mockedLogsData, mockedLogsTableData } from './ErrorTrackingAnalysis.mocks'
+
+function getString(key: StringKeys): StringKeys {
+  return key
+}
+
+describe('Unit tests for LogAnalysis utils', () => {
+  test('Verify if getClusterTypes gives correct results', async () => {
+    expect(getClusterTypes(getString)).toEqual([
+      { label: 'pipeline.verification.logs.allEvents', value: '' },
+      { label: 'pipeline.verification.logs.knownEvent', value: ErrorTrackingEvents.KNOWN },
+      { label: 'pipeline.verification.logs.unknownEvent', value: ErrorTrackingEvents.UNKNOWN },
+      { label: 'pipeline.verification.logs.unexpectedFrequency', value: ErrorTrackingEvents.UNEXPECTED }
+    ])
+  })
+
+  test('Verify if getLogAnalysisTableData method gives the correct logs analysis Table data', async () => {
+    expect(getErrorTrackingAnalysisTableData(mockedLogsData)).toEqual(mockedLogsTableData)
+  })
+})

--- a/src/modules/85-cv/components/ErrorTrackingAnalysis/__tests__/__snapshots__/ErrorTrackingAnalysis.test.tsx.snap
+++ b/src/modules/85-cv/components/ErrorTrackingAnalysis/__tests__/__snapshots__/ErrorTrackingAnalysis.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Unit tests for LogAnalysisContainer Verify if LogAnalysisContainer renders 1`] = `
+exports[`Unit tests for ErrorTrackingAnalysisContainer Verify if ErrorTrackingAnalysisContainer renders 1`] = `
 <div>
   <div
     class="container"

--- a/src/modules/85-cv/components/ErrorTrackingAnalysis/__tests__/__snapshots__/ErrorTrackingAnalysis.test.tsx.snap
+++ b/src/modules/85-cv/components/ErrorTrackingAnalysis/__tests__/__snapshots__/ErrorTrackingAnalysis.test.tsx.snap
@@ -1,0 +1,387 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Unit tests for LogAnalysisContainer Verify if LogAnalysisContainer renders 1`] = `
+<div>
+  <div
+    class="container"
+  >
+    <div
+      class="Layout--horizontal Layout--layout-spacing-medium StyledProps--main StyledProps--margin-bottom-medium"
+    >
+      <div
+        class="bp3-popover-wrapper logsAnalysisFilters Select--main bp3-fill"
+      >
+        <div
+          class="bp3-popover-target"
+        >
+          <div
+            class="bp3-input-group"
+          >
+            <input
+              autocomplete="off"
+              class="bp3-input"
+              placeholder="pipeline.verification.logs.filterByClusterType"
+              style="padding-right: 0px;"
+              type="text"
+              value="pipeline.verification.logs.unknownEvent"
+            />
+            <span
+              class="bp3-input-action"
+            >
+              <span
+                class="bp3-icon bp3-icon-chevron-down StyledProps--main StyledProps--padding-small"
+                icon="chevron-down"
+              >
+                <svg
+                  data-icon="chevron-down"
+                  height="14"
+                  viewBox="0 0 16 16"
+                  width="14"
+                >
+                  <desc>
+                    chevron-down
+                  </desc>
+                  <path
+                    d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
+        class="bp3-popover-wrapper maxDropDownWidth logsAnalysisFilters Select--main bp3-fill"
+      >
+        <div
+          class="bp3-popover-target"
+        >
+          <div
+            class="bp3-input-group"
+          >
+            <input
+              autocomplete="off"
+              class="bp3-input"
+              name="healthsources-select"
+              placeholder="pipeline.verification.healthSourcePlaceholder"
+              style="padding-right: 0px;"
+              type="text"
+              value=""
+            />
+            <span
+              class="bp3-input-action"
+            >
+              <span
+                class="bp3-icon bp3-icon-chevron-down StyledProps--main StyledProps--padding-small"
+                icon="chevron-down"
+              >
+                <svg
+                  data-icon="chevron-down"
+                  height="14"
+                  viewBox="0 0 16 16"
+                  width="14"
+                >
+                  <desc>
+                    chevron-down
+                  </desc>
+                  <path
+                    d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="bp3-card bp3-elevation-0 Card--card clusterChart"
+    >
+      <h2
+        class="StyledProps--font StyledProps--font-h2 StyledProps--main StyledProps--font-variation-card-title"
+        level="2"
+      >
+        pipeline.verification.logs.logCluster
+      </h2>
+      <div
+        class="StyledProps--font StyledProps--main StyledProps--padding-medium"
+      />
+    </div>
+    <div
+      class="StyledProps--font StyledProps--main main"
+    >
+      <div
+        class="StyledProps--font StyledProps--main mainRow columnHeader"
+      >
+        <p
+          class="StyledProps--font StyledProps--main clusterType logRowColumnHeader StyledProps--color StyledProps--color-black"
+        >
+          pipeline.verification.logs.clusterType
+        </p>
+        <p
+          class="StyledProps--font StyledProps--main risk logRowColumnHeader StyledProps--color StyledProps--color-black"
+        >
+          pipeline.verification.logs.risk
+        </p>
+        <p
+          class="StyledProps--font StyledProps--main message logRowColumnHeader StyledProps--color StyledProps--color-black"
+        >
+          pipeline.verification.logs.sampleMessage
+        </p>
+        <p
+          class="StyledProps--font StyledProps--main count logRowColumnHeader StyledProps--color StyledProps--color-black"
+        >
+          pipeline.verification.logs.messageCount
+        </p>
+        <p
+          class="StyledProps--font StyledProps--main messageFrequency logRowColumnHeader StyledProps--color StyledProps--color-black"
+        >
+          pipeline.verification.logs.messageFrequency
+        </p>
+      </div>
+      <div
+        class="StyledProps--font StyledProps--main dataContainer"
+      >
+        <div
+          class="StyledProps--font StyledProps--main mainRow dataRow highlightRow"
+          data-testid="logs-data-row"
+        >
+          <div
+            class="StyledProps--font StyledProps--main dataColumn openModalColumn compareDataColumn clusterType"
+          >
+            <p
+              class="StyledProps--font StyledProps--main"
+            >
+              Known
+            </p>
+          </div>
+          <div
+            class="StyledProps--font StyledProps--main logRowText dataColumn openModalColumn risk"
+          >
+            <div
+              class="healthScoreCard"
+            >
+              <p
+                class="StyledProps--font StyledProps--main StyledProps--font-size-xsmall StyledProps--font-weight-semi-bold StyledProps--color StyledProps--color-white"
+              >
+                NA
+              </p>
+            </div>
+          </div>
+          <div
+            class="StyledProps--font StyledProps--main logText dataColumn openModalColumn message"
+          >
+            <p
+              class="logRowText"
+            >
+              prod-setup-205416
+            </p>
+          </div>
+          <div
+            class="StyledProps--font StyledProps--main logRowText dataColumn openModalColumn count StyledProps--padding-left-medium"
+          >
+            <p
+              class="count"
+            >
+              1
+            </p>
+          </div>
+          <div
+            class="StyledProps--font StyledProps--main lineChartContainer dataColumn messageFrequency"
+          />
+        </div>
+        <div
+          class="StyledProps--font StyledProps--main mainRow dataRow highlightRow"
+          data-testid="logs-data-row"
+        >
+          <div
+            class="StyledProps--font StyledProps--main dataColumn openModalColumn compareDataColumn clusterType"
+          >
+            <p
+              class="StyledProps--font StyledProps--main"
+            >
+              Unknown
+            </p>
+          </div>
+          <div
+            class="StyledProps--font StyledProps--main logRowText dataColumn openModalColumn risk"
+          >
+            <div
+              class="healthScoreCard"
+            >
+              <p
+                class="StyledProps--font StyledProps--main StyledProps--font-size-xsmall StyledProps--font-weight-semi-bold StyledProps--color StyledProps--color-white"
+              >
+                NA
+              </p>
+            </div>
+          </div>
+          <div
+            class="StyledProps--font StyledProps--main logText dataColumn openModalColumn message"
+          >
+            <p
+              class="logRowText"
+            >
+              prod-setup-205416
+            </p>
+          </div>
+          <div
+            class="StyledProps--font StyledProps--main logRowText dataColumn openModalColumn count StyledProps--padding-left-medium"
+          >
+            <p
+              class="count"
+            >
+              1
+            </p>
+          </div>
+          <div
+            class="StyledProps--font StyledProps--main lineChartContainer dataColumn messageFrequency"
+          />
+        </div>
+        <div
+          class="StyledProps--font StyledProps--main mainRow dataRow highlightRow"
+          data-testid="logs-data-row"
+        >
+          <div
+            class="StyledProps--font StyledProps--main dataColumn openModalColumn compareDataColumn clusterType"
+          >
+            <p
+              class="StyledProps--font StyledProps--main"
+            >
+              Unexpected
+            </p>
+          </div>
+          <div
+            class="StyledProps--font StyledProps--main logRowText dataColumn openModalColumn risk"
+          >
+            <div
+              class="healthScoreCard"
+            >
+              <p
+                class="StyledProps--font StyledProps--main StyledProps--font-size-xsmall StyledProps--font-weight-semi-bold StyledProps--color StyledProps--color-white"
+              >
+                NA
+              </p>
+            </div>
+          </div>
+          <div
+            class="StyledProps--font StyledProps--main logText dataColumn openModalColumn message"
+          >
+            <p
+              class="logRowText"
+            >
+              prod-setup-205416
+            </p>
+          </div>
+          <div
+            class="StyledProps--font StyledProps--main logRowText dataColumn openModalColumn count StyledProps--padding-left-medium"
+          >
+            <p
+              class="count"
+            >
+              1
+            </p>
+          </div>
+          <div
+            class="StyledProps--font StyledProps--main lineChartContainer dataColumn messageFrequency"
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      class="Layout--horizontal StyledProps--main Pagination--container StyledProps--padding-top-medium StyledProps--padding-bottom-medium StyledProps--flex StyledProps--flex-align-center-center StyledProps--flex-distribution-space-between"
+    >
+      <span
+        class="StyledProps--font StyledProps--main StyledProps--inline StyledProps--font-variation-small-semi"
+      >
+        1
+         of 
+        1
+      </span>
+      <div
+        class="Layout--horizontal StyledProps--main"
+      >
+        <button
+          class="bp3-button bp3-disabled Button--button StyledProps--font StyledProps--main Pagination--roundedButton Pagination--buttonLeft Button--with-current-color Button--withLeftIcon Button--size Button--small"
+          disabled=""
+          tabindex="-1"
+          type="button"
+        >
+          <span
+            class="bp3-icon bp3-icon-arrow-left StyledProps--main StyledProps--padding-right-xsmall"
+            icon="arrow-left"
+          >
+            <svg
+              data-icon="arrow-left"
+              height="12"
+              viewBox="0 0 16 16"
+              width="12"
+            >
+              <desc>
+                arrow-left
+              </desc>
+              <path
+                d="M13.99 6.99H4.41L7.7 3.7a1.003 1.003 0 00-1.42-1.42l-5 5a1.014 1.014 0 000 1.42l5 5a1.003 1.003 0 001.42-1.42L4.41 8.99H14c.55 0 1-.45 1-1s-.46-1-1.01-1z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <span
+            class="bp3-button-text"
+          >
+            Prev
+          </span>
+        </button>
+        <button
+          class="bp3-button bp3-disabled Button--button StyledProps--font StyledProps--main Pagination--roundedButton Pagination--selected Button--with-current-color"
+          disabled=""
+          tabindex="-1"
+          type="button"
+        >
+          <span
+            class="bp3-button-text"
+          >
+            1
+          </span>
+        </button>
+        <button
+          class="bp3-button bp3-disabled Button--button StyledProps--font StyledProps--main Pagination--roundedButton Pagination--buttonRight Button--with-current-color Button--withRightIcon Button--size Button--small"
+          disabled=""
+          tabindex="-1"
+          type="button"
+        >
+          <span
+            class="bp3-button-text"
+          >
+            Next
+          </span>
+          <span
+            class="bp3-icon bp3-icon-arrow-right StyledProps--main"
+            icon="arrow-right"
+          >
+            <svg
+              data-icon="arrow-right"
+              height="12"
+              viewBox="0 0 16 16"
+              width="12"
+            >
+              <desc>
+                arrow-right
+              </desc>
+              <path
+                d="M14.7 7.29l-5-5a.965.965 0 00-.71-.3 1.003 1.003 0 00-.71 1.71l3.29 3.29H1.99c-.55 0-1 .45-1 1s.45 1 1 1h9.59l-3.29 3.29a1.003 1.003 0 001.42 1.42l5-5c.18-.18.29-.43.29-.71s-.12-.52-.3-.7z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </button>
+      </div>
+      <span>
+        Showing 10 per page
+      </span>
+    </div>
+  </div>
+</div>
+`;

--- a/src/modules/85-cv/pages/monitored-service/components/ServiceHealth/ServiceHealth.tsx
+++ b/src/modules/85-cv/pages/monitored-service/components/ServiceHealth/ServiceHealth.tsx
@@ -14,6 +14,8 @@ import TimelineSlider from '@cv/components/ChangeTimeline/components/TimelineSli
 import type { RiskData } from 'services/cv'
 import type { ChangesInfoCardData } from '@cv/components/ChangeTimeline/ChangeTimeline.types'
 import ServiceDependencyGraph from '@cv/pages/monitored-service/CVMonitoredService/components/MonitoredServiceGraphView/MonitoredServiceGraphView'
+import { useFeatureFlag } from '@common/hooks/useFeatureFlag'
+import { FeatureFlag } from '@common/featureFlags'
 import {
   calculateLowestHealthScoreBar,
   calculateStartAndEndTimes,
@@ -30,6 +32,7 @@ import MetricsAndLogs from './components/MetricsAndLogs/MetricsAndLogs'
 import AnomaliesCard from './components/AnomaliesCard/AnomaliesCard'
 import ChangesSourceCard from './components/ChangesSourceCard/ChangesSourceCard'
 import ChangesTable from './components/ChangesAndServiceDependency/components/ChangesTable/ChangesTable'
+import ErrorTracking from './components/ErrorTracking/ErrorTracking'
 import css from './ServiceHealth.module.scss'
 
 export default function ServiceHealth({
@@ -50,6 +53,7 @@ export default function ServiceHealth({
   const [changeTimelineSummary, setChangeTimelineSummary] = useState<ChangesInfoCardData[] | null>(null)
   const [healthScoreData, setHealthScoreData] = useState<RiskData[]>()
   const containerRef = useRef<HTMLElement>(null)
+  const isErrorTrackingEnabled = useFeatureFlag(FeatureFlag.ERROR_TRACKING_ENABLED)
 
   useEffect(() => {
     //changing timeperiod in dropdown should reset the timerange and remove the slider.
@@ -223,6 +227,16 @@ export default function ServiceHealth({
           startTime={timeRange?.startTime}
           endTime={timeRange?.endTime}
         />
+
+        {isErrorTrackingEnabled && (
+          <ErrorTracking
+            monitoredServiceIdentifier={monitoredServiceIdentifier}
+            serviceIdentifier={serviceIdentifier}
+            environmentIdentifier={environmentIdentifier}
+            startTime={timeRange?.startTime}
+            endTime={timeRange?.endTime}
+          />
+        )}
       </Container>
     </>
   )

--- a/src/modules/85-cv/pages/monitored-service/components/ServiceHealth/components/ErrorTracking/ErrorTracking.module.scss
+++ b/src/modules/85-cv/pages/monitored-service/components/ServiceHealth/components/ErrorTracking/ErrorTracking.module.scss
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+.metricsAndLogsCard {
+  display: flex;
+  flex-direction: column;
+  width: 50%;
+  height: 850px;
+  max-height: 850px;
+  overflow-y: auto;
+}
+
+.noServiceImageCard {
+  width: 100%;
+
+  .noDataCardContainer {
+    height: 100% !important;
+  }
+
+  .noDataCard {
+    margin-top: var(--spacing-none) !important;
+  }
+
+  .noServiceImage {
+    width: 600px;
+    height: 290px;
+  }
+}

--- a/src/modules/85-cv/pages/monitored-service/components/ServiceHealth/components/ErrorTracking/ErrorTracking.module.scss.d.ts
+++ b/src/modules/85-cv/pages/monitored-service/components/ServiceHealth/components/ErrorTracking/ErrorTracking.module.scss.d.ts
@@ -1,0 +1,16 @@
+/* eslint-disable */
+/**
+ * Copyright 2021 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ **/
+// this is an auto-generated file, do not update this manually
+declare const styles: {
+  readonly metricsAndLogsCard: string
+  readonly noDataCard: string
+  readonly noDataCardContainer: string
+  readonly noServiceImage: string
+  readonly noServiceImageCard: string
+}
+export default styles

--- a/src/modules/85-cv/pages/monitored-service/components/ServiceHealth/components/ErrorTracking/ErrorTracking.tsx
+++ b/src/modules/85-cv/pages/monitored-service/components/ServiceHealth/components/ErrorTracking/ErrorTracking.tsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import React from 'react'
+import { Container, Layout, Heading, Card, NoDataCard, FontVariation } from '@wings-software/uicore'
+import noServiceAvailableImage from '@cv/assets/noServiceAvailable.png'
+import { useStrings } from 'framework/strings'
+import ErrorTrackingAnalysis from '@cv/components/ErrorTrackingAnalysis/ErrorTrackingAnalysis'
+import type { MetricsAndLogsProps } from '../MetricsAndLogs/MetricsAndLogs.types'
+import css from './ErrorTracking.module.scss'
+
+const ErrorTracking: React.FC<MetricsAndLogsProps> = props => {
+  const { getString } = useStrings()
+
+  const { startTime, endTime } = props
+
+  return (
+    <Container margin={{ bottom: 'medium' }}>
+      <Heading level={2} font={{ variation: FontVariation.H6 }} padding={{ bottom: 'small' }}>
+        {getString('errors')}
+      </Heading>
+
+      {startTime && endTime ? (
+        <Layout.Horizontal data-testid="error-tracking-analysis-view" spacing="medium">
+          <Card className={css.metricsAndLogsCard}>
+            <ErrorTrackingAnalysis {...props} startTime={startTime} endTime={endTime} />
+          </Card>
+        </Layout.Horizontal>
+      ) : (
+        <Card className={css.noServiceImageCard} data-testid="error-tracking-analysis-image-view">
+          <NoDataCard
+            image={noServiceAvailableImage}
+            message={getString('cv.monitoredServices.serviceHealth.selectTimelineErrorTracking')}
+            containerClassName={css.noDataCardContainer}
+            className={css.noDataCard}
+            imageClassName={css.noServiceImage}
+          />
+        </Card>
+      )}
+    </Container>
+  )
+}
+
+export default ErrorTracking

--- a/src/modules/85-cv/pages/monitored-service/components/ServiceHealth/components/ErrorTracking/__tests__/ErrorTracking.mock.ts
+++ b/src/modules/85-cv/pages/monitored-service/components/ServiceHealth/components/ErrorTracking/__tests__/ErrorTracking.mock.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import { RiskValues } from '@cv/utils/CommonUtils'
+
+export const mockedHealthSourcesData = {
+  data: {
+    resource: [
+      {
+        identifier: 'GCO_Health_source',
+        name: 'GCO Health source',
+        type: 'STACKDRIVER_LOG'
+      },
+      {
+        identifier: 'Appd_Health_source',
+        name: 'Appd Health source',
+        type: 'APP_DYNAMICS'
+      }
+    ]
+  }
+}
+
+export const mockedClustersData = {
+  metaData: {},
+  resource: [
+    {
+      text: 'verification-svc',
+      risk: RiskValues.HEALTHY,
+      x: 0,
+      y: 0,
+      tag: 'KNOWN'
+    }
+  ],
+  responseMessages: []
+}

--- a/src/modules/85-cv/pages/monitored-service/components/ServiceHealth/components/ErrorTracking/__tests__/ErrorTracking.test.tsx
+++ b/src/modules/85-cv/pages/monitored-service/components/ServiceHealth/components/ErrorTracking/__tests__/ErrorTracking.test.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import React from 'react'
+import { render } from '@testing-library/react'
+import { TestWrapper } from '@common/utils/testUtils'
+import ErrorTracking from '../ErrorTracking'
+import type { MetricsAndLogsProps } from '../../MetricsAndLogs/MetricsAndLogs.types'
+import { mockedClustersData, mockedHealthSourcesData } from './ErrorTracking.mock'
+
+const WrapperComponent = (props: MetricsAndLogsProps): JSX.Element => {
+  return (
+    <TestWrapper>
+      <ErrorTracking {...props} />
+    </TestWrapper>
+  )
+}
+
+jest.mock('highcharts-react-official', () => () => <></>)
+const fetchLogAnalysis = jest.fn()
+const fetchMetricsData = jest.fn()
+const fetchClusterData = jest.fn()
+
+jest.mock('services/cv', () => ({
+  useGetAllErrorTrackingData: jest
+    .fn()
+    .mockImplementation(() => ({ data: {}, loading: false, error: null, refetch: fetchLogAnalysis })),
+  useGetTimeSeriesMetricData: jest.fn().mockImplementation(() => {
+    return { data: {}, refetch: fetchMetricsData, error: null, loading: false }
+  }),
+  useGetAllHealthSourcesForMonitoredServiceIdentifier: jest.fn().mockImplementation(() => {
+    return { data: mockedHealthSourcesData, error: null, loading: false }
+  }),
+  useGetAllLogsClusterData: jest.fn().mockImplementation(() => {
+    return { data: mockedClustersData, error: null, loading: false, refetch: fetchClusterData }
+  })
+}))
+
+describe('Unit tests for ErrorTracking', () => {
+  test('Verify if Error Tracking View is rendered when required params are defined', async () => {
+    const props = {
+      monitoredServiceIdentifier: 'monitored_service_identifier',
+      serviceIdentifier: 'service-identifier',
+      environmentIdentifier: 'env-identifier',
+      startTime: 1630594988077,
+      endTime: 1630595011443
+    }
+    const { getByTestId } = render(<WrapperComponent {...props} />)
+    expect(getByTestId('error-tracking-analysis-view')).toBeTruthy()
+  })
+
+  test('Verify if appropriate image is rendered when start or endtime is not present', async () => {
+    const props = {
+      monitoredServiceIdentifier: 'monitored_service_identifier',
+      serviceIdentifier: 'service-identifier',
+      environmentIdentifier: 'env-identifier',
+      startTime: 0,
+      endTime: 0
+    }
+    const { getByTestId } = render(<WrapperComponent {...props} />)
+    expect(getByTestId('error-tracking-analysis-image-view')).toBeTruthy()
+  })
+})

--- a/src/modules/85-cv/strings/strings.en.yaml
+++ b/src/modules/85-cv/strings/strings.en.yaml
@@ -477,6 +477,7 @@ monitoredServices:
     noDataAvailableForHealthScore: No healthscore data available in the {{duration}}
     pleaseSelectAnotherTimeWindow: Please select another time window.
     selectTimeline: Select a timeline to see metric & logs data
+    selectTimelineErrorTracking: Select a timeline to see error data
     metricsAndLogs: Metrics & Logs
     lowestHealthScore: Lowest Health Score
     anamolies: Anamolies

--- a/src/services/cv/index.tsx
+++ b/src/services/cv/index.tsx
@@ -7912,6 +7912,133 @@ export const getWorkloadsPromise = (
     signal
   )
 
+export interface GetAllErrorTrackingClusterDataQueryParams {
+  accountId?: string
+  orgIdentifier: string
+  projectIdentifier: string
+  monitoredServiceIdentifier?: string
+  clusterTypes?: ('KNOWN' | 'UNEXPECTED' | 'UNKNOWN')[]
+  startTime: number
+  endTime: number
+  healthSources?: string[]
+}
+
+export type GetAllErrorTrackingClusterDataProps = Omit<
+  GetProps<
+    RestResponseListLiveMonitoringLogAnalysisClusterDTO,
+    unknown,
+    GetAllErrorTrackingClusterDataQueryParams,
+    void
+  >,
+  'path'
+>
+
+/**
+ * get all log cluster data for a time range
+ */
+export const GetAllErrorTrackingClusterData = (props: GetAllErrorTrackingClusterDataProps) => (
+  <Get<RestResponseListLiveMonitoringLogAnalysisClusterDTO, unknown, GetAllErrorTrackingClusterDataQueryParams, void>
+    path={`/error-tracking-dashboard/cluster`}
+    base={getConfig('cv/api')}
+    {...props}
+  />
+)
+
+export type UseGetAllErrorTrackingClusterDataProps = Omit<
+  UseGetProps<
+    RestResponseListLiveMonitoringLogAnalysisClusterDTO,
+    unknown,
+    GetAllErrorTrackingClusterDataQueryParams,
+    void
+  >,
+  'path'
+>
+
+/**
+ * get all log cluster data for a time range
+ */
+export const useGetAllErrorTrackingClusterData = (props: UseGetAllErrorTrackingClusterDataProps) =>
+  useGet<RestResponseListLiveMonitoringLogAnalysisClusterDTO, unknown, GetAllErrorTrackingClusterDataQueryParams, void>(
+    `/error-tracking-dashboard/cluster`,
+    { base: getConfig('cv/api'), ...props }
+  )
+
+/**
+ * get all log cluster data for a time range
+ */
+export const getAllErrorTrackingClusterDataPromise = (
+  props: GetUsingFetchProps<
+    RestResponseListLiveMonitoringLogAnalysisClusterDTO,
+    unknown,
+    GetAllErrorTrackingClusterDataQueryParams,
+    void
+  >,
+  signal?: RequestInit['signal']
+) =>
+  getUsingFetch<
+    RestResponseListLiveMonitoringLogAnalysisClusterDTO,
+    unknown,
+    GetAllErrorTrackingClusterDataQueryParams,
+    void
+  >(getConfig('cv/api'), `/error-tracking-dashboard/cluster`, props, signal)
+
+export interface GetAllErrorTrackingDataQueryParams {
+  accountId?: string
+  orgIdentifier: string
+  projectIdentifier: string
+  monitoredServiceIdentifier?: string
+  clusterTypes?: ('KNOWN' | 'UNEXPECTED' | 'UNKNOWN')[]
+  startTime: number
+  endTime: number
+  healthSources?: string[]
+  page?: number
+  size?: number
+}
+
+export type GetAllErrorTrackingDataProps = Omit<
+  GetProps<RestResponsePageAnalyzedLogDataDTO, unknown, GetAllErrorTrackingDataQueryParams, void>,
+  'path'
+>
+
+/**
+ * get all error tracking data for a time range
+ */
+export const GetAllErrorTrackingData = (props: GetAllErrorTrackingDataProps) => (
+  <Get<RestResponsePageAnalyzedLogDataDTO, unknown, GetAllErrorTrackingDataQueryParams, void>
+    path={`/error-tracking-dashboard/data`}
+    base={getConfig('cv/api')}
+    {...props}
+  />
+)
+
+export type UseGetAllErrorTrackingDataProps = Omit<
+  UseGetProps<RestResponsePageAnalyzedLogDataDTO, unknown, GetAllErrorTrackingDataQueryParams, void>,
+  'path'
+>
+
+/**
+ * get all error tracking data for a time range
+ */
+export const useGetAllErrorTrackingData = (props: UseGetAllErrorTrackingDataProps) =>
+  useGet<RestResponsePageAnalyzedLogDataDTO, unknown, GetAllErrorTrackingDataQueryParams, void>(
+    `/error-tracking-dashboard/data`,
+    { base: getConfig('cv/api'), ...props }
+  )
+
+/**
+ * get all error tracking data for a time range
+ */
+export const getAllErrorTrackingDataPromise = (
+  props: GetUsingFetchProps<RestResponsePageAnalyzedLogDataDTO, unknown, GetAllErrorTrackingDataQueryParams, void>,
+  signal?: RequestInit['signal']
+) =>
+  getUsingFetch<RestResponsePageAnalyzedLogDataDTO, unknown, GetAllErrorTrackingDataQueryParams, void>(
+    getConfig('cv/api'),
+    `/error-tracking-dashboard/data`,
+    props,
+    signal
+  )
+
 export interface GetAllLogsClusterDataQueryParams {
   accountId?: string
   orgIdentifier: string

--- a/src/services/cv/overrides.yaml
+++ b/src/services/cv/overrides.yaml
@@ -107,6 +107,7 @@ allowpaths:
   - /monitored-service/service-details
   - /monitored-service/count-of-services
   - /log-dashboard/logs-data
+  - /error-tracking-dashboard/data
   - /timeseries-dashboard/metrics
   - /verify-step/input-set-template
   - /monitored-service/{identifier}/scores
@@ -119,6 +120,7 @@ allowpaths:
   - /account/{accountIdentifier}/org/{orgIdentifier}/project/{projectIdentifier}/change-event/timeline
   - /account/{accountIdentifier}/org/{orgIdentifier}/project/{projectIdentifier}/change-event/{activityId}
   - /log-dashboard/logs-cluster
+  - /error-tracking-dashboard/cluster
   - /user-journey/create
   - /user-journey
   - /slo

--- a/src/stringTypes.ts
+++ b/src/stringTypes.ts
@@ -4901,6 +4901,7 @@ export interface StringsMap {
   'cv.monitoredServices.serviceHealth.overallHealthScore': string
   'cv.monitoredServices.serviceHealth.pleaseSelectAnotherTimeWindow': string
   'cv.monitoredServices.serviceHealth.selectTimeline': string
+  'cv.monitoredServices.serviceHealth.selectTimelineErrorTracking': string
   'cv.monitoredServices.serviceHealth.serviceDependencies.states.exhausted': string
   'cv.monitoredServices.serviceHealth.serviceDependencies.states.healthy': string
   'cv.monitoredServices.serviceHealth.serviceDependencies.states.needsAttention': string


### PR DESCRIPTION
##### Summary:

Create a separate table for Error Tracking in the SRM Live Monitoring

##### Jira Links:

https://harness.atlassian.net/browse/SRM-9399

##### Screenshots:

<img width="1844" alt="image" src="https://user-images.githubusercontent.com/2991478/158259166-831cc09a-dd90-4867-b10f-05a2a2bcc727.png">

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
