### PR TITLE
fix: [PL-22646]: Invalid branch fixes

### DIFF
--- a/coverage-groups.json
+++ b/coverage-groups.json
@@ -17,7 +17,11 @@
     "Connectors": ["src/modules/35-connectors/**", "src/modules/10-common/components/YAMLBuilder/**"],
     "Delegates": ["src/modules/30-delegates/**"],
     "STO": ["src/modules/85-sto-steps/**", "src/modules/27-sto/**"],
-    "GitSync": ["src/modules/40-gitsync/**", "src/modules/10-common/components/SCMCheck/**"],
+    "GitSync": [
+      "src/modules/40-gitsync/**",
+      "src/modules/10-common/components/SCMCheck/**",
+      "src/modules/10-common/components/GitContextForm/**"
+    ],
     "CI": ["src/modules/75-ci/**"],
     "CF": ["src/modules/75-cf/**"],
     "CE": ["src/modules/75-ce/**", "src/modules/35-connectors/CreateConnector/CEK8sConnector/**"],

--- a/src/modules/10-common/components/GitContextForm/GitContextForm.tsx
+++ b/src/modules/10-common/components/GitContextForm/GitContextForm.tsx
@@ -197,7 +197,7 @@ const GitContextForm: React.FC<GitContextFormProps<Record<string, any> & GitCont
           }}
           className={css.selectBranchInput}
         />
-        {loadingBranchList && <Icon margin={{ top: 'xsmall' }} name="spinner" />}
+        <Container width={16}>{loadingBranchList && <Icon margin={{ top: 'xsmall' }} name="spinner" />}</Container>
       </Layout.Horizontal>
     </Container>
   )

--- a/src/modules/10-common/components/GitContextForm/GitContextForm.tsx
+++ b/src/modules/10-common/components/GitContextForm/GitContextForm.tsx
@@ -60,8 +60,9 @@ const GitContextForm: React.FC<GitContextFormProps<Record<string, any> & GitCont
   const [searchTerm, setSearchTerm] = React.useState<string>('')
 
   React.useEffect(() => {
+    const defaultRepoSelect = gitDetails?.repoIdentifier ?? gitSyncRepos[0]?.identifier
     const isSelectedBranchExist = !!branchSelectOptions.filter(item => item.value === defaultBranchSelect.value)[0]
-    if (!isSelectedBranchExist) {
+    if (!isSelectedBranchExist && defaultRepoSelect === formikProps?.values?.repo) {
       branchSelectOptions.push(defaultBranchSelect)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -101,7 +102,7 @@ const GitContextForm: React.FC<GitContextFormProps<Record<string, any> & GitCont
           projectIdentifier,
           yamlGitConfigIdentifier: formikProps.values.repo,
           page: 0,
-          size: 20,
+          size: 100,
           searchTerm
         }
       })

--- a/src/modules/10-common/components/GitContextForm/__tests__/__snapshots__/GitContextForm.test.tsx.snap
+++ b/src/modules/10-common/components/GitContextForm/__tests__/__snapshots__/GitContextForm.test.tsx.snap
@@ -157,6 +157,10 @@ exports[`GitContextForm test GitContextForm for create with deafault restriction
                 </div>
               </div>
             </div>
+            <div
+              class="StyledProps--font StyledProps--main"
+              style="width: 16px;"
+            />
           </div>
         </div>
       </div>
@@ -321,6 +325,10 @@ exports[`GitContextForm test GitContextForm for create without deafult restricti
                 </div>
               </div>
             </div>
+            <div
+              class="StyledProps--font StyledProps--main"
+              style="width: 16px;"
+            />
           </div>
         </div>
       </div>
@@ -487,6 +495,10 @@ exports[`GitContextForm test GitContextForm for edit should have repo and branch
                 </div>
               </div>
             </div>
+            <div
+              class="StyledProps--font StyledProps--main"
+              style="width: 16px;"
+            />
           </div>
         </div>
       </div>

--- a/src/modules/35-connectors/components/CreateConnector/commonSteps/ConnectorDetailsStep.module.scss
+++ b/src/modules/35-connectors/components/CreateConnector/commonSteps/ConnectorDetailsStep.module.scss
@@ -24,8 +24,12 @@
     }
 
     .gitDetailsContainer {
-      .bp3-popover-wrapper {
-        width: 56% !important;
+      .bp3-form-group {
+        width: 54% !important;
+      }
+
+      [class*='Layout--horizontal'] {
+        width: calc(54% + 24px) !important;
       }
     }
   }


### PR DESCRIPTION
##### Summary:

Changes are : 
- Invalid branch fixes : `GitContextForm` is always initialised with a given <Repo, branch> or <1st Repo, default branch>.Bug was to push branch used for initialising for all the repo.

- CSS fixes : Loading Icon was in far right.And branch Select dropdown size was changing while loading.

- Making Branch list size as 100 as decided for consistency
- Including `GitContextForm` of common under GitSync coverage

##### Jira Links:
https://harness.atlassian.net/browse/PL-22646
##### Screenshots:

**Before fix as in QA now**
https://user-images.githubusercontent.com/63278928/159774873-cb780830-af74-4609-af75-f88547ceecb0.mov


**After fix:** 

https://user-images.githubusercontent.com/63278928/159774393-289e1d7b-ecf8-44a4-b8ea-16d821ac3e6c.mov


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
