### PR TITLE
feat: [CDS-35238]: made a simple env and service select

### DIFF
--- a/src/microfrontends/package.json
+++ b/src/microfrontends/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/microfrontends",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "",
   "types": "dist/microfrontends/index.d.ts",
   "main": "dist/microfrontends/index.js",

--- a/src/modules/75-cd/RouteDestinations.tsx
+++ b/src/modules/75-cd/RouteDestinations.tsx
@@ -146,6 +146,8 @@ import manifestSourceBaseFactory from './factory/ManifestSourceFactory/ManifestS
 import { DeployServiceWidget } from './components/PipelineSteps/DeployServiceStep/DeployServiceStep'
 import { DeployEnvironmentWidget } from './components/PipelineSteps/DeployEnvStep/DeployEnvStep'
 import type { GitOpsCustomMicroFrontendProps } from './interfaces/GitOps.types'
+import { SimpleEnvironmentWidget } from './components/PipelineSteps/DeployEnvStep/SimpleEnvWidget'
+import { SimpleServiceWidget } from './components/PipelineSteps/DeployServiceStep/SimpleServiceWidget'
 
 // eslint-disable-next-line import/no-unresolved
 const GitOpsServersList = React.lazy(() => import('gitopsui/MicroFrontendApp'))
@@ -418,7 +420,12 @@ const GitOpsPage = (): React.ReactElement | null => {
     return (
       <ChildAppMounter<GitOpsCustomMicroFrontendProps>
         ChildApp={GitOpsServersList}
-        customComponents={{ DeployEnvironmentWidget, DeployServiceWidget }}
+        customComponents={{
+          DeployEnvironmentWidget,
+          DeployServiceWidget,
+          SimpleEnvironmentWidget,
+          SimpleServiceWidget
+        }}
       />
     )
   }

--- a/src/modules/75-cd/components/PipelineSteps/DeployEnvStep/DeployEnvStep.tsx
+++ b/src/modules/75-cd/components/PipelineSteps/DeployEnvStep/DeployEnvStep.tsx
@@ -64,6 +64,7 @@ import css from './DeployEnvStep.module.scss'
 
 const logger = loggerFor(ModuleName.CD)
 export interface DeployEnvData extends Omit<PipelineInfrastructure, 'environmentRef'> {
+  environmentVal?: string
   environmentRef?: string
 }
 
@@ -207,14 +208,14 @@ export interface DeployEnvironmentProps {
   environmentLabel?: string
 }
 
-interface DeployEnvironmentState {
+export interface DeployEnvironmentState {
   isEdit: boolean
   isEnvironment: boolean
   formik?: FormikProps<DeployEnvData>
   data?: EnvironmentResponseDTO
 }
 
-function isEditEnvironment(data: DeployEnvData): boolean {
+export function isEditEnvironment(data: DeployEnvData): boolean {
   if (getMultiTypeFromValue(data.environmentRef) !== MultiTypeInputType.RUNTIME && !isEmpty(data.environmentRef)) {
     return true
   } else if (data.environment && !isEmpty(data.environment.identifier)) {
@@ -438,7 +439,9 @@ export const DeployEnvironmentWidget: React.FC<DeployEnvironmentProps> = ({
               >
                 <FormInput.MultiTypeInput
                   label={
-                    environmentLabel ? environmentLabel : getString('cd.pipelineSteps.serviceTab.specifyYourService')
+                    environmentLabel
+                      ? environmentLabel
+                      : getString('cd.pipelineSteps.environmentTab.specifyYourEnvironment')
                   }
                   tooltipProps={{ dataTooltipId: 'specifyYourEnvironment' }}
                   name="environmentRef"

--- a/src/modules/75-cd/components/PipelineSteps/DeployEnvStep/SimpleEnvWidget.tsx
+++ b/src/modules/75-cd/components/PipelineSteps/DeployEnvStep/SimpleEnvWidget.tsx
@@ -1,0 +1,351 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import React from 'react'
+import {
+  Button,
+  ButtonSize,
+  ButtonVariation,
+  Formik,
+  FormInput,
+  Dialog,
+  Layout,
+  SelectOption,
+  DataTooltipInterface
+} from '@wings-software/uicore'
+import { useModalHook } from '@harness/use-modal'
+import * as Yup from 'yup'
+import { defaultTo, isEmpty, isNil, noop, omit } from 'lodash-es'
+import { useParams } from 'react-router-dom'
+
+import type { FormikProps } from 'formik'
+
+import { EnvironmentRequestDTO, EnvironmentYaml, useGetEnvironmentList } from 'services/cd-ng'
+
+import { useStrings } from 'framework/strings'
+import type { StepViewType } from '@pipeline/components/AbstractSteps/Step'
+import type { PipelineType } from '@common/interfaces/RouteInterfaces'
+import { useToaster } from '@common/exports'
+import { usePermission } from '@rbac/hooks/usePermission'
+import { ResourceType } from '@rbac/interfaces/ResourceType'
+import { PermissionIdentifier } from '@rbac/interfaces/PermissionIdentifier'
+import { StageErrorContext } from '@pipeline/context/StageErrorContext'
+import { DeployTabs } from '@cd/components/PipelineStudio/DeployStageSetupShell/DeployStageSetupShellUtils'
+import { getEnvironmentRefSchema, getEnvironmentSchema } from '@cd/components/PipelineSteps/PipelineStepsUtil'
+import { DeployEnvData, DeployEnvironmentState, isEditEnvironment, NewEditEnvironmentModal } from './DeployEnvStep'
+import css from './DeployEnvStep.module.scss'
+
+export interface SimpleEnvironmentProps {
+  initialValues: DeployEnvData
+  onUpdate?: (data: DeployEnvData) => void
+  stepViewType?: StepViewType
+  readonly: boolean
+  inputSetData?: {
+    template?: DeployEnvData
+    path?: string
+    readonly?: boolean
+  }
+  environmentLabel?: string
+  clearButton?: boolean
+  tooltipProp?: DataTooltipInterface | undefined
+  serviceNotRequired?: boolean
+  showEditHide?: boolean
+}
+
+export const SimpleEnvironmentWidget: React.FC<SimpleEnvironmentProps> = ({
+  initialValues,
+  onUpdate,
+  readonly,
+  environmentLabel,
+  clearButton,
+  tooltipProp,
+  serviceNotRequired,
+  showEditHide
+}): JSX.Element => {
+  const { getString } = useStrings()
+  const { accountId, projectIdentifier, orgIdentifier } = useParams<
+    PipelineType<{
+      orgIdentifier: string
+      projectIdentifier: string
+      pipelineIdentifier: string
+      accountId: string
+    }>
+  >()
+
+  const { showError } = useToaster()
+  const {
+    data: environmentsResponse,
+    loading,
+    error
+  } = useGetEnvironmentList({
+    queryParams: { accountIdentifier: accountId, orgIdentifier, projectIdentifier }
+  })
+
+  const [environments, setEnvironments] = React.useState<EnvironmentYaml[]>()
+  const [selectOptions, setSelectOptions] = React.useState<SelectOption[]>()
+
+  const [state, setState] = React.useState<DeployEnvironmentState>({
+    isEdit: false,
+    isEnvironment: false,
+    data: { name: '', identifier: '' }
+  })
+
+  const updateEnvironmentsList = (value: EnvironmentRequestDTO) => {
+    formikRef.current?.setValues({ environmentVal: value.identifier, ...(state.isEnvironment && { environment: {} }) })
+    if (!isNil(environments)) {
+      const newEnvironment = {
+        description: value.description,
+        identifier: defaultTo(value.identifier, ''),
+        name: value.name || '',
+        tags: value.tags,
+        type: value.type
+      }
+      const newEnvironmentsList = [...environments]
+      const existingIndex = newEnvironmentsList.findIndex(item => item.identifier === value.identifier)
+      if (existingIndex >= 0) {
+        newEnvironmentsList.splice(existingIndex, 1, newEnvironment)
+      } else {
+        newEnvironmentsList.unshift(newEnvironment)
+      }
+      setEnvironments(newEnvironmentsList)
+    }
+  }
+
+  const [showModal, hideModal] = useModalHook(
+    () => (
+      <Dialog
+        isOpen={true}
+        enforceFocus={false}
+        onClose={onClose}
+        title={state.isEdit ? getString('editEnvironment') : getString('newEnvironment')}
+      >
+        <NewEditEnvironmentModal
+          data={state.data || { name: '', identifier: '' }}
+          isEnvironment={state.isEnvironment}
+          isEdit={state.isEdit}
+          onCreateOrUpdate={value => {
+            updateEnvironmentsList(value)
+            onClose.call(null)
+          }}
+          closeModal={onClose}
+        />
+      </Dialog>
+    ),
+    [state]
+  )
+
+  const onClose = React.useCallback(() => {
+    setState({ isEdit: false, isEnvironment: false })
+    hideModal()
+  }, [hideModal])
+
+  React.useEffect(() => {
+    if (!isNil(selectOptions) && initialValues.environmentVal) {
+      const doesExist = selectOptions.filter(env => env.value === initialValues.environmentVal).length > 0
+      if (!doesExist) {
+        if (!readonly) {
+          formikRef.current?.setFieldValue('environmentVal', '')
+        } else {
+          const options = [...selectOptions]
+          options.push({
+            label: initialValues.environmentVal,
+            value: initialValues.environmentVal
+          })
+          setSelectOptions(options)
+        }
+      }
+    }
+  }, [selectOptions])
+
+  React.useEffect(() => {
+    if (!isNil(environments)) {
+      setSelectOptions(
+        environments.map(environment => {
+          return { label: environment.name, value: environment.identifier }
+        })
+      )
+    }
+  }, [environments])
+
+  React.useEffect(() => {
+    if (!loading) {
+      const envList: EnvironmentYaml[] = []
+      if (environmentsResponse?.data?.content?.length) {
+        environmentsResponse.data.content.forEach(env => {
+          envList.push({
+            description: env.environment?.description,
+            identifier: env.environment?.identifier || '',
+            name: env.environment?.name || '',
+            tags: env.environment?.tags,
+            type: env.environment?.type || 'PreProduction'
+          })
+        })
+      }
+      if (initialValues.environment) {
+        const identifier = initialValues.environment.identifier
+        const isExist = envList.filter(env => env.identifier === identifier).length > 0
+        if (initialValues.environment && identifier && !isExist) {
+          envList.push({
+            description: initialValues.environment.description,
+            identifier: initialValues.environment.identifier || '',
+            name: initialValues.environment.name || '',
+            tags: initialValues.environment.tags,
+            type: initialValues.environment.type || 'PreProduction'
+          })
+        }
+      }
+      setEnvironments(envList)
+    }
+  }, [loading, environmentsResponse, environmentsResponse?.data?.content?.length])
+
+  if (error?.message) {
+    showError(error.message, undefined, 'cd.env.list.error')
+  }
+
+  const [canEdit] = usePermission({
+    resource: {
+      resourceType: ResourceType.ENVIRONMENT,
+      resourceIdentifier: environments ? (environments[0]?.identifier as string) : ''
+    },
+    permissions: [PermissionIdentifier.EDIT_ENVIRONMENT],
+    options: {
+      skipCondition: ({ resourceIdentifier }) => !resourceIdentifier
+    }
+  })
+
+  const [canCreate] = usePermission({
+    resource: {
+      resourceType: ResourceType.ENVIRONMENT
+    },
+    permissions: [PermissionIdentifier.EDIT_ENVIRONMENT]
+  })
+
+  const { subscribeForm, unSubscribeForm } = React.useContext(StageErrorContext)
+
+  const formikRef = React.useRef<FormikProps<unknown> | null>(null)
+
+  React.useEffect(() => {
+    subscribeForm({ tab: DeployTabs.INFRASTRUCTURE, form: formikRef })
+    return () => unSubscribeForm({ tab: DeployTabs.INFRASTRUCTURE, form: formikRef })
+  }, [])
+
+  const environmentVal = initialValues?.environment?.identifier || initialValues?.environmentVal
+
+  return (
+    <>
+      <Formik<DeployEnvData>
+        formName="deployEnvStepForm"
+        onSubmit={noop}
+        validate={values => {
+          if (!isEmpty(values.environment)) {
+            onUpdate?.({ ...omit(values, 'environmentVal') })
+          } else {
+            onUpdate?.({ ...omit(values, 'environment'), environmentVal: values.environmentVal })
+          }
+        }}
+        initialValues={{
+          ...initialValues,
+          ...{ environmentVal }
+        }}
+        validationSchema={Yup.object().shape(
+          serviceNotRequired
+            ? {
+                environmentVal: getEnvironmentSchema()
+              }
+            : {
+                environmentVal: getEnvironmentRefSchema(getString)
+              }
+        )}
+      >
+        {formik => {
+          window.dispatchEvent(new CustomEvent('UPDATE_ERRORS_STRIP', { detail: DeployTabs.INFRASTRUCTURE }))
+          formikRef.current = formik
+          const { values, setFieldValue } = formik
+          return (
+            <Layout.Horizontal
+              className={css.formRow}
+              spacing="medium"
+              flex={{ alignItems: 'flex-start', justifyContent: 'flex-start' }}
+            >
+              <FormInput.Select
+                label={
+                  environmentLabel
+                    ? environmentLabel
+                    : getString('cd.pipelineSteps.environmentTab.specifyYourEnvironment')
+                }
+                tooltipProps={tooltipProp}
+                name="environmentVal"
+                key={formik?.values?.environmentVal}
+                disabled={readonly || loading}
+                placeholder={
+                  loading ? getString('loading') : getString('cd.pipelineSteps.environmentTab.selectEnvironment')
+                }
+                onChange={val => {
+                  if (values.environment?.identifier && (val as SelectOption).value !== values.environment.identifier) {
+                    setEnvironments(environments?.filter(env => env.identifier !== values.environment?.identifier))
+                    setFieldValue('environment', undefined)
+                  }
+                }}
+                addClearButton={clearButton}
+                selectProps={{
+                  disabled: loading,
+                  onQueryChange: val => {
+                    if (values.environment?.identifier && (val as any).value !== values.environment.identifier) {
+                      setEnvironments(environments?.filter(env => env.identifier !== values.environment?.identifier))
+                      setFieldValue('environment', undefined)
+                    }
+                  }
+                }}
+                items={selectOptions || []}
+              />
+              {showEditHide && (
+                <Button
+                  size={ButtonSize.SMALL}
+                  variation={ButtonVariation.LINK}
+                  disabled={readonly || (isEditEnvironment(values) ? !canEdit : !canCreate)}
+                  onClick={() => {
+                    const isEdit = isEditEnvironment(values)
+                    if (isEdit) {
+                      if (values.environment?.identifier) {
+                        setState({
+                          isEdit,
+                          formik,
+                          isEnvironment: true,
+                          data: values.environment
+                        })
+                      } else {
+                        setState({
+                          isEdit,
+                          formik,
+                          isEnvironment: false,
+                          data: environments?.find(env => env.identifier === values.environmentVal)
+                        })
+                      }
+                    } else {
+                      setState({
+                        isEdit: false,
+                        isEnvironment: false,
+                        formik
+                      })
+                    }
+                    showModal()
+                  }}
+                  text={
+                    isEditEnvironment(values)
+                      ? getString('editEnvironment')
+                      : getString('cd.pipelineSteps.environmentTab.plusNewEnvironment')
+                  }
+                  id={isEditEnvironment(values) ? 'edit-environment' : 'add-new-environment'}
+                />
+              )}
+            </Layout.Horizontal>
+          )
+        }}
+      </Formik>
+    </>
+  )
+}

--- a/src/modules/75-cd/components/PipelineSteps/DeployServiceStep/DeployServiceStep.tsx
+++ b/src/modules/75-cd/components/PipelineSteps/DeployServiceStep/DeployServiceStep.tsx
@@ -60,6 +60,7 @@ import css from './DeployServiceStep.module.scss'
 const logger = loggerFor(ModuleName.CD)
 export interface DeployServiceData extends Omit<ServiceConfig, 'serviceRef'> {
   serviceRef?: string
+  serviceVal?: string
 }
 
 interface NewEditServiceModalProps {
@@ -191,14 +192,14 @@ export interface DeployServiceProps {
   serviceLabel?: string
 }
 
-interface DeployServiceState {
+export interface DeployServiceState {
   isEdit: boolean
   data?: ServiceResponseDTO
   isService: boolean
   formik?: FormikProps<DeployServiceData>
 }
 
-function isEditService(data: DeployServiceData): boolean {
+export function isEditService(data: DeployServiceData): boolean {
   if (getMultiTypeFromValue(data.serviceRef) !== MultiTypeInputType.RUNTIME) {
     if (typeof data.serviceRef === 'object') {
       const serviceRef = (data.serviceRef as SelectOption).value as string

--- a/src/modules/75-cd/components/PipelineSteps/DeployServiceStep/SimpleServiceWidget.tsx
+++ b/src/modules/75-cd/components/PipelineSteps/DeployServiceStep/SimpleServiceWidget.tsx
@@ -1,0 +1,329 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import React from 'react'
+import {
+  Button,
+  ButtonSize,
+  ButtonVariation,
+  Formik,
+  FormInput,
+  Dialog,
+  Layout,
+  SelectOption,
+  DataTooltipInterface
+} from '@wings-software/uicore'
+import { useModalHook } from '@harness/use-modal'
+import * as Yup from 'yup'
+import { defaultTo, isEmpty, isNil, noop, omit } from 'lodash-es'
+import { useParams } from 'react-router-dom'
+import type { FormikProps } from 'formik'
+
+import { ServiceRequestDTO, ServiceYaml, useGetServiceList } from 'services/cd-ng'
+import { useStrings } from 'framework/strings'
+
+import type { PipelineType } from '@common/interfaces/RouteInterfaces'
+import { useToaster } from '@common/exports'
+
+import { usePermission } from '@rbac/hooks/usePermission'
+import { ResourceType } from '@rbac/interfaces/ResourceType'
+import { PermissionIdentifier } from '@rbac/interfaces/PermissionIdentifier'
+import { StageErrorContext } from '@pipeline/context/StageErrorContext'
+import { DeployTabs } from '@cd/components/PipelineStudio/DeployStageSetupShell/DeployStageSetupShellUtils'
+import { getServiceRefSchema, getServiceSchema } from '@cd/components/PipelineSteps/PipelineStepsUtil'
+import type { StepViewType } from '@pipeline/components/AbstractSteps/Step'
+import { DeployServiceData, DeployServiceState, isEditService, NewEditServiceModal } from './DeployServiceStep'
+import css from './DeployServiceStep.module.scss'
+
+export interface SimpleServiceProps {
+  initialValues: DeployServiceData
+  onUpdate?: (data: DeployServiceData) => void
+  stepViewType?: StepViewType
+  readonly: boolean
+  inputSetData?: {
+    template?: DeployServiceData
+    path?: string
+    readonly?: boolean
+  }
+  serviceLabel?: string
+  clearButton?: boolean
+  tooltipProp?: DataTooltipInterface | undefined
+  serviceNotRequired?: boolean
+  showHideEdit?: boolean
+}
+
+export const SimpleServiceWidget: React.FC<SimpleServiceProps> = ({
+  initialValues,
+  onUpdate,
+  readonly,
+  serviceLabel,
+  clearButton,
+  tooltipProp,
+  serviceNotRequired,
+  showHideEdit
+}): JSX.Element => {
+  const { getString } = useStrings()
+  const { accountId, projectIdentifier, orgIdentifier } = useParams<
+    PipelineType<{
+      orgIdentifier: string
+      projectIdentifier: string
+      pipelineIdentifier: string
+      accountId: string
+    }>
+  >()
+
+  const { showError } = useToaster()
+  const {
+    data: serviceResponse,
+    error,
+    loading
+  } = useGetServiceList({
+    queryParams: { accountIdentifier: accountId, orgIdentifier, projectIdentifier }
+  })
+
+  const [services, setService] = React.useState<ServiceYaml[]>()
+  const [selectOptions, setSelectOptions] = React.useState<SelectOption[]>()
+
+  const [state, setState] = React.useState<DeployServiceState>({ isEdit: false, isService: false })
+
+  const updateServicesList = (value: ServiceRequestDTO) => {
+    formikRef.current?.setValues({ serviceVal: value.identifier, ...(state.isService && { service: {} }) })
+    if (!isNil(services)) {
+      const newService = {
+        description: value.description,
+        identifier: defaultTo(value.identifier, ''),
+        name: value.name || '',
+        tags: value.tags
+      }
+      const newServicesList = [...services]
+      const existingIndex = newServicesList.findIndex(item => item.identifier === value.identifier)
+      if (existingIndex >= 0) {
+        newServicesList.splice(existingIndex, 1, newService)
+      } else {
+        newServicesList.unshift(newService)
+      }
+      setService(newServicesList)
+    }
+  }
+
+  const [showModal, hideModal] = useModalHook(
+    () => (
+      <Dialog
+        isOpen={true}
+        enforceFocus={false}
+        onClose={onClose}
+        title={state.isEdit ? getString('editService') : getString('newService')}
+      >
+        <NewEditServiceModal
+          data={state.data || { name: '', identifier: '' }}
+          isEdit={state.isEdit}
+          isService={state.isService}
+          onCreateOrUpdate={value => {
+            updateServicesList(value)
+            onClose.call(null)
+          }}
+          closeModal={onClose}
+        />
+      </Dialog>
+    ),
+    [state]
+  )
+
+  const onClose = React.useCallback(() => {
+    setState({ isEdit: false, isService: false })
+    hideModal()
+  }, [hideModal])
+
+  React.useEffect(() => {
+    if (!isNil(selectOptions) && initialValues.serviceVal) {
+      const doesExist = selectOptions.filter(service => service.value === initialValues.serviceVal).length > 0
+      if (!doesExist) {
+        if (!readonly) {
+          formikRef.current?.setFieldValue('serviceVal', '')
+        } else {
+          const options = [...selectOptions]
+          options.push({
+            label: initialValues.serviceVal,
+            value: initialValues.serviceVal
+          })
+          setSelectOptions(options)
+        }
+      }
+    }
+  }, [selectOptions])
+
+  React.useEffect(() => {
+    if (!isNil(services)) {
+      setSelectOptions(
+        services.map(service => {
+          return { label: service.name, value: service.identifier }
+        })
+      )
+    }
+  }, [services])
+
+  React.useEffect(() => {
+    if (!loading) {
+      const serviceList: ServiceYaml[] = []
+      if (serviceResponse?.data?.content?.length) {
+        serviceResponse.data.content.forEach(service => {
+          serviceList.push({
+            description: service.service?.description,
+            identifier: service.service?.identifier || '',
+            name: service.service?.name || '',
+            tags: service.service?.tags
+          })
+        })
+      }
+      if (initialValues.service) {
+        const identifier = initialValues.service.identifier
+        const isExist = serviceList.filter(service => service.identifier === identifier).length > 0
+        if (initialValues.service && identifier && !isExist) {
+          serviceList.push({
+            description: initialValues.service?.description,
+            identifier: initialValues.service?.identifier || '',
+            name: initialValues.service?.name || '',
+            tags: initialValues.service?.tags
+          })
+        }
+      }
+      setService(serviceList)
+    }
+  }, [loading, serviceResponse, serviceResponse?.data?.content?.length])
+
+  if (error?.message) {
+    showError(error.message, undefined, 'cd.svc.list.error')
+  }
+
+  const [canEdit] = usePermission({
+    resource: {
+      resourceType: ResourceType.SERVICE,
+      resourceIdentifier: services ? (services[0]?.identifier as string) : ''
+    },
+    permissions: [PermissionIdentifier.EDIT_SERVICE],
+    options: {
+      skipCondition: ({ resourceIdentifier }) => !resourceIdentifier
+    }
+  })
+
+  const [canCreate] = usePermission({
+    resource: {
+      resourceType: ResourceType.SERVICE
+    },
+    permissions: [PermissionIdentifier.EDIT_SERVICE]
+  })
+
+  const { subscribeForm, unSubscribeForm } = React.useContext(StageErrorContext)
+
+  const formikRef = React.useRef<FormikProps<unknown> | null>(null)
+
+  React.useEffect(() => {
+    subscribeForm({ tab: DeployTabs.SERVICE, form: formikRef })
+    return () => unSubscribeForm({ tab: DeployTabs.SERVICE, form: formikRef })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const serviceVal = initialValues?.service?.identifier || initialValues?.serviceVal
+
+  return (
+    <>
+      <Formik<DeployServiceData>
+        formName="deployServiceStepForm"
+        onSubmit={noop}
+        validate={values => {
+          if (!isEmpty(values.service)) {
+            onUpdate?.({ ...omit(values, 'serviceVal') })
+          } else {
+            onUpdate?.({ ...omit(values, 'service'), serviceVal: values.serviceVal })
+          }
+        }}
+        initialValues={{
+          ...initialValues,
+          ...{ serviceVal }
+        }}
+        validationSchema={Yup.object().shape(
+          serviceNotRequired
+            ? { serviceVal: getServiceSchema() }
+            : {
+                serviceVal: getServiceRefSchema(getString)
+              }
+        )}
+      >
+        {formik => {
+          window.dispatchEvent(new CustomEvent('UPDATE_ERRORS_STRIP', { detail: DeployTabs.SERVICE }))
+          formikRef.current = formik
+          const { values, setFieldValue } = formik
+          return (
+            <Layout.Horizontal
+              className={css.formRow}
+              spacing="medium"
+              flex={{ alignItems: 'flex-start', justifyContent: 'flex-start' }}
+            >
+              <FormInput.Select
+                key={formik?.values?.serviceVal}
+                tooltipProps={tooltipProp}
+                label={serviceLabel ? serviceLabel : getString('cd.pipelineSteps.serviceTab.specifyYourService')}
+                name="serviceVal"
+                disabled={readonly || loading}
+                placeholder={loading ? getString('loading') : getString('cd.pipelineSteps.serviceTab.selectService')}
+                onChange={val => {
+                  if (values.service?.identifier && (val as SelectOption).value !== values.service.identifier) {
+                    setService(services?.filter(service => service.identifier !== values.service?.identifier))
+                    setFieldValue('service', undefined)
+                  }
+                }}
+                addClearButton={clearButton}
+                selectProps={{ disabled: loading }}
+                items={selectOptions || []}
+              />
+              {showHideEdit && (
+                <Button
+                  size={ButtonSize.SMALL}
+                  variation={ButtonVariation.LINK}
+                  disabled={readonly || (isEditService(values) ? !canEdit : !canCreate)}
+                  onClick={() => {
+                    const isEdit = isEditService(values)
+                    if (isEdit) {
+                      if (values.service?.identifier) {
+                        setState({
+                          isEdit,
+                          formik,
+                          isService: true,
+                          data: values.service
+                        })
+                      } else {
+                        setState({
+                          isEdit,
+                          formik,
+                          isService: false,
+                          data: services?.find(service => service.identifier === values.serviceVal)
+                        })
+                      }
+                    } else {
+                      setState({
+                        isEdit: false,
+                        formik,
+                        isService: false
+                      })
+                    }
+                    showModal()
+                  }}
+                  text={
+                    isEditService(values)
+                      ? getString('editService')
+                      : getString('cd.pipelineSteps.serviceTab.plusNewService')
+                  }
+                  id={isEditService(initialValues) ? 'edit-service' : 'add-new-service'}
+                />
+              )}
+            </Layout.Horizontal>
+          )
+        }}
+      </Formik>
+    </>
+  )
+}

--- a/src/modules/75-cd/components/PipelineSteps/PipelineStepsUtil.ts
+++ b/src/modules/75-cd/components/PipelineSteps/PipelineStepsUtil.ts
@@ -63,11 +63,17 @@ export function getConnectorSchema(getString: UseStringsReturn['getString']): Yu
 export function getServiceRefSchema(getString: UseStringsReturn['getString']): Yup.StringSchema<string | undefined> {
   return Yup.string().trim().required(getString('cd.pipelineSteps.serviceTab.serviceIsRequired'))
 }
+export function getServiceSchema(): Yup.StringSchema<string | undefined> {
+  return Yup.string().trim()
+}
 
 export function getEnvironmentRefSchema(
   getString: UseStringsReturn['getString']
 ): Yup.StringSchema<string | undefined> {
   return Yup.string().trim().required(getString('cd.pipelineSteps.environmentTab.environmentIsRequired'))
+}
+export function getEnvironmentSchema(): Yup.StringSchema<string | undefined> {
+  return Yup.string().trim()
 }
 
 export function getServiceDeploymentTypeSchema(

--- a/src/modules/75-cd/interfaces/GitOps.types.ts
+++ b/src/modules/75-cd/interfaces/GitOps.types.ts
@@ -7,10 +7,14 @@
 
 import type { DeployServiceProps } from '@cd/components/PipelineSteps/DeployServiceStep/DeployServiceStep'
 import type { DeployEnvironmentProps } from '@cd/components/PipelineSteps/DeployEnvStep/DeployEnvStep'
+import type { SimpleServiceProps } from '@cd/components/PipelineSteps/DeployServiceStep/SimpleServiceWidget'
+import type { SimpleEnvironmentProps } from '@cd/components/PipelineSteps/DeployEnvStep/SimpleEnvWidget'
 
 export interface GitOpsCustomMicroFrontendProps {
   customComponents: {
     DeployServiceWidget: React.ComponentType<DeployServiceProps>
     DeployEnvironmentWidget: React.ComponentType<DeployEnvironmentProps>
+    SimpleServiceWidget: React.ComponentType<SimpleServiceProps>
+    SimpleEnvironmentWidget: React.ComponentType<SimpleEnvironmentProps>
   }
 }


### PR DESCRIPTION
##### Summary:

Made a simple environment and service select as there some modifications necessary for it to be used on the gitops mfe.

Made some options optional or enhanced features:
- such as the serviceRequired validation
- custom labels
- show or hide the create/edit button
- show or hide the tooltipProp
- show or hide clear button

##### Jira Links:

(https://harness.atlassian.net/browse/CDS-35238)

##### Screenshots:

![image](https://user-images.githubusercontent.com/92757601/158906761-2af7d81f-09bf-43e1-952b-356ba8b92182.png)
![image](https://user-images.githubusercontent.com/92757601/158906781-118412a6-19b2-4c62-989a-0b73310cc976.png)


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
