### PR TITLE
fix: [PIE-2805]: fix for expression input

### DIFF
--- a/src/modules/10-common/components/MultiTypeExecutionCondition/MultiTypeExecutionCondition.tsx
+++ b/src/modules/10-common/components/MultiTypeExecutionCondition/MultiTypeExecutionCondition.tsx
@@ -9,7 +9,7 @@ import React from 'react'
 import cx from 'classnames'
 import { connect, FormikContext } from 'formik'
 import { filter, get } from 'lodash-es'
-import { Container, ExpressionAndRuntimeType, MultiTypeInputType } from '@wings-software/uicore'
+import { Container, ExpressionAndRuntimeType, getMultiTypeFromValue, MultiTypeInputType } from '@wings-software/uicore'
 import { MonacoTextField } from '@common/components/MonacoTextField/MonacoTextField'
 import multiBtnCss from '@common/components/MultiTypeTextArea/MultiTypeTextArea.module.scss'
 import css from './MultiTypeExecutionCondition.module.scss'
@@ -37,6 +37,13 @@ function MultiTypeMonacoTextFieldFixedTypeComponent(props: {
       <MonacoTextField name={name} expressions={expressions} disabled={readonly} />
     </Container>
   )
+}
+
+export function getRestrictedMultiTypeFromValue(conditionValue: string) {
+  const multiType = getMultiTypeFromValue(conditionValue)
+
+  // Since expression type is not support for JEXL input
+  return multiType === MultiTypeInputType.EXPRESSION ? MultiTypeInputType.FIXED : multiType
 }
 
 function MultiTypeExecutionConditionInternal(props: MultiTypeExecutionConditionProps) {

--- a/src/modules/70-pipeline/components/PipelineInputSetForm/StageAdvancedInputSetForm.tsx
+++ b/src/modules/70-pipeline/components/PipelineInputSetForm/StageAdvancedInputSetForm.tsx
@@ -6,21 +6,16 @@
  */
 
 import React, { useState } from 'react'
-import {
-  Text,
-  Color,
-  HarnessDocTooltip,
-  Layout,
-  Container,
-  MultiTypeInputType,
-  getMultiTypeFromValue
-} from '@wings-software/uicore'
+import { Text, Color, HarnessDocTooltip, Layout, Container, MultiTypeInputType } from '@wings-software/uicore'
 import { isEmpty, get } from 'lodash-es'
 import { connect, FormikContext } from 'formik'
 import cx from 'classnames'
 import type { StageElementConfig } from 'services/cd-ng'
 import { useVariablesExpression } from '@pipeline/components/PipelineStudio/PiplineHooks/useVariablesExpression'
-import { MultiTypeExecutionCondition } from '@common/components/MultiTypeExecutionCondition/MultiTypeExecutionCondition'
+import {
+  MultiTypeExecutionCondition,
+  getRestrictedMultiTypeFromValue
+} from '@common/components/MultiTypeExecutionCondition/MultiTypeExecutionCondition'
 import { useStrings } from 'framework/strings'
 import css from './PipelineInputSetForm.module.scss'
 import stepCss from '@pipeline/components/PipelineSteps/Steps/Steps.module.scss'
@@ -45,7 +40,7 @@ function ConditionalExecutionFormInternal(props: ConditionalExecutionFormProps):
   const { getString } = useStrings()
   const conditionValue = get(formik?.values, path)
   const { expressions } = useVariablesExpression()
-  const [multiType, setMultiType] = useState<MultiTypeInputType>(getMultiTypeFromValue(conditionValue))
+  const [multiType, setMultiType] = useState<MultiTypeInputType>(getRestrictedMultiTypeFromValue(conditionValue))
 
   return (
     <Container margin={{ bottom: 'medium' }}>

--- a/src/modules/70-pipeline/components/PipelineSteps/AdvancedSteps/ConditionalExecutionPanel/ConditionalExecutionCondition.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/AdvancedSteps/ConditionalExecutionPanel/ConditionalExecutionCondition.tsx
@@ -6,12 +6,15 @@
  */
 
 import React, { useState } from 'react'
-import { Container, getMultiTypeFromValue, HarnessDocTooltip, MultiTypeInputType } from '@wings-software/uicore'
+import { Container, HarnessDocTooltip, MultiTypeInputType } from '@wings-software/uicore'
 import { Checkbox } from '@blueprintjs/core'
 import type { FormikProps } from 'formik'
 import cx from 'classnames'
 import { useStrings } from 'framework/strings'
-import { MultiTypeExecutionCondition } from '@common/components/MultiTypeExecutionCondition/MultiTypeExecutionCondition'
+import {
+  MultiTypeExecutionCondition,
+  getRestrictedMultiTypeFromValue
+} from '@common/components/MultiTypeExecutionCondition/MultiTypeExecutionCondition'
 import { useVariablesExpression } from '@pipeline/components/PipelineStudio/PiplineHooks/useVariablesExpression'
 import type { StepMode as Modes } from '@pipeline/utils/stepUtils'
 import type { ConditionalExecutionOption } from './ConditionalExecutionPanelUtils'
@@ -28,7 +31,7 @@ export default function ConditionalExecutionCondition(props: ConditionalExecutio
   const { getString } = useStrings()
   const { formikProps, mode, isReadonly } = props
   const conditionValue = formikProps.values?.condition
-  const [multiType, setMultiType] = useState<MultiTypeInputType>(getMultiTypeFromValue(conditionValue))
+  const [multiType, setMultiType] = useState<MultiTypeInputType>(getRestrictedMultiTypeFromValue(conditionValue))
   const isInputDisabled = !formikProps.values.enableJEXL || isReadonly
   const { expressions } = useVariablesExpression()
 


### PR DESCRIPTION
##### Summary:

Expression value restricted for Multi type component for JEXL condition input

##### Jira Links:

https://harness.atlassian.net/browse/PIE-2805

##### Screenshots:


https://user-images.githubusercontent.com/96409598/158444927-0e839a5d-d45e-46e5-98a6-9b8cd846393d.mov


https://user-images.githubusercontent.com/96409598/158445103-5ec0a33a-94ad-4ed4-9059-12164a125763.mov


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
