### PR TITLE
fix: [PIE-3077]: added spinner to view in rpf

### DIFF
--- a/src/modules/70-pipeline/components/RunPipelineModal/RunPipelineForm.tsx
+++ b/src/modules/70-pipeline/components/RunPipelineModal/RunPipelineForm.tsx
@@ -736,10 +736,6 @@ function RunPipelineFormBasic({
     throw runPipelineFormErrors
   }
 
-  if (shouldShowPageSpinner()) {
-    return <PageSpinner />
-  }
-
   const getFormikInitialValues = () => {
     if (isEmpty(yamlTemplate)) {
       return {}
@@ -810,43 +806,51 @@ function RunPipelineFormBasic({
                   updateExpressionValue={updateExpressionValue}
                   expressions={template?.data?.replacedExpressions}
                 />
-                {selectedView === SelectedView.VISUAL ? (
-                  <VisualView
-                    executionView={executionView}
-                    selectedInputSets={selectedInputSets}
-                    existingProvide={existingProvide}
-                    setExistingProvide={setExistingProvide}
-                    executionInputSetTemplateYaml={executionInputSetTemplateYaml}
-                    pipelineIdentifier={pipelineIdentifier}
-                    template={template}
-                    pipeline={pipeline}
-                    currentPipeline={currentPipeline}
-                    getTemplateError={getTemplateError}
-                    resolvedPipeline={resolvedPipeline}
-                    submitForm={submitForm}
-                    setRunClicked={setRunClicked}
-                    inputSets={inputSets}
-                    setSelectedInputSets={setSelectedInputSets}
-                    loading={loadingMergeInputSetUpdate || loadingInputSetUpdate}
-                    loadingMergeInputSetUpdate={loadingMergeInputSetUpdate}
-                  />
-                ) : (
-                  <div className={css.editor}>
-                    <Layout.Vertical className={css.content} padding="xlarge">
-                      <YamlBuilderMemo
-                        {...yamlBuilderReadOnlyModeProps}
-                        existingJSON={{ pipeline: values }}
-                        bind={setYamlHandler}
-                        schema={{}}
-                        invocationMap={factory.getInvocationMap()}
-                        height="55vh"
-                        width="100%"
-                        showSnippetSection={false}
-                        isEditModeSupported={canEdit}
-                      />
-                    </Layout.Vertical>
-                  </div>
-                )}
+                <Layout.Vertical style={{ minHeight: '30vh' }}>
+                  {shouldShowPageSpinner() ? (
+                    <PageSpinner />
+                  ) : (
+                    <>
+                      {selectedView === SelectedView.VISUAL ? (
+                        <VisualView
+                          executionView={executionView}
+                          selectedInputSets={selectedInputSets}
+                          existingProvide={existingProvide}
+                          setExistingProvide={setExistingProvide}
+                          executionInputSetTemplateYaml={executionInputSetTemplateYaml}
+                          pipelineIdentifier={pipelineIdentifier}
+                          template={template}
+                          pipeline={pipeline}
+                          currentPipeline={currentPipeline}
+                          getTemplateError={getTemplateError}
+                          resolvedPipeline={resolvedPipeline}
+                          submitForm={submitForm}
+                          setRunClicked={setRunClicked}
+                          inputSets={inputSets}
+                          setSelectedInputSets={setSelectedInputSets}
+                          loading={loadingMergeInputSetUpdate || loadingInputSetUpdate}
+                          loadingMergeInputSetUpdate={loadingMergeInputSetUpdate}
+                        />
+                      ) : (
+                        <div className={css.editor}>
+                          <Layout.Vertical className={css.content} padding="xlarge">
+                            <YamlBuilderMemo
+                              {...yamlBuilderReadOnlyModeProps}
+                              existingJSON={{ pipeline: values }}
+                              bind={setYamlHandler}
+                              schema={{}}
+                              invocationMap={factory.getInvocationMap()}
+                              height="55vh"
+                              width="100%"
+                              showSnippetSection={false}
+                              isEditModeSupported={canEdit}
+                            />
+                          </Layout.Vertical>
+                        </div>
+                      )}
+                    </>
+                  )}
+                </Layout.Vertical>
                 <CheckBoxActions
                   executionView={executionView}
                   notifyOnlyMe={notifyOnlyMe}


### PR DESCRIPTION
##### Summary:

Run pipeline modal does not retain selected stage on stage select

##### Jira Links:

https://harness.atlassian.net/browse/PIE-3077

##### Screenshots:

Before:


https://user-images.githubusercontent.com/96711906/158197346-0fe182f2-a24d-456a-a7d1-20c7617e9fae.mov



After:


https://user-images.githubusercontent.com/96711906/158197315-5229b4ce-9d41-45e4-bf4c-aa33f6afbcd5.mov



You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
