### PR TITLE
feat: [FFM-2612]: Display governance tabs when OPA_FF_GOVERNANCE enabled

### DIFF
--- a/src/modules/10-common/components/AccountSideNav/AccountSideNav.tsx
+++ b/src/modules/10-common/components/AccountSideNav/AccountSideNav.tsx
@@ -20,14 +20,15 @@ import { LaunchButton } from '../LaunchButton/LaunchButton'
 export default function AccountSideNav(): React.ReactElement {
   const { getString } = useStrings()
   const { accountId } = useParams<AccountPathProps>()
-  const { NG_LICENSES_ENABLED, OPA_PIPELINE_GOVERNANCE, AUDIT_TRAIL_WEB_INTERFACE } = useFeatureFlags()
+  const { NG_LICENSES_ENABLED, OPA_PIPELINE_GOVERNANCE, OPA_FF_GOVERNANCE, AUDIT_TRAIL_WEB_INTERFACE } =
+    useFeatureFlags()
 
   return (
     <Layout.Vertical spacing="small" margin={{ top: 'xxxlarge' }}>
       <SidebarLink exact label={getString('overview')} to={routes.toAccountSettingsOverview({ accountId })} />
       <SidebarLink label={getString('authentication')} to={routes.toAuthenticationSettings({ accountId })} />
       <SidebarLink label={getString('common.accountResources')} to={routes.toAccountResources({ accountId })} />
-      {OPA_PIPELINE_GOVERNANCE && (
+      {(OPA_PIPELINE_GOVERNANCE || OPA_FF_GOVERNANCE) && (
         <SidebarLink label={getString('common.governance')} to={routes.toGovernance({ accountId })} />
       )}
       <SidebarLink to={routes.toAccessControl({ accountId })} label={getString('accessControl')} />

--- a/src/modules/10-common/components/__tests__/AccountSideNav.test.tsx
+++ b/src/modules/10-common/components/__tests__/AccountSideNav.test.tsx
@@ -47,9 +47,23 @@ describe('AccountSideNav', () => {
     expect(container).toMatchSnapshot()
   })
 
-  test('AccountSideNav test governance', () => {
+  test('AccountSideNav test pipeline governance', () => {
     jest.spyOn(FeatureFlag, 'useFeatureFlags').mockReturnValue({
-      OPA_PIPELINE_GOVERNANCE: true
+      OPA_PIPELINE_GOVERNANCE: true,
+      OPA_FF_GOVERNANCE: false
+    })
+    const renderObj = render(
+      <TestWrapper>
+        <AccountSideNav />
+      </TestWrapper>
+    )
+    expect(renderObj.getByText('common.governance')).toBeTruthy()
+  })
+
+  test('AccountSideNav test ff governance', () => {
+    jest.spyOn(FeatureFlag, 'useFeatureFlags').mockReturnValue({
+      OPA_PIPELINE_GOVERNANCE: false,
+      OPA_FF_GOVERNANCE: true
     })
     const renderObj = render(
       <TestWrapper>

--- a/src/modules/45-projects-orgs/pages/organizations/OrganizationDetails/OrganizationDetailsPage.tsx
+++ b/src/modules/45-projects-orgs/pages/organizations/OrganizationDetails/OrganizationDetailsPage.tsx
@@ -29,7 +29,7 @@ import css from './OrganizationDetailsPage.module.scss'
 
 const OrganizationDetailsPage: React.FC = () => {
   const { accountId, orgIdentifier } = useParams<OrgPathProps>()
-  const { OPA_PIPELINE_GOVERNANCE, AUDIT_TRAIL_WEB_INTERFACE } = useFeatureFlags()
+  const { OPA_PIPELINE_GOVERNANCE, OPA_FF_GOVERNANCE, AUDIT_TRAIL_WEB_INTERFACE } = useFeatureFlags()
   const history = useHistory()
   const { getString } = useStrings()
   const { data, refetch, loading, error } = useGetOrganizationAggregateDTO({
@@ -220,7 +220,7 @@ const OrganizationDetailsPage: React.FC = () => {
             </Heading>
             <ResourceCardList items={getResourceCardList()} />
           </Layout.Vertical>
-          {OPA_PIPELINE_GOVERNANCE && (
+          {(OPA_PIPELINE_GOVERNANCE || OPA_FF_GOVERNANCE) && (
             <Layout.Vertical spacing="medium" padding={{ top: 'large' }}>
               <Heading font={{ size: 'medium', weight: 'bold' }} color={Color.BLACK}>
                 {getString('projectsOrgs.orgGovernance')}

--- a/src/modules/45-projects-orgs/pages/organizations/__tests__/OrganizationDetails.test.tsx
+++ b/src/modules/45-projects-orgs/pages/organizations/__tests__/OrganizationDetails.test.tsx
@@ -127,9 +127,26 @@ describe('Organization Details', () => {
     expect(form).toBeTruthy()
   })
 
-  test('Governance should be visible', async () => {
+  test('Governance should be visible when pipeline governance enabled', async () => {
     mockImport('@common/hooks/useFeatureFlag', {
-      useFeatureFlags: () => ({ OPA_PIPELINE_GOVERNANCE: true })
+      useFeatureFlags: () => ({ OPA_PIPELINE_GOVERNANCE: true, OPA_FF_GOVERNANCE: false })
+    })
+
+    render(
+      <TestWrapper
+        path={routes.toOrganizationDetails({ ...orgPathProps })}
+        pathParams={{ accountId: 'testAcc', orgIdentifier: 'testOrg' }}
+      >
+        <OrganizationDetailsPage />
+      </TestWrapper>
+    )
+
+    expect(getByText('common.governance')).toBeTruthy()
+  })
+
+  test('Governance should be visible when ff governance enabled', async () => {
+    mockImport('@common/hooks/useFeatureFlag', {
+      useFeatureFlags: () => ({ OPA_PIPELINE_GOVERNANCE: false, OPA_FF_GOVERNANCE: true })
     })
 
     render(

--- a/src/modules/75-cf/components/SideNav/SideNav.tsx
+++ b/src/modules/75-cf/components/SideNav/SideNav.tsx
@@ -32,7 +32,7 @@ export default function CFSideNav(): React.ReactElement {
   const { experience } = useQueryParams<{ experience?: ModuleLicenseType }>()
   const events = useFeatureFlagTelemetry()
 
-  const { FF_GITSYNC, FF_PIPELINE, OPA_PIPELINE_GOVERNANCE } = useFeatureFlags()
+  const { FF_GITSYNC, FF_PIPELINE, OPA_FF_GOVERNANCE } = useFeatureFlags()
 
   /* istanbul ignore next */
   const projectSelectHandler: ProjectSelectorProps['onSelect'] = data => {
@@ -104,7 +104,7 @@ export default function CFSideNav(): React.ReactElement {
                   />
                 </>
               )}
-              {OPA_PIPELINE_GOVERNANCE && (
+              {OPA_FF_GOVERNANCE && (
                 <SidebarLink
                   label={getString('common.governance')}
                   to={routes.toGovernance({ accountId, orgIdentifier, projectIdentifier, module: 'cf' })}


### PR DESCRIPTION
##### Summary:
Display governance tab when OPA_PIPELINE_GOVERNANCE or OPA_FF_GOVERNANCE are enabled. 
Note: this will be phased out once these features go GA. 

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
