### PR TITLE
feat: [SRM-9295]: remove SID

### DIFF
--- a/src/modules/35-connectors/components/CreateConnector/ErrorTrackingConnector/CreateErrorTrackingConnector.tsx
+++ b/src/modules/35-connectors/components/CreateConnector/ErrorTrackingConnector/CreateErrorTrackingConnector.tsx
@@ -24,7 +24,6 @@ export function ErrorTrackingConfigStep(props: ConnectionConfigProps): JSX.Eleme
   const { getString } = useStrings()
   const [initialValues, setInitialValues] = useState<ConnectorConfigDTO>({
     url: '',
-    sid: '',
     apiKeyRef: {},
     accountId,
     projectIdentifier,
@@ -53,7 +52,6 @@ export function ErrorTrackingConfigStep(props: ConnectionConfigProps): JSX.Eleme
         initialValues={{ ...initialValues }}
         validationSchema={Yup.object().shape({
           url: Yup.string().trim().required(getString('connectors.errorTracking.urlValidation')),
-          sid: Yup.string().trim().required(getString('connectors.errorTracking.sidValidation')),
           apiKeyRef: Yup.string().trim().required(getString('connectors.encryptedAPIKeyValidation'))
         })}
         onSubmit={(formData: ConnectorConfigDTO) => nextStep?.({ ...connectorInfo, ...prevStepData, ...formData })}
@@ -61,7 +59,6 @@ export function ErrorTrackingConfigStep(props: ConnectionConfigProps): JSX.Eleme
         <FormikForm className={css.form}>
           <Layout.Vertical spacing="large" height={450}>
             <FormInput.Text label={getString('UrlLabel')} name="url" />
-            <FormInput.Text label={getString('connectors.errorTracking.sidLabel')} name="sid" />
             <SecretInput label={getString('connectors.encryptedAPIKeyLabel')} name="apiKeyRef" />
           </Layout.Vertical>
           <Layout.Horizontal spacing="xlarge">

--- a/src/modules/35-connectors/components/CreateConnector/ErrorTrackingConnector/utils.ts
+++ b/src/modules/35-connectors/components/CreateConnector/ErrorTrackingConnector/utils.ts
@@ -11,7 +11,6 @@ import type { ConnectorConfigDTO } from 'services/cd-ng'
 
 export interface SpecData {
   url: string
-  sid: string
   apiKeyRef: string
   delegateSelectors: string
 }
@@ -43,7 +42,6 @@ export async function initializeErrorTrackingConnectorWithStepData(
   }
 
   updateInitialValue(prevData as PrevData, spec as SpecData, updatedInitialValues, 'url' as AllowedKeyList)
-  updateInitialValue(prevData as PrevData, spec as SpecData, updatedInitialValues, 'sid' as AllowedKeyList)
   updateInitialValue(prevData as PrevData, spec as SpecData, updatedInitialValues, 'apiKeyRef' as AllowedKeyList)
 
   const initValueWithSecrets = await setErrorTrackingSecrets(updatedInitialValues, accountId)

--- a/src/modules/35-connectors/pages/connectors/utils/ConnectorUtils.ts
+++ b/src/modules/35-connectors/pages/connectors/utils/ConnectorUtils.ts
@@ -24,7 +24,8 @@ import type {
   AwsSMCredentialSpecAssumeSTS,
   VaultConnectorDTO,
   AzureKeyVaultConnectorDTO,
-  GcpKmsConnectorDTO
+  GcpKmsConnectorDTO,
+  ErrorTrackingConnectorDTO
 } from 'services/cd-ng'
 import { FormData, CredTypeValues, HashiCorpVaultAccessTypes } from '@connectors/interfaces/ConnectorInterface'
 import type { SecretReferenceInterface } from '@secrets/utils/SecretField'
@@ -1365,7 +1366,7 @@ export const buildDatadogPayload = (formData: FormData) => {
   }
 }
 
-export const buildErrorTrackingPayload = (formData: FormData) => {
+export const buildErrorTrackingPayload = (formData: FormData): Connector => {
   const {
     name,
     identifier,
@@ -1373,7 +1374,6 @@ export const buildErrorTrackingPayload = (formData: FormData) => {
     orgIdentifier,
     delegateSelectors,
     url,
-    sid,
     apiKeyRef: { referenceString: apiReferenceKey },
     description,
     tags
@@ -1389,10 +1389,9 @@ export const buildErrorTrackingPayload = (formData: FormData) => {
       tags,
       spec: {
         url,
-        sid,
         apiKeyRef: apiReferenceKey,
         delegateSelectors: delegateSelectors || {}
-      }
+      } as ErrorTrackingConnectorDTO
     }
   }
 }

--- a/src/modules/35-connectors/strings/strings.en.yaml
+++ b/src/modules/35-connectors/strings/strings.en.yaml
@@ -310,8 +310,6 @@ datadog:
   encryptedAPPKeyValidation: Encrypted APP Key is required.
 errorTracking:
   urlValidation: Error Tracking URL is required.
-  sidValidation: Error Tracking SID is required.
-  sidLabel: SID
 dynatrace:
   apiToken: API Token
   apiTokenValidation: API Token is required.

--- a/src/services/ce/index.tsx
+++ b/src/services/ce/index.tsx
@@ -1135,7 +1135,6 @@ export interface ErrorMetadataDTO {
 export type ErrorTrackingConnectorDTO = ConnectorConfigDTO & {
   apiKeyRef: string
   delegateSelectors?: string[]
-  sid: string
   url: string
 }
 

--- a/src/services/ce/swagger.json
+++ b/src/services/ce/swagger.json
@@ -5386,12 +5386,9 @@
         },
         {
           "type": "object",
-          "required": ["apiKeyRef", "sid", "url"],
+          "required": ["apiKeyRef", "url"],
           "properties": {
             "url": {
-              "type": "string"
-            },
-            "sid": {
               "type": "string"
             },
             "apiKeyRef": {

--- a/src/services/cv/index.tsx
+++ b/src/services/cv/index.tsx
@@ -1456,7 +1456,6 @@ export interface ErrorMetadataDTO {
 export type ErrorTrackingConnectorDTO = ConnectorConfigDTO & {
   apiKeyRef: string
   delegateSelectors?: string[]
-  sid: string
   url: string
 }
 

--- a/src/services/cv/swagger.json
+++ b/src/services/cv/swagger.json
@@ -19552,12 +19552,9 @@
         },
         {
           "type": "object",
-          "required": ["apiKeyRef", "sid", "url"],
+          "required": ["apiKeyRef", "url"],
           "properties": {
             "url": {
-              "type": "string"
-            },
-            "sid": {
               "type": "string"
             },
             "apiKeyRef": {

--- a/src/services/portal/index.tsx
+++ b/src/services/portal/index.tsx
@@ -6623,7 +6623,6 @@ export interface ErrorDetail {
 export type ErrorTrackingConnectorDTO = ConnectorConfigDTO & {
   apiKeyRef: string
   delegateSelectors?: string[]
-  sid: string
   url: string
 }
 

--- a/src/services/portal/swagger.json
+++ b/src/services/portal/swagger.json
@@ -92455,12 +92455,9 @@
         },
         {
           "type": "object",
-          "required": ["apiKeyRef", "sid", "url"],
+          "required": ["apiKeyRef", "url"],
           "properties": {
             "url": {
-              "type": "string"
-            },
-            "sid": {
               "type": "string"
             },
             "apiKeyRef": {

--- a/src/stringTypes.ts
+++ b/src/stringTypes.ts
@@ -1786,8 +1786,6 @@ export interface StringsMap {
   'connectors.editConnector': string
   'connectors.encryptedAPIKeyLabel': string
   'connectors.encryptedAPIKeyValidation': string
-  'connectors.errorTracking.sidLabel': string
-  'connectors.errorTracking.sidValidation': string
   'connectors.errorTracking.urlValidation': string
   'connectors.gcpKms.credentialsFile': string
   'connectors.gcpKms.credentialsFileRequired': string


### PR DESCRIPTION
##### Summary:
Removes OverOps SID (service ID) from the connector and uses account ID, Org ID, and Project ID instead

##### Jira Links:
https://harness.atlassian.net/browse/SRM-9295

##### Screenshots:
SID text field removed
<img width="1195" alt="image" src="https://user-images.githubusercontent.com/2991478/158731820-a0acca9e-19b5-43b7-96eb-2bb80e44e910.png">


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
