### PR TITLE
fix: [CCM-7002]: hotfix to hide CLI option for ECS rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nextgenui",
   "description": "Harness Inc",
-  "version": "0.293.0",
+  "version": "0.293.1",
   "author": "Harness Inc",
   "license": "Harness Inc",
   "homepage": "http://app.harness.io/",

--- a/src/modules/75-ce/components/COGatewayList/COGatewayAnalytics.tsx
+++ b/src/modules/75-ce/components/COGatewayList/COGatewayAnalytics.tsx
@@ -364,12 +364,12 @@ const COGatewayAnalytics: React.FC<COGatewayAnalyticsProps> = props => {
         <Container className={css.analyticsHeader}>
           <Layout.Vertical spacing="medium">
             <Heading level={2} font={{ weight: 'bold' }}>
-              Advanced configuration
+              {getString('ce.co.autoStoppingRule.configuration.step4.advancedConfiguration')}
             </Heading>
             <FixedScheduleAccordion service={props.service?.data} />
           </Layout.Vertical>
         </Container>
-        {props.service?.data.fulfilment !== 'kubernetes' && (
+        {props.service?.data.fulfilment !== 'kubernetes' && !isEcsRule && (
           <Container className={css.analyticsHeader}>
             <Layout.Vertical spacing="medium">
               <Heading level={2} font={{ weight: 'bold' }} className={css.analyticsSubHeader}>

--- a/src/modules/75-ce/components/COGatewayList/__tests__/__snapshots__/COGatewayAnalytics.test.tsx.snap
+++ b/src/modules/75-ce/components/COGatewayList/__tests__/__snapshots__/COGatewayAnalytics.test.tsx.snap
@@ -308,7 +308,7 @@ exports[`Autostopping rule analytics drawer render analytics drawer 1`] = `
             class="StyledProps--font StyledProps--font-h2 StyledProps--main StyledProps--font-weight-bold"
             level="2"
           >
-            Advanced configuration
+            ce.co.autoStoppingRule.configuration.step4.advancedConfiguration
           </h2>
         </div>
       </div>
@@ -841,7 +841,7 @@ exports[`Autostopping rule analytics drawer render k8s rule analytics drawer 1`]
             class="StyledProps--font StyledProps--font-h2 StyledProps--main StyledProps--font-weight-bold"
             level="2"
           >
-            Advanced configuration
+            ce.co.autoStoppingRule.configuration.step4.advancedConfiguration
           </h2>
         </div>
       </div>


### PR DESCRIPTION
##### Summary:

<!--- Add summary of your changes here -->

##### Jira Links:

<!--- Add jira links for your changes here -->

##### Screenshots:

<!--- Add screenshots for your changes here -->

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
