### PR TITLE
fix: [FFM-2591]: enforce modal width and padding in Flag Wizard

### DIFF
--- a/src/modules/75-cf/components/CreateFlagDialog/FlagDialog.module.scss
+++ b/src/modules/75-cf/components/CreateFlagDialog/FlagDialog.module.scss
@@ -7,13 +7,13 @@
 
 .modal {
   position: relative;
-  width: 1000px;
+  width: 1000px !important;
   min-height: 600px;
   height: fit-content;
   background: var(--primary-7) !important;
   border-left: 0 !important;
   overflow: hidden;
-  padding-bottom: 0;
+  padding-bottom: 0 !important;
   .close-icon {
     position: absolute;
     right: var(--spacing-small);

--- a/src/modules/75-cf/components/CreateFlagDialog/FlagDialog.tsx
+++ b/src/modules/75-cf/components/CreateFlagDialog/FlagDialog.tsx
@@ -7,7 +7,7 @@
 
 import React, { useState } from 'react'
 import { Dialog } from '@blueprintjs/core'
-import { Color, Button, Container, Text, Icon } from '@wings-software/uicore'
+import { Button, Color, Container, Icon, Text } from '@wings-software/uicore'
 import { useModalHook } from '@harness/use-modal'
 import { useStrings } from 'framework/strings'
 import { FlagTypeVariations } from './FlagDialogUtils'


### PR DESCRIPTION
Fix issue whereby the Flag wizard's width override was not taking precedence, leading to the Flag wizard displaying as too narrow.

|Before|After|
|------|------|
|![Before](https://user-images.githubusercontent.com/7167253/159254349-e43972cf-59d9-4865-87c1-1ea8512a9a0c.png)|![After](https://user-images.githubusercontent.com/7167253/159254418-245dac94-c810-4c6c-bfb6-2faa4c29b259.png)|
|![Screenshot 2022-03-21 at 11 42 03](https://user-images.githubusercontent.com/7167253/159254485-01cb47e2-9e31-4945-80fb-329093570454.png)|![Screenshot 2022-03-21 at 11 42 17](https://user-images.githubusercontent.com/7167253/159254525-714bec60-9705-4065-9d0c-6399f546efca.png)|

Refs [FFM-2591](https://harness.atlassian.net/browse/FFM-2591)

### Changes
- added `!important` to `FlagDialog` `width`
- added `!important` to `FlagDialog` `padding-bottom`
