### PR TITLE
fix: [CCM-5409]: Disable continue button in AWS connector overview step when form inputs are not valid

### DIFF
--- a/src/modules/35-connectors/components/CreateConnector/commonSteps/ConnectorDetailsStep.tsx
+++ b/src/modules/35-connectors/components/CreateConnector/commonSteps/ConnectorDetailsStep.tsx
@@ -184,7 +184,7 @@ const ConnectorDetailsStep: React.FC<StepProps<ConnectorConfigDTO> & ConnectorDe
                     type="submit"
                     intent="primary"
                     rightIcon="chevron-right"
-                    disabled={loading}
+                    disabled={loading || !formikProps.isValid}
                     variation={ButtonVariation.PRIMARY}
                   >
                     <String stringID="continue" />


### PR DESCRIPTION

##### Summary:

<!--- Add summary of your changes here -->

##### Jira Links:

https://harness.atlassian.net/browse/CCM-5409

##### Screenshots:

<!--- Add screenshots for your changes here -->

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
