### PR TITLE
fix: [CDS-34638]: fixed the label before it was the wrong label

### DIFF
--- a/src/modules/75-cd/components/PipelineSteps/DeployEnvStep/DeployEnvStep.tsx
+++ b/src/modules/75-cd/components/PipelineSteps/DeployEnvStep/DeployEnvStep.tsx
@@ -438,7 +438,9 @@ export const DeployEnvironmentWidget: React.FC<DeployEnvironmentProps> = ({
               >
                 <FormInput.MultiTypeInput
                   label={
-                    environmentLabel ? environmentLabel : getString('cd.pipelineSteps.serviceTab.specifyYourService')
+                    environmentLabel
+                      ? environmentLabel
+                      : getString('cd.pipelineSteps.environmentTab.specifyYourEnvironment')
                   }
                   tooltipProps={{ dataTooltipId: 'specifyYourEnvironment' }}
                   name="environmentRef"


### PR DESCRIPTION
##### Summary:

accidentally changed the environment drop down to use the wrong string. Should actually be "specify Environment" but was accidentally changed to specify Environment


##### Jira Links:

[<!--- Add jira links for your changes here -->](https://harness.atlassian.net/browse/CDS-34638)

##### Screenshots:

![image](https://user-images.githubusercontent.com/92757601/159347692-edac5dff-8bbb-44ec-ab8d-0c4bf74e91ed.png)

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
