### PR TITLE
fix: [CDS-25535]: user group input expression list support added

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@harness/monaco-yaml": "^1.0.0",
     "@harness/ng-tooltip": "^1.30.75",
     "@harness/telemetry": "^1.0.37",
-    "@harness/uicore": "2.46.0",
+    "@harness/uicore": "2.47.0",
     "@harness/use-modal": "1.1.0",
     "@popperjs/core": "^2.4.2",
     "@projectstorm/react-diagrams-core": "^6.6.0",

--- a/src/modules/10-common/components/DelegateSelectors/DelegateSelectors.tsx
+++ b/src/modules/10-common/components/DelegateSelectors/DelegateSelectors.tsx
@@ -8,6 +8,7 @@
 import React, { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import cx from 'classnames'
+import { noop } from 'lodash-es'
 import { SimpleTagInput, Text, Icon } from '@wings-software/uicore'
 import { Color } from '@harness/design-system'
 import { useToaster } from '@common/exports'
@@ -38,11 +39,20 @@ export interface DelegateSelectorsProps
   placeholder?: string
   pollingInterval?: number
   wrapperClassName?: string
+  onTagInputChange?: (tags: string[]) => void
 }
 
 export const DelegateSelectors = (props: DelegateSelectorsProps): React.ReactElement | null => {
   const { accountId } = useParams<AccountPathProps>()
-  const { orgIdentifier, projectIdentifier, pollingInterval = null, wrapperClassName, placeholder, ...rest } = props
+  const {
+    orgIdentifier,
+    projectIdentifier,
+    pollingInterval = null,
+    onTagInputChange = noop,
+    wrapperClassName,
+    placeholder,
+    ...rest
+  } = props
 
   const { getString } = useStrings()
   const { showError } = useToaster()
@@ -97,6 +107,7 @@ export const DelegateSelectors = (props: DelegateSelectorsProps): React.ReactEle
             className: css.delegatePopover
           }}
           items={data?.resource || []}
+          onChange={onTagInputChange}
           {...rest}
           allowNewTag
           getTagProps={(value, _index, _selectedItems, createdItems, items) => {

--- a/src/modules/10-common/components/ExpressionsListInput/ExpressionsListInput.module.scss
+++ b/src/modules/10-common/components/ExpressionsListInput/ExpressionsListInput.module.scss
@@ -5,7 +5,8 @@
  * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
  */
 
-.expressionsInput {
+.expressionsInputContainer {
   flex: 1 1 auto;
   position: relative;
+  margin-bottom: 0 !important;
 }

--- a/src/modules/10-common/components/ExpressionsListInput/ExpressionsListInput.module.scss
+++ b/src/modules/10-common/components/ExpressionsListInput/ExpressionsListInput.module.scss
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+.expressionsInput {
+  flex: 1 1 auto;
+  position: relative;
+}

--- a/src/modules/10-common/components/ExpressionsListInput/ExpressionsListInput.module.scss.d.ts
+++ b/src/modules/10-common/components/ExpressionsListInput/ExpressionsListInput.module.scss.d.ts
@@ -1,0 +1,12 @@
+/* eslint-disable */
+/**
+ * Copyright 2021 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ **/
+// this is an auto-generated file, do not update this manually
+declare const styles: {
+  readonly expressionsInput: string
+}
+export default styles

--- a/src/modules/10-common/components/ExpressionsListInput/ExpressionsListInput.module.scss.d.ts
+++ b/src/modules/10-common/components/ExpressionsListInput/ExpressionsListInput.module.scss.d.ts
@@ -7,6 +7,6 @@
  **/
 // this is an auto-generated file, do not update this manually
 declare const styles: {
-  readonly expressionsInput: string
+  readonly expressionsInputContainer: string
 }
 export default styles

--- a/src/modules/10-common/components/ExpressionsListInput/ExpressionsListInput.tsx
+++ b/src/modules/10-common/components/ExpressionsListInput/ExpressionsListInput.tsx
@@ -5,13 +5,12 @@
  * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
  */
 
-import React from 'react'
+import React, { useEffect } from 'react'
 import { connect, FormikContext } from 'formik'
-import { get } from 'lodash-es'
-import { FormGroup, Intent } from '@blueprintjs/core'
+import { isEmpty } from 'lodash-es'
+import { FormGroup } from '@blueprintjs/core'
 import { ExpressionInput, EXPRESSION_INPUT_PLACEHOLDER } from '@wings-software/uicore'
 import { ListInput } from '@common/components/ListInput/ListInput'
-import { errorCheck } from '@common/utils/formikHelpers'
 
 import css from './ExpressionsListInput.module.scss'
 
@@ -27,6 +26,13 @@ export interface ExpressionsListInputProps {
 function ExpressionsListInputInternal(props: ExpressionsListInputProps) {
   const { name, value, readOnly, expressions = [], formik, inputClassName } = props
 
+  // To initialize minimum one input row
+  useEffect(() => {
+    if (isEmpty(value)) {
+      formik?.setFieldValue(name, [''])
+    }
+  }, [])
+
   return (
     <ListInput
       name={name}
@@ -34,13 +40,8 @@ function ExpressionsListInputInternal(props: ExpressionsListInputProps) {
       readOnly={readOnly}
       listItemRenderer={(str: string, index: number) => {
         const fieldName = `${name}.${index}`
-        const hasError = errorCheck(fieldName, formik)
         return (
-          <FormGroup
-            helperText={hasError ? get(formik?.errors, fieldName) : null}
-            intent={hasError ? Intent.DANGER : Intent.NONE}
-            className={css.expressionsInputContainer}
-          >
+          <FormGroup className={css.expressionsInputContainer}>
             <ExpressionInput
               name={fieldName}
               value={str}

--- a/src/modules/10-common/components/ExpressionsListInput/ExpressionsListInput.tsx
+++ b/src/modules/10-common/components/ExpressionsListInput/ExpressionsListInput.tsx
@@ -47,7 +47,10 @@ function ExpressionsListInputInternal(props: ExpressionsListInputProps) {
               disabled={readOnly}
               inputProps={{ className: inputClassName, placeholder: EXPRESSION_INPUT_PLACEHOLDER }}
               items={expressions}
-              onChange={val => formik?.setFieldValue(fieldName, val)}
+              onChange={val =>
+                /* istanbul ignore next */
+                formik?.setFieldValue(fieldName, val)
+              }
             />
           </FormGroup>
         )

--- a/src/modules/10-common/components/ExpressionsListInput/ExpressionsListInput.tsx
+++ b/src/modules/10-common/components/ExpressionsListInput/ExpressionsListInput.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import React from 'react'
+import type { FormikProps } from 'formik'
+import { ExpressionInput, EXPRESSION_INPUT_PLACEHOLDER } from '@wings-software/uicore'
+import { ListInput } from '@common/components/ListInput/ListInput'
+
+import css from './ExpressionsListInput.module.scss'
+
+export interface ExpressionsListInputProps {
+  name: string
+  value: string[]
+  readOnly?: boolean
+  expressions?: string[]
+  formikProps?: FormikProps<any>
+  inputClassName?: string
+}
+
+export function ExpressionsListInput(props: ExpressionsListInputProps) {
+  const { name, value, readOnly, expressions = [], formikProps, inputClassName } = props
+
+  return (
+    <ListInput
+      name={name}
+      elementList={value}
+      readOnly={readOnly}
+      listItemRenderer={(str: string, index: number) => (
+        <ExpressionInput
+          name={`${name}.${index}`}
+          value={str}
+          disabled={readOnly}
+          inputProps={{ className: inputClassName, placeholder: EXPRESSION_INPUT_PLACEHOLDER }}
+          items={expressions}
+          onChange={val => formikProps?.setFieldValue(`${name}.${index}`, val)}
+          popoverProps={{
+            className: css.expressionsInput
+          }}
+        />
+      )}
+    />
+  )
+}

--- a/src/modules/10-common/components/ExpressionsListInput/__tests__/ExpressionListInput.test.tsx
+++ b/src/modules/10-common/components/ExpressionsListInput/__tests__/ExpressionListInput.test.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import React from 'react'
+import { render, fireEvent, queryByAttribute } from '@testing-library/react'
+import { Formik, FormikForm } from '@wings-software/uicore'
+import { TestWrapper } from '@common/utils/testUtils'
+import { errorCheck } from '@common/utils/formikHelpers'
+
+import { ExpressionsListInput } from '../ExpressionsListInput'
+
+jest.mock('@common/utils/formikHelpers', () => ({
+  errorCheck: jest.fn()
+}))
+
+const getListInputComponent = () => (
+  <TestWrapper>
+    {/* eslint-disable-next-line @typescript-eslint/no-empty-function */}
+    <Formik initialValues={{ test: ['Element 1', 'Element 2'] }} onSubmit={() => {}} formName="TestWrapper">
+      <FormikForm>
+        <ExpressionsListInput name="test" value={['Element 1', 'Element 2']} />
+      </FormikForm>
+    </Formik>
+  </TestWrapper>
+)
+
+describe('ExpressionsListInput tests', () => {
+  test('Should render properly with error', async () => {
+    // @ts-ignore
+    errorCheck.mockImplementation(() => true)
+    const { container } = render(getListInputComponent())
+
+    const queryByNameAttribute = (name: string): HTMLElement | null => queryByAttribute('name', container, name)
+
+    fireEvent.change(queryByNameAttribute('test.0')!, { target: { value: '<+pipeline.name>' } })
+    expect(container).toMatchSnapshot()
+  })
+
+  test('Should render properly without error', async () => {
+    // @ts-ignore
+    errorCheck.mockImplementation(() => false)
+    const { container } = render(getListInputComponent())
+
+    const queryByNameAttribute = (name: string): HTMLElement | null => queryByAttribute('name', container, name)
+
+    fireEvent.change(queryByNameAttribute('test.0')!, { target: { value: '<+pipeline.name>' } })
+    expect(container).toMatchSnapshot()
+  })
+})

--- a/src/modules/10-common/components/ExpressionsListInput/__tests__/__snapshots__/ExpressionListInput.test.tsx.snap
+++ b/src/modules/10-common/components/ExpressionsListInput/__tests__/__snapshots__/ExpressionListInput.test.tsx.snap
@@ -1,0 +1,311 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ExpressionsListInput tests Should render properly with error 1`] = `
+<div>
+  <div
+    class="OverlaySpinner--overlaySpinner"
+  >
+    <form
+      class="FormikForm--main"
+    >
+      <div>
+        <div
+          class="Layout--horizontal Layout--layout-spacing-small StyledProps--main StyledProps--flex StyledProps--flex-alignItems-center StyledProps--padding-bottom-small"
+        >
+          <div
+            class="bp3-form-group bp3-intent-danger expressionsInputContainer"
+            data-id="test.0-0"
+          >
+            <div
+              class="bp3-form-content"
+            >
+              <div
+                class="bp3-popover-wrapper"
+              >
+                <div
+                  class="bp3-popover-target"
+                >
+                  <div
+                    class="bp3-input-group"
+                  >
+                    <input
+                      autocomplete="off"
+                      class="bp3-input"
+                      name="test.0"
+                      placeholder="<+expression>"
+                      type="text"
+                      value="<+pipeline.name>"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <button
+            class="bp3-button bp3-minimal Button--button StyledProps--font StyledProps--main Button--with-current-color Button--iconOnly Button--without-shadow Button--withLeftIcon"
+            data-testid="remove-test-[0]"
+            type="button"
+          >
+            <span
+              class="bp3-icon StyledProps--main"
+              data-icon="main-trash"
+            >
+              <svg
+                height="22"
+                viewBox="0 0 16 20"
+                width="22"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  clip-rule="evenodd"
+                  d="M1.143 8.48a1.2 1.2 0 011.189-1.36h10.649a1.2 1.2 0 011.194 1.321l-1.039 10.208a1.2 1.2 0 01-1.193 1.079H3.716a1.2 1.2 0 01-1.189-1.04L1.143 8.48zm11.837-.16H2.332l1.385 10.207h8.226L12.98 8.32zM5.916 1.594a.6.6 0 01.719-.452l4.224.965a.6.6 0 01.452.719L11 4.179l3.86.882a.6.6 0 01-.267 1.17L1.535 3.248a.6.6 0 11.267-1.17l3.805.87.309-1.354zm.86 1.62l3.056.698.175-.768-3.055-.698-.175.768z"
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                />
+                <path
+                  clip-rule="evenodd"
+                  d="M8 10.808a.5.5 0 01.5.5v5a.5.5 0 01-1 0v-5a.5.5 0 01.5-.5zm-2.761.012a.5.5 0 01.541.454l.436 4.981a.5.5 0 11-.996.087l-.436-4.98a.5.5 0 01.455-.542zM10.762 10.82a.5.5 0 01.455.541l-.436 4.981a.5.5 0 11-.996-.087l.435-4.98a.5.5 0 01.542-.455z"
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  opacity="0.3"
+                />
+              </svg>
+            </span>
+          </button>
+        </div>
+        <div
+          class="Layout--horizontal Layout--layout-spacing-small StyledProps--main StyledProps--flex StyledProps--flex-alignItems-center StyledProps--padding-bottom-small"
+        >
+          <div
+            class="bp3-form-group bp3-intent-danger expressionsInputContainer"
+            data-id="test.1-1"
+          >
+            <div
+              class="bp3-form-content"
+            >
+              <div
+                class="bp3-popover-wrapper"
+              >
+                <div
+                  class="bp3-popover-target"
+                >
+                  <div
+                    class="bp3-input-group"
+                  >
+                    <input
+                      autocomplete="off"
+                      class="bp3-input"
+                      name="test.1"
+                      placeholder="<+expression>"
+                      type="text"
+                      value="Element 2"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <button
+            class="bp3-button bp3-minimal Button--button StyledProps--font StyledProps--main Button--with-current-color Button--iconOnly Button--without-shadow Button--withLeftIcon"
+            data-testid="remove-test-[1]"
+            type="button"
+          >
+            <span
+              class="bp3-icon StyledProps--main"
+              data-icon="main-trash"
+            >
+              <svg
+                height="22"
+                viewBox="0 0 16 20"
+                width="22"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  clip-rule="evenodd"
+                  d="M1.143 8.48a1.2 1.2 0 011.189-1.36h10.649a1.2 1.2 0 011.194 1.321l-1.039 10.208a1.2 1.2 0 01-1.193 1.079H3.716a1.2 1.2 0 01-1.189-1.04L1.143 8.48zm11.837-.16H2.332l1.385 10.207h8.226L12.98 8.32zM5.916 1.594a.6.6 0 01.719-.452l4.224.965a.6.6 0 01.452.719L11 4.179l3.86.882a.6.6 0 01-.267 1.17L1.535 3.248a.6.6 0 11.267-1.17l3.805.87.309-1.354zm.86 1.62l3.056.698.175-.768-3.055-.698-.175.768z"
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                />
+                <path
+                  clip-rule="evenodd"
+                  d="M8 10.808a.5.5 0 01.5.5v5a.5.5 0 01-1 0v-5a.5.5 0 01.5-.5zm-2.761.012a.5.5 0 01.541.454l.436 4.981a.5.5 0 11-.996.087l-.436-4.98a.5.5 0 01.455-.542zM10.762 10.82a.5.5 0 01.455.541l-.436 4.981a.5.5 0 11-.996-.087l.435-4.98a.5.5 0 01.542-.455z"
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  opacity="0.3"
+                />
+              </svg>
+            </span>
+          </button>
+        </div>
+        <button
+          class="bp3-button bp3-minimal Button--button StyledProps--font StyledProps--main StyledProps--intent-primary Button--with-current-color Button--without-shadow"
+          data-testid="add-test"
+          style="padding: 0px;"
+          type="button"
+        >
+          <span
+            class="bp3-button-text"
+          >
+            plusAdd
+          </span>
+        </button>
+      </div>
+    </form>
+  </div>
+</div>
+`;
+
+exports[`ExpressionsListInput tests Should render properly without error 1`] = `
+<div>
+  <div
+    class="OverlaySpinner--overlaySpinner"
+  >
+    <form
+      class="FormikForm--main"
+    >
+      <div>
+        <div
+          class="Layout--horizontal Layout--layout-spacing-small StyledProps--main StyledProps--flex StyledProps--flex-alignItems-center StyledProps--padding-bottom-small"
+        >
+          <div
+            class="bp3-form-group expressionsInputContainer"
+            data-id="test.0-0"
+          >
+            <div
+              class="bp3-form-content"
+            >
+              <div
+                class="bp3-popover-wrapper"
+              >
+                <div
+                  class="bp3-popover-target"
+                >
+                  <div
+                    class="bp3-input-group"
+                  >
+                    <input
+                      autocomplete="off"
+                      class="bp3-input"
+                      name="test.0"
+                      placeholder="<+expression>"
+                      type="text"
+                      value="<+pipeline.name>"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <button
+            class="bp3-button bp3-minimal Button--button StyledProps--font StyledProps--main Button--with-current-color Button--iconOnly Button--without-shadow Button--withLeftIcon"
+            data-testid="remove-test-[0]"
+            type="button"
+          >
+            <span
+              class="bp3-icon StyledProps--main"
+              data-icon="main-trash"
+            >
+              <svg
+                height="22"
+                viewBox="0 0 16 20"
+                width="22"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  clip-rule="evenodd"
+                  d="M1.143 8.48a1.2 1.2 0 011.189-1.36h10.649a1.2 1.2 0 011.194 1.321l-1.039 10.208a1.2 1.2 0 01-1.193 1.079H3.716a1.2 1.2 0 01-1.189-1.04L1.143 8.48zm11.837-.16H2.332l1.385 10.207h8.226L12.98 8.32zM5.916 1.594a.6.6 0 01.719-.452l4.224.965a.6.6 0 01.452.719L11 4.179l3.86.882a.6.6 0 01-.267 1.17L1.535 3.248a.6.6 0 11.267-1.17l3.805.87.309-1.354zm.86 1.62l3.056.698.175-.768-3.055-.698-.175.768z"
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                />
+                <path
+                  clip-rule="evenodd"
+                  d="M8 10.808a.5.5 0 01.5.5v5a.5.5 0 01-1 0v-5a.5.5 0 01.5-.5zm-2.761.012a.5.5 0 01.541.454l.436 4.981a.5.5 0 11-.996.087l-.436-4.98a.5.5 0 01.455-.542zM10.762 10.82a.5.5 0 01.455.541l-.436 4.981a.5.5 0 11-.996-.087l.435-4.98a.5.5 0 01.542-.455z"
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  opacity="0.3"
+                />
+              </svg>
+            </span>
+          </button>
+        </div>
+        <div
+          class="Layout--horizontal Layout--layout-spacing-small StyledProps--main StyledProps--flex StyledProps--flex-alignItems-center StyledProps--padding-bottom-small"
+        >
+          <div
+            class="bp3-form-group expressionsInputContainer"
+            data-id="test.1-1"
+          >
+            <div
+              class="bp3-form-content"
+            >
+              <div
+                class="bp3-popover-wrapper"
+              >
+                <div
+                  class="bp3-popover-target"
+                >
+                  <div
+                    class="bp3-input-group"
+                  >
+                    <input
+                      autocomplete="off"
+                      class="bp3-input"
+                      name="test.1"
+                      placeholder="<+expression>"
+                      type="text"
+                      value="Element 2"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <button
+            class="bp3-button bp3-minimal Button--button StyledProps--font StyledProps--main Button--with-current-color Button--iconOnly Button--without-shadow Button--withLeftIcon"
+            data-testid="remove-test-[1]"
+            type="button"
+          >
+            <span
+              class="bp3-icon StyledProps--main"
+              data-icon="main-trash"
+            >
+              <svg
+                height="22"
+                viewBox="0 0 16 20"
+                width="22"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  clip-rule="evenodd"
+                  d="M1.143 8.48a1.2 1.2 0 011.189-1.36h10.649a1.2 1.2 0 011.194 1.321l-1.039 10.208a1.2 1.2 0 01-1.193 1.079H3.716a1.2 1.2 0 01-1.189-1.04L1.143 8.48zm11.837-.16H2.332l1.385 10.207h8.226L12.98 8.32zM5.916 1.594a.6.6 0 01.719-.452l4.224.965a.6.6 0 01.452.719L11 4.179l3.86.882a.6.6 0 01-.267 1.17L1.535 3.248a.6.6 0 11.267-1.17l3.805.87.309-1.354zm.86 1.62l3.056.698.175-.768-3.055-.698-.175.768z"
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                />
+                <path
+                  clip-rule="evenodd"
+                  d="M8 10.808a.5.5 0 01.5.5v5a.5.5 0 01-1 0v-5a.5.5 0 01.5-.5zm-2.761.012a.5.5 0 01.541.454l.436 4.981a.5.5 0 11-.996.087l-.436-4.98a.5.5 0 01.455-.542zM10.762 10.82a.5.5 0 01.455.541l-.436 4.981a.5.5 0 11-.996-.087l.435-4.98a.5.5 0 01.542-.455z"
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  opacity="0.3"
+                />
+              </svg>
+            </span>
+          </button>
+        </div>
+        <button
+          class="bp3-button bp3-minimal Button--button StyledProps--font StyledProps--main StyledProps--intent-primary Button--with-current-color Button--without-shadow"
+          data-testid="add-test"
+          style="padding: 0px;"
+          type="button"
+        >
+          <span
+            class="bp3-button-text"
+          >
+            plusAdd
+          </span>
+        </button>
+      </div>
+    </form>
+  </div>
+</div>
+`;

--- a/src/modules/10-common/components/ListInput/ListInput.tsx
+++ b/src/modules/10-common/components/ListInput/ListInput.tsx
@@ -28,10 +28,17 @@ export function ListInput(props: ListInputProps) {
   const { name, elementList, readOnly, deleteIconProps, deleteBtnClassName, addBtnClassName, listItemRenderer } = props
   const { getString } = useStrings()
   const addBtnLabel = defaultTo(props.addBtnLabel, getString('plusAdd'))
+  const [count, setCount] = React.useState(0)
+
+  const handleItemRemove = (index: number, removeCallback: (index: number) => void) => {
+    removeCallback(index)
+    setCount(prevCount => prevCount + 1)
+  }
 
   return (
     <FieldArray
       name={name}
+      key={`${name}-${count}`}
       render={({ push, remove }) => (
         <>
           {map(elementList, (value: string, index: number) => (
@@ -46,7 +53,7 @@ export function ListInput(props: ListInputProps) {
                 icon="main-trash"
                 iconProps={{ ...deleteIconProps, size: 22 }}
                 minimal
-                onClick={() => remove(index)}
+                onClick={() => handleItemRemove(index, remove)}
                 data-testid={`remove-${name}-[${index}]`}
                 disabled={readOnly}
                 className={deleteBtnClassName}

--- a/src/modules/10-common/components/ListInput/ListInput.tsx
+++ b/src/modules/10-common/components/ListInput/ListInput.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import React from 'react'
+import { defaultTo, map } from 'lodash-es'
+import { FieldArray } from 'formik'
+import type { IconProps } from '@harness/uicore/dist/icons/Icon'
+import { Button, Layout } from '@wings-software/uicore'
+import { useStrings } from 'framework/strings'
+
+export interface ListInputProps {
+  name: string
+  elementList: string[]
+  readOnly?: boolean
+  defaultValueToReset?: string[]
+  addBtnLabel?: string
+  deleteIconProps?: IconProps
+  deleteBtnClassName?: string
+  addBtnClassName?: string
+  listItemRenderer(value: string, index: number): React.ReactNode
+}
+
+export function ListInput(props: ListInputProps) {
+  const { name, elementList, readOnly, deleteIconProps, deleteBtnClassName, addBtnClassName, listItemRenderer } = props
+  const { getString } = useStrings()
+  const addBtnLabel = defaultTo(props.addBtnLabel, getString('plusAdd'))
+
+  return (
+    <FieldArray
+      name={name}
+      render={({ push, remove }) => (
+        <>
+          {map(elementList, (value: string, index: number) => (
+            <Layout.Horizontal
+              key={index}
+              flex={{ alignItems: 'center' }}
+              spacing="small"
+              padding={{ bottom: 'small' }}
+            >
+              {listItemRenderer(value, index)}
+              <Button
+                icon="main-trash"
+                iconProps={{ ...deleteIconProps, size: 22 }}
+                minimal
+                onClick={() => remove(index)}
+                data-testid={`remove-${name}-[${index}]`}
+                disabled={readOnly}
+                className={deleteBtnClassName}
+              />
+            </Layout.Horizontal>
+          ))}
+          <Button
+            intent="primary"
+            minimal
+            text={addBtnLabel}
+            data-testid={`add-${name}`}
+            onClick={() => push('')}
+            disabled={readOnly}
+            style={{ padding: 0 }}
+            className={addBtnClassName}
+          />
+        </>
+      )}
+    />
+  )
+}

--- a/src/modules/10-common/components/ListInput/__tests__/ListInput.test.tsx
+++ b/src/modules/10-common/components/ListInput/__tests__/ListInput.test.tsx
@@ -7,10 +7,10 @@
 
 import React from 'react'
 import { render, act, fireEvent } from '@testing-library/react'
+import { Formik, FormikForm } from '@wings-software/uicore'
 import { TestWrapper } from '@common/utils/testUtils'
 
 import { ListInput } from '../ListInput'
-import { Formik, FormikForm } from '@wings-software/uicore'
 
 const getListInputComponent = () => (
   <TestWrapper>

--- a/src/modules/10-common/components/ListInput/__tests__/ListInput.test.tsx
+++ b/src/modules/10-common/components/ListInput/__tests__/ListInput.test.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import React from 'react'
+import { render, act, fireEvent } from '@testing-library/react'
+import { TestWrapper } from '@common/utils/testUtils'
+
+import { ListInput } from '../ListInput'
+import { Formik, FormikForm } from '@wings-software/uicore'
+
+const getListInputComponent = () => (
+  <TestWrapper>
+    {/* eslint-disable-next-line @typescript-eslint/no-empty-function */}
+    <Formik initialValues={{ test: ['Element 1', 'Element 2'] }} onSubmit={() => {}} formName="TestWrapper">
+      <FormikForm>
+        <ListInput name="test" elementList={['Element 1', 'Element 2']} listItemRenderer={val => <div>{val}</div>} />
+      </FormikForm>
+    </Formik>
+  </TestWrapper>
+)
+
+describe('ListInput tests', () => {
+  test('Should render properly', async () => {
+    const { getByTestId, container, debug } = render(getListInputComponent())
+
+    await act(async () => {
+      const addBtn = getByTestId('add-test')
+      expect(addBtn).toBeTruthy()
+      fireEvent.click(addBtn)
+    })
+
+    await act(async () => {
+      const removeBtn = getByTestId('remove-test-[1]')
+      expect(removeBtn).toBeTruthy()
+      fireEvent.click(removeBtn)
+    })
+
+    expect(container).toMatchSnapshot()
+
+    debug()
+  })
+})

--- a/src/modules/10-common/components/ListInput/__tests__/__snapshots__/ListInput.test.tsx.snap
+++ b/src/modules/10-common/components/ListInput/__tests__/__snapshots__/ListInput.test.tsx.snap
@@ -1,0 +1,104 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ListInput tests Should render properly 1`] = `
+<div>
+  <div
+    class="OverlaySpinner--overlaySpinner"
+  >
+    <form
+      class="FormikForm--main"
+    >
+      <div>
+        <div
+          class="Layout--horizontal Layout--layout-spacing-small StyledProps--main StyledProps--flex StyledProps--flex-alignItems-center StyledProps--padding-bottom-small"
+        >
+          <div>
+            Element 1
+          </div>
+          <button
+            class="bp3-button bp3-minimal Button--button StyledProps--font StyledProps--main Button--with-current-color Button--iconOnly Button--without-shadow Button--withLeftIcon"
+            data-testid="remove-test-[0]"
+            type="button"
+          >
+            <span
+              class="bp3-icon StyledProps--main"
+              data-icon="main-trash"
+            >
+              <svg
+                height="22"
+                viewBox="0 0 16 20"
+                width="22"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  clip-rule="evenodd"
+                  d="M1.143 8.48a1.2 1.2 0 011.189-1.36h10.649a1.2 1.2 0 011.194 1.321l-1.039 10.208a1.2 1.2 0 01-1.193 1.079H3.716a1.2 1.2 0 01-1.189-1.04L1.143 8.48zm11.837-.16H2.332l1.385 10.207h8.226L12.98 8.32zM5.916 1.594a.6.6 0 01.719-.452l4.224.965a.6.6 0 01.452.719L11 4.179l3.86.882a.6.6 0 01-.267 1.17L1.535 3.248a.6.6 0 11.267-1.17l3.805.87.309-1.354zm.86 1.62l3.056.698.175-.768-3.055-.698-.175.768z"
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                />
+                <path
+                  clip-rule="evenodd"
+                  d="M8 10.808a.5.5 0 01.5.5v5a.5.5 0 01-1 0v-5a.5.5 0 01.5-.5zm-2.761.012a.5.5 0 01.541.454l.436 4.981a.5.5 0 11-.996.087l-.436-4.98a.5.5 0 01.455-.542zM10.762 10.82a.5.5 0 01.455.541l-.436 4.981a.5.5 0 11-.996-.087l.435-4.98a.5.5 0 01.542-.455z"
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  opacity="0.3"
+                />
+              </svg>
+            </span>
+          </button>
+        </div>
+        <div
+          class="Layout--horizontal Layout--layout-spacing-small StyledProps--main StyledProps--flex StyledProps--flex-alignItems-center StyledProps--padding-bottom-small"
+        >
+          <div>
+            Element 2
+          </div>
+          <button
+            class="bp3-button bp3-minimal Button--button StyledProps--font StyledProps--main Button--with-current-color Button--iconOnly Button--without-shadow Button--withLeftIcon"
+            data-testid="remove-test-[1]"
+            type="button"
+          >
+            <span
+              class="bp3-icon StyledProps--main"
+              data-icon="main-trash"
+            >
+              <svg
+                height="22"
+                viewBox="0 0 16 20"
+                width="22"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  clip-rule="evenodd"
+                  d="M1.143 8.48a1.2 1.2 0 011.189-1.36h10.649a1.2 1.2 0 011.194 1.321l-1.039 10.208a1.2 1.2 0 01-1.193 1.079H3.716a1.2 1.2 0 01-1.189-1.04L1.143 8.48zm11.837-.16H2.332l1.385 10.207h8.226L12.98 8.32zM5.916 1.594a.6.6 0 01.719-.452l4.224.965a.6.6 0 01.452.719L11 4.179l3.86.882a.6.6 0 01-.267 1.17L1.535 3.248a.6.6 0 11.267-1.17l3.805.87.309-1.354zm.86 1.62l3.056.698.175-.768-3.055-.698-.175.768z"
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                />
+                <path
+                  clip-rule="evenodd"
+                  d="M8 10.808a.5.5 0 01.5.5v5a.5.5 0 01-1 0v-5a.5.5 0 01.5-.5zm-2.761.012a.5.5 0 01.541.454l.436 4.981a.5.5 0 11-.996.087l-.436-4.98a.5.5 0 01.455-.542zM10.762 10.82a.5.5 0 01.455.541l-.436 4.981a.5.5 0 11-.996-.087l.435-4.98a.5.5 0 01.542-.455z"
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  opacity="0.3"
+                />
+              </svg>
+            </span>
+          </button>
+        </div>
+        <button
+          class="bp3-button bp3-minimal Button--button StyledProps--font StyledProps--main StyledProps--intent-primary Button--with-current-color Button--without-shadow"
+          data-testid="add-test"
+          style="padding: 0px;"
+          type="button"
+        >
+          <span
+            class="bp3-button-text"
+          >
+            plusAdd
+          </span>
+        </button>
+      </div>
+    </form>
+  </div>
+</div>
+`;

--- a/src/modules/10-common/components/MultiTypeDelegateSelector/MultiTypeDelegateSelector.module.scss
+++ b/src/modules/10-common/components/MultiTypeDelegateSelector/MultiTypeDelegateSelector.module.scss
@@ -9,3 +9,12 @@
   flex: 1 0 auto;
   min-width: 0;
 }
+
+.fieldSelectorContainer {
+  :global {
+    .bp3-disabled input {
+      border-color: var(--grey-200) !important;
+      box-shadow: none !important;
+    }
+  }
+}

--- a/src/modules/10-common/components/MultiTypeDelegateSelector/MultiTypeDelegateSelector.module.scss.d.ts
+++ b/src/modules/10-common/components/MultiTypeDelegateSelector/MultiTypeDelegateSelector.module.scss.d.ts
@@ -7,6 +7,7 @@
  **/
 // this is an auto-generated file, do not update this manually
 declare const styles: {
+  readonly fieldSelectorContainer: string
   readonly wrapper: string
 }
 export default styles

--- a/src/modules/10-common/components/MultiTypeDelegateSelector/MultiTypeDelegateSelector.tsx
+++ b/src/modules/10-common/components/MultiTypeDelegateSelector/MultiTypeDelegateSelector.tsx
@@ -11,7 +11,8 @@ import {
   FormikTooltipContext,
   DataTooltipInterface,
   MultiTypeInputType,
-  HarnessDocTooltip
+  HarnessDocTooltip,
+  Container
 } from '@wings-software/uicore'
 import { get } from 'lodash-es'
 import { FormGroup, IFormGroupProps, Intent } from '@blueprintjs/core'
@@ -60,6 +61,10 @@ export function MultiTypeDelegateSelector(props: ConnectedMultiTypeDelegateSelec
     ...rest
   } = restProps
 
+  const handleDelegateSelectorFixedValueChange = React.useCallback((tags: string[]) => {
+    formik.setFieldValue(name, tags)
+  }, [])
+
   const tooltipContext = React.useContext(FormikTooltipContext)
   const dataTooltipId =
     props.tooltipProps?.dataTooltipId || (tooltipContext?.formName ? `${tooltipContext?.formName}_${name}` : '')
@@ -72,26 +77,34 @@ export function MultiTypeDelegateSelector(props: ConnectedMultiTypeDelegateSelec
       intent={intent}
       helperText={helperText}
     >
-      <MultiTypeFieldSelector
-        name={name}
-        label={getString('common.defineDelegateSelector')}
-        defaultValueToReset={['']}
-        skipRenderValueInExpressionLabel
-        allowedTypes={allowableTypes}
-        expressionRender={() => (
-          <ExpressionsListInput
-            name={name}
-            value={value}
-            readOnly={disabled}
-            expressions={expressions}
-            formikProps={formik}
+      <Container className={css.fieldSelectorContainer}>
+        <MultiTypeFieldSelector
+          name={name}
+          label={getString('common.defineDelegateSelector')}
+          defaultValueToReset={['']}
+          skipRenderValueInExpressionLabel
+          allowedTypes={allowableTypes}
+          disableMultiSelectBtn={disabled}
+          expressionRender={() => (
+            <ExpressionsListInput
+              name={name}
+              value={value}
+              readOnly={disabled}
+              expressions={expressions}
+              formikProps={formik}
+            />
+          )}
+          style={{ flexGrow: 1, marginBottom: 0 }}
+        >
+          <DelegateSelectors
+            {...inputProps}
+            wrapperClassName={css.wrapper}
+            selectedItems={value}
+            readonly={disabled}
+            onTagInputChange={handleDelegateSelectorFixedValueChange}
           />
-        )}
-        style={{ flexGrow: 1, marginBottom: 0 }}
-        disableTypeSelection={disabled}
-      >
-        <DelegateSelectors {...inputProps} wrapperClassName={css.wrapper} selectedItems={value} readonly={disabled} />
-      </MultiTypeFieldSelector>
+        </MultiTypeFieldSelector>
+      </Container>
     </FormGroup>
   )
 }

--- a/src/modules/10-common/components/MultiTypeDelegateSelector/MultiTypeDelegateSelector.tsx
+++ b/src/modules/10-common/components/MultiTypeDelegateSelector/MultiTypeDelegateSelector.tsx
@@ -8,17 +8,17 @@
 import React from 'react'
 import { connect, FormikContext } from 'formik'
 import {
-  DataTooltipInterface,
-  ExpressionAndRuntimeType,
-  ExpressionAndRuntimeTypeProps,
   FormikTooltipContext,
-  HarnessDocTooltip,
-  MultiTypeInputType
+  DataTooltipInterface,
+  MultiTypeInputType,
+  HarnessDocTooltip
 } from '@wings-software/uicore'
 import { get } from 'lodash-es'
 import { FormGroup, IFormGroupProps, Intent } from '@blueprintjs/core'
-
+import { useStrings } from 'framework/strings'
 import { errorCheck } from '@common/utils/formikHelpers'
+import MultiTypeFieldSelector from '@common/components/MultiTypeFieldSelector/MultiTypeFieldSelector'
+import { ExpressionsListInput } from '@common/components/ExpressionsListInput/ExpressionsListInput'
 import { DelegateSelectors, DelegateSelectorsProps } from '@common/components/DelegateSelectors/DelegateSelectors'
 
 import css from './MultiTypeDelegateSelector.module.scss'
@@ -38,10 +38,20 @@ export interface ConnectedMultiTypeDelegateSelectorProps extends MultiTypeDelega
 }
 
 export function MultiTypeDelegateSelector(props: ConnectedMultiTypeDelegateSelectorProps): React.ReactElement {
-  const { formik, label, name, expressions = [], inputProps, ...restProps } = props
+  const {
+    formik,
+    allowableTypes = [MultiTypeInputType.FIXED, MultiTypeInputType.RUNTIME, MultiTypeInputType.EXPRESSION],
+    label,
+    name,
+    expressions = [],
+    inputProps,
+    ...restProps
+  } = props
 
   const value = get(formik.values, name)
   const hasError = errorCheck(name, formik)
+
+  const { getString } = useStrings()
 
   const {
     intent = hasError ? Intent.DANGER : Intent.NONE,
@@ -50,9 +60,6 @@ export function MultiTypeDelegateSelector(props: ConnectedMultiTypeDelegateSelec
     ...rest
   } = restProps
 
-  const handleChange: ExpressionAndRuntimeTypeProps['onChange'] = val => {
-    formik.setFieldValue(name, val)
-  }
   const tooltipContext = React.useContext(FormikTooltipContext)
   const dataTooltipId =
     props.tooltipProps?.dataTooltipId || (tooltipContext?.formName ? `${tooltipContext?.formName}_${name}` : '')
@@ -65,23 +72,26 @@ export function MultiTypeDelegateSelector(props: ConnectedMultiTypeDelegateSelec
       intent={intent}
       helperText={helperText}
     >
-      <ExpressionAndRuntimeType
+      <MultiTypeFieldSelector
         name={name}
-        value={value}
-        disabled={disabled}
-        onChange={handleChange}
-        expressions={expressions}
-        style={{ flexGrow: 1 }}
-        fixedTypeComponentProps={{
-          ...inputProps,
-          wrapperClassName: css.wrapper,
-          selectedItems: value,
-          readonly: disabled
-        }}
-        fixedTypeComponent={DelegateSelectors as any}
-        defaultValueToReset={[]}
-        allowableTypes={props.allowableTypes}
-      />
+        label={getString('common.defineDelegateSelector')}
+        defaultValueToReset={['']}
+        skipRenderValueInExpressionLabel
+        allowedTypes={allowableTypes}
+        expressionRender={() => (
+          <ExpressionsListInput
+            name={name}
+            value={value}
+            readOnly={disabled}
+            expressions={expressions}
+            formikProps={formik}
+          />
+        )}
+        style={{ flexGrow: 1, marginBottom: 0 }}
+        disableTypeSelection={disabled}
+      >
+        <DelegateSelectors {...inputProps} wrapperClassName={css.wrapper} selectedItems={value} readonly={disabled} />
+      </MultiTypeFieldSelector>
     </FormGroup>
   )
 }

--- a/src/modules/10-common/components/MultiTypeDelegateSelector/MultiTypeDelegateSelector.tsx
+++ b/src/modules/10-common/components/MultiTypeDelegateSelector/MultiTypeDelegateSelector.tsx
@@ -14,7 +14,7 @@ import {
   HarnessDocTooltip,
   Container
 } from '@wings-software/uicore'
-import { get } from 'lodash-es'
+import { get, compact } from 'lodash-es'
 import { FormGroup, IFormGroupProps, Intent } from '@blueprintjs/core'
 import { useStrings } from 'framework/strings'
 import { errorCheck } from '@common/utils/formikHelpers'
@@ -62,7 +62,7 @@ export function MultiTypeDelegateSelector(props: ConnectedMultiTypeDelegateSelec
   } = restProps
 
   const handleDelegateSelectorFixedValueChange = React.useCallback((tags: string[]) => {
-    formik.setFieldValue(name, tags)
+    formik.setFieldValue(name, compact(tags))
   }, [])
 
   const tooltipContext = React.useContext(FormikTooltipContext)
@@ -86,13 +86,7 @@ export function MultiTypeDelegateSelector(props: ConnectedMultiTypeDelegateSelec
           allowedTypes={allowableTypes}
           disableMultiSelectBtn={disabled}
           expressionRender={() => (
-            <ExpressionsListInput
-              name={name}
-              value={value}
-              readOnly={disabled}
-              expressions={expressions}
-              formikProps={formik}
-            />
+            <ExpressionsListInput name={name} value={value} readOnly={disabled} expressions={expressions} />
           )}
           style={{ flexGrow: 1, marginBottom: 0 }}
         >

--- a/src/modules/10-common/components/MultiTypeFieldSelector/MultiTypeFieldSelector.tsx
+++ b/src/modules/10-common/components/MultiTypeFieldSelector/MultiTypeFieldSelector.tsx
@@ -37,6 +37,7 @@ export interface MultiTypeFieldSelectorProps extends Omit<IFormGroupProps, 'labe
   isOptional?: boolean
   optionalLabel?: string
   tooltipProps?: DataTooltipInterface
+  disableMultiSelectBtn?: boolean
 }
 
 export interface ConnectedMultiTypeFieldSelectorProps extends MultiTypeFieldSelectorProps {
@@ -55,6 +56,7 @@ export function MultiTypeFieldSelector(props: ConnectedMultiTypeFieldSelectorPro
     expressionRender,
     skipRenderValueInExpressionLabel,
     isOptional,
+    disableMultiSelectBtn,
     optionalLabel = '(optional)',
     ...restProps
   } = props
@@ -96,7 +98,12 @@ export function MultiTypeFieldSelector(props: ConnectedMultiTypeFieldSelectorPro
         <div className={css.formLabel}>
           <HarnessDocTooltip tooltipId={dataTooltipId} labelText={labelText} />
           {disableTypeSelection ? null : (
-            <MultiTypeSelectorButton allowedTypes={allowedTypes} type={type} onChange={handleChange} />
+            <MultiTypeSelectorButton
+              allowedTypes={allowedTypes}
+              type={type}
+              onChange={handleChange}
+              disabled={disableMultiSelectBtn}
+            />
           )}
         </div>
       }

--- a/src/modules/10-common/components/MultiTypeFieldSelector/MultiTypeFieldSelector.tsx
+++ b/src/modules/10-common/components/MultiTypeFieldSelector/MultiTypeFieldSelector.tsx
@@ -38,6 +38,8 @@ export interface MultiTypeFieldSelectorProps extends Omit<IFormGroupProps, 'labe
   optionalLabel?: string
   tooltipProps?: DataTooltipInterface
   disableMultiSelectBtn?: boolean
+  hideError?: boolean
+  onTypeChange?: (newType: MultiTypeInputType) => void
 }
 
 export interface ConnectedMultiTypeFieldSelectorProps extends MultiTypeFieldSelectorProps {
@@ -57,15 +59,18 @@ export function MultiTypeFieldSelector(props: ConnectedMultiTypeFieldSelectorPro
     skipRenderValueInExpressionLabel,
     isOptional,
     disableMultiSelectBtn,
+    hideError,
+    onTypeChange,
     optionalLabel = '(optional)',
     ...restProps
   } = props
   const error = get(formik?.errors, name)
   const hasError = errorCheck(name, formik) && typeof error === 'string'
+  const showError = hasError && !hideError
   const labelText = !isOptional ? label : `${label} ${optionalLabel}`
   const {
-    intent = hasError ? Intent.DANGER : Intent.NONE,
-    helperText = hasError ? <FormError name={name} errorMessage={get(formik?.errors, name)} /> : null,
+    intent = showError ? Intent.DANGER : Intent.NONE,
+    helperText = showError ? <FormError name={name} errorMessage={get(formik?.errors, name)} /> : null,
     disabled,
     ...rest
   } = restProps
@@ -80,6 +85,7 @@ export function MultiTypeFieldSelector(props: ConnectedMultiTypeFieldSelectorPro
 
   function handleChange(newType: MultiTypeInputType): void {
     setType(newType)
+    onTypeChange?.(newType)
     if (newType === type) return
     formik.setFieldValue(name, newType === MultiTypeInputType.RUNTIME ? RUNTIME_INPUT_VALUE : defaultValueToReset)
   }

--- a/src/modules/10-common/components/UserGroupsInput/UserGroupsInput.tsx
+++ b/src/modules/10-common/components/UserGroupsInput/UserGroupsInput.tsx
@@ -80,9 +80,11 @@ const UserGroupsInput: React.FC<FormikUserGroupsInput> = props => {
   useEffect(() => {
     if (userGroupsReference && userGroupsReference.length) {
       setUserGroupsScopeAndIndentifier(
-        userGroupsReference.map(el => {
-          return { scope: getScopeFromValue(el), identifier: getIdentifierFromValue(el) }
-        })
+        userGroupsReference
+          .filter(userGroupStr => !!userGroupStr)
+          .map(el => {
+            return { scope: getScopeFromValue(el), identifier: getIdentifierFromValue(el) }
+          })
       )
     }
   }, [userGroupsReference])

--- a/src/modules/10-common/strings/strings.en.yaml
+++ b/src/modules/10-common/strings/strings.en.yaml
@@ -15,6 +15,7 @@ accountSetup: Account Setup
 projectSetup: Project Setup
 orgSetup: Org Setup
 delegateForTask: '{{delegate}} for {{taskName}}'
+defineDelegateSelector: 'Define Delegate Selector'
 noDelegateForTask: 'No delegate found for {{taskName}}'
 gitDetailsTitle: 'Git Details'
 lastConnected: 'Last Connected'

--- a/src/modules/70-pipeline/components/PipelineInputSetForm/StageInputSetForm.tsx
+++ b/src/modules/70-pipeline/components/PipelineInputSetForm/StageInputSetForm.tsx
@@ -141,7 +141,7 @@ function StepFormInternal({
       />
       {getMultiTypeFromValue((template?.step as StepElementConfig)?.spec?.delegateSelectors) ===
         MultiTypeInputType.RUNTIME && (
-        <div className={cx(stepCss.formGroup, stepCss.sm)}>
+        <div className={cx(stepCss.formGroup, stepCss.md)}>
           <MultiTypeDelegateSelector
             expressions={expressions}
             inputProps={{ projectIdentifier, orgIdentifier }}
@@ -153,7 +153,7 @@ function StepFormInternal({
         </div>
       )}
       {getMultiTypeFromValue((template?.step as StepElementConfig)?.when?.condition) === MultiTypeInputType.RUNTIME && (
-        <Container padding={{ left: 'xlarge' }} className={cx(stepCss.formGroup, stepCss.sm)}>
+        <Container className={cx(stepCss.formGroup, stepCss.md)}>
           <ConditionalExecutionForm
             readonly={readonly}
             path={`${path}.when.condition`}

--- a/src/modules/70-pipeline/components/PipelineSteps/AdvancedSteps/DelegateSelectorPanel/__tests__/__snapshots__/DelegateSelectorPanel.test.tsx.snap
+++ b/src/modules/70-pipeline/components/PipelineSteps/AdvancedSteps/DelegateSelectorPanel/__tests__/__snapshots__/DelegateSelectorPanel.test.tsx.snap
@@ -11,126 +11,187 @@ exports[`<DelegateSelectorPanel /> test should be able to select multiple tags f
       <div>
         <div
           class="bp3-form-group"
-          data-id="undefined-0"
+          data-id="delegateSelectors-0"
         >
           <div
             class="bp3-form-content"
           >
             <div
-              class="Layout--horizontal StyledProps--main MultiTypeInput--main"
-              style="flex-grow: 1;"
+              class="StyledProps--font StyledProps--main fieldSelectorContainer"
             >
               <div
-                class="wrapper wrapper"
-                data-name="DelegateSelectors"
+                class="bp3-form-group"
+                data-id="delegateSelectors-1"
+                style="flex-grow: 1; margin-bottom: 0px;"
               >
-                <div
-                  class="bp3-popover-wrapper TagInput--tagInput delegatePopover bp3-fill"
+                <label
+                  class="bp3-label"
+                  for="delegateSelectors"
                 >
                   <div
-                    class="bp3-popover-target bp3-popover-open"
+                    class="formLabel"
                   >
+                    <span
+                      class="Tooltip--acenter"
+                      data-tooltip-id="delegateSelectorPanelForm_delegateSelectors"
+                    >
+                      common.defineDelegateSelector
+                    </span>
                     <div
-                      class=""
+                      class="bp3-popover-wrapper typeSelectorWrapper"
                     >
                       <div
-                        class="bp3-input bp3-tag-input bp3-fill bp3-multi-select"
+                        class="bp3-popover-target typeSelector"
                       >
-                        <div
-                          class="bp3-tag-input-values"
+                        <button
+                          class="bp3-button bp3-minimal Button--button StyledProps--font StyledProps--main btn Button--iconOnly Button--without-shadow"
+                          type="button"
                         >
                           <span
-                            class="bp3-tag bp3-intent-danger bp3-minimal TagInput--tag"
-                            data-tag-index="0"
+                            class="bp3-button-text"
                           >
                             <span
-                              class="bp3-text-overflow-ellipsis bp3-fill"
+                              class="bp3-icon StyledProps--main icon fixed"
+                              data-icon="fixed-input"
                             >
-                              harness-sample-k8s-delegate
-                            </span>
-                            <button
-                              class="bp3-tag-remove"
-                              type="button"
-                            >
-                              <span
-                                class="bp3-icon bp3-icon-small-cross"
-                                icon="small-cross"
+                              <svg
+                                height="12"
+                                viewBox="0 0 9 9"
+                                width="12"
+                                xmlns="http://www.w3.org/2000/svg"
                               >
-                                <svg
-                                  data-icon="small-cross"
-                                  height="16"
-                                  viewBox="0 0 16 16"
-                                  width="16"
-                                >
-                                  <desc>
-                                    small-cross
-                                  </desc>
-                                  <path
-                                    d="M9.41 8l2.29-2.29c.19-.18.3-.43.3-.71a1.003 1.003 0 00-1.71-.71L8 6.59l-2.29-2.3a1.003 1.003 0 00-1.42 1.42L6.59 8 4.3 10.29c-.19.18-.3.43-.3.71a1.003 1.003 0 001.71.71L8 9.41l2.29 2.29c.18.19.43.3.71.3a1.003 1.003 0 00.71-1.71L9.41 8z"
-                                    fill-rule="evenodd"
-                                  />
-                                </svg>
-                              </span>
-                            </button>
+                                <path
+                                  d="M5.61 7.55c.62-.7.3-1.42.18-2.35a.32.32 0 01.1-.29l1.43-1.42a.76.76 0 01.28-.15c.39-.1 1 0 1.28-.29a.34.34 0 000-.51L6.46.12a.33.33 0 00-.52 0c-.28.29-.2.9-.28 1.3a.53.53 0 01-.13.23L4.09 3.12a.29.29 0 01-.28.09c-.89-.11-1.6-.49-2.27.11-.29.26-.29.43 0 .7l1.31 1.34.15.16-.15.15-2.7 2.69a.36.36 0 000 .54.36.36 0 00.54-.05l2.63-2.68.17-.17.17.16c.45.46.9.91 1.36 1.36.21.21.42.22.59.03z"
+                                  fill="currentColor"
+                                />
+                              </svg>
+                            </span>
                           </span>
-                          <input
-                            class="bp3-input-ghost bp3-multi-select-tag-input-input"
-                            value="new-tag"
-                          />
-                        </div>
+                        </button>
                       </div>
                     </div>
                   </div>
+                   
+                  <span
+                    class="bp3-text-muted"
+                  />
+                </label>
+                <div
+                  class="bp3-form-content"
+                >
                   <div
-                    class="bp3-overlay bp3-overlay-open bp3-overlay-inline"
+                    class="wrapper wrapper"
+                    data-name="DelegateSelectors"
                   >
                     <div
-                      class="bp3-transition-container bp3-popover-appear bp3-popover-appear-active"
-                      style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+                      class="bp3-popover-wrapper TagInput--tagInput delegatePopover bp3-fill"
                     >
                       <div
-                        class="bp3-popover bp3-minimal bp3-multi-select-popover"
+                        class="bp3-popover-target bp3-popover-open"
                       >
                         <div
-                          class="bp3-popover-content"
+                          class=""
                         >
-                          <div>
-                            <ul
-                              class="bp3-menu"
+                          <div
+                            class="bp3-input bp3-tag-input bp3-fill bp3-multi-select"
+                          >
+                            <div
+                              class="bp3-tag-input-values"
                             >
-                              <li
-                                class=""
+                              <span
+                                class="bp3-tag bp3-intent-danger bp3-minimal TagInput--tag"
+                                data-tag-index="0"
                               >
-                                <a
-                                  class="bp3-menu-item bp3-popover-dismiss"
+                                <span
+                                  class="bp3-text-overflow-ellipsis bp3-fill"
+                                >
+                                  harness-sample-k8s-delegate
+                                </span>
+                                <button
+                                  class="bp3-tag-remove"
+                                  type="button"
                                 >
                                   <span
-                                    class="bp3-icon bp3-icon-add"
-                                    icon="add"
+                                    class="bp3-icon bp3-icon-small-cross"
+                                    icon="small-cross"
                                   >
                                     <svg
-                                      data-icon="add"
+                                      data-icon="small-cross"
                                       height="16"
                                       viewBox="0 0 16 16"
                                       width="16"
                                     >
                                       <desc>
-                                        add
+                                        small-cross
                                       </desc>
                                       <path
-                                        d="M10.99 6.99h-2v-2c0-.55-.45-1-1-1s-1 .45-1 1v2h-2c-.55 0-1 .45-1 1s.45 1 1 1h2v2c0 .55.45 1 1 1s1-.45 1-1v-2h2c.55 0 1-.45 1-1s-.45-1-1-1zm-3-7c-4.42 0-8 3.58-8 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6s2.69-6 6-6 6 2.69 6 6-2.68 6-6 6z"
+                                        d="M9.41 8l2.29-2.29c.19-.18.3-.43.3-.71a1.003 1.003 0 00-1.71-.71L8 6.59l-2.29-2.3a1.003 1.003 0 00-1.42 1.42L6.59 8 4.3 10.29c-.19.18-.3.43-.3.71a1.003 1.003 0 001.71.71L8 9.41l2.29 2.29c.18.19.43.3.71.3a1.003 1.003 0 00.71-1.71L9.41 8z"
                                         fill-rule="evenodd"
                                       />
                                     </svg>
                                   </span>
-                                  <div
-                                    class="bp3-text-overflow-ellipsis bp3-fill"
+                                </button>
+                              </span>
+                              <input
+                                class="bp3-input-ghost bp3-multi-select-tag-input-input"
+                                value="new-tag"
+                              />
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        class="bp3-overlay bp3-overlay-open bp3-overlay-inline"
+                      >
+                        <div
+                          class="bp3-transition-container bp3-popover-appear bp3-popover-appear-active"
+                          style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+                        >
+                          <div
+                            class="bp3-popover bp3-minimal bp3-multi-select-popover"
+                          >
+                            <div
+                              class="bp3-popover-content"
+                            >
+                              <div>
+                                <ul
+                                  class="bp3-menu"
+                                >
+                                  <li
+                                    class=""
                                   >
-                                    Create "new-tag"
-                                  </div>
-                                </a>
-                              </li>
-                            </ul>
+                                    <a
+                                      class="bp3-menu-item bp3-popover-dismiss"
+                                    >
+                                      <span
+                                        class="bp3-icon bp3-icon-add"
+                                        icon="add"
+                                      >
+                                        <svg
+                                          data-icon="add"
+                                          height="16"
+                                          viewBox="0 0 16 16"
+                                          width="16"
+                                        >
+                                          <desc>
+                                            add
+                                          </desc>
+                                          <path
+                                            d="M10.99 6.99h-2v-2c0-.55-.45-1-1-1s-1 .45-1 1v2h-2c-.55 0-1 .45-1 1s.45 1 1 1h2v2c0 .55.45 1 1 1s1-.45 1-1v-2h2c.55 0 1-.45 1-1s-.45-1-1-1zm-3-7c-4.42 0-8 3.58-8 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6s2.69-6 6-6 6 2.69 6 6-2.68 6-6 6z"
+                                            fill-rule="evenodd"
+                                          />
+                                        </svg>
+                                      </span>
+                                      <div
+                                        class="bp3-text-overflow-ellipsis bp3-fill"
+                                      >
+                                        Create "new-tag"
+                                      </div>
+                                    </a>
+                                  </li>
+                                </ul>
+                              </div>
+                            </div>
                           </div>
                         </div>
                       </div>
@@ -138,34 +199,6 @@ exports[`<DelegateSelectorPanel /> test should be able to select multiple tags f
                   </div>
                 </div>
               </div>
-              <span
-                class="bp3-popover-wrapper MultiTypeInput--wrapper"
-              >
-                <span
-                  class="bp3-popover-target"
-                >
-                  <button
-                    class="MultiTypeInput--btn MultiTypeInput--FIXED"
-                  >
-                    <span
-                      class="bp3-icon StyledProps--main"
-                      data-icon="fixed-input"
-                    >
-                      <svg
-                        height="12"
-                        viewBox="0 0 9 9"
-                        width="12"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M5.61 7.55c.62-.7.3-1.42.18-2.35a.32.32 0 01.1-.29l1.43-1.42a.76.76 0 01.28-.15c.39-.1 1 0 1.28-.29a.34.34 0 000-.51L6.46.12a.33.33 0 00-.52 0c-.28.29-.2.9-.28 1.3a.53.53 0 01-.13.23L4.09 3.12a.29.29 0 01-.28.09c-.89-.11-1.6-.49-2.27.11-.29.26-.29.43 0 .7l1.31 1.34.15.16-.15.15-2.7 2.69a.36.36 0 000 .54.36.36 0 00.54-.05l2.63-2.68.17-.17.17.16c.45.46.9.91 1.36 1.36.21.21.42.22.59.03z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                    </span>
-                  </button>
-                </span>
-              </span>
             </div>
           </div>
         </div>
@@ -186,106 +219,139 @@ exports[`<DelegateSelectorPanel /> test snapshot testing 1`] = `
       <div>
         <div
           class="bp3-form-group"
-          data-id="undefined-0"
+          data-id="delegateSelectors-0"
         >
           <div
             class="bp3-form-content"
           >
             <div
-              class="Layout--horizontal StyledProps--main MultiTypeInput--main"
-              style="flex-grow: 1;"
+              class="StyledProps--font StyledProps--main fieldSelectorContainer"
             >
               <div
-                class="wrapper wrapper"
-                data-name="DelegateSelectors"
+                class="bp3-form-group"
+                data-id="delegateSelectors-1"
+                style="flex-grow: 1; margin-bottom: 0px;"
               >
-                <div
-                  class="bp3-popover-wrapper TagInput--tagInput delegatePopover bp3-fill"
+                <label
+                  class="bp3-label"
+                  for="delegateSelectors"
                 >
                   <div
-                    class="bp3-popover-target"
+                    class="formLabel"
                   >
+                    <span
+                      class="Tooltip--acenter"
+                      data-tooltip-id="delegateSelectorPanelForm_delegateSelectors"
+                    >
+                      common.defineDelegateSelector
+                    </span>
                     <div
-                      class=""
+                      class="bp3-popover-wrapper typeSelectorWrapper"
                     >
                       <div
-                        class="bp3-input bp3-tag-input bp3-fill bp3-multi-select"
+                        class="bp3-popover-target typeSelector"
                       >
-                        <div
-                          class="bp3-tag-input-values"
+                        <button
+                          class="bp3-button bp3-minimal Button--button StyledProps--font StyledProps--main btn Button--iconOnly Button--without-shadow"
+                          type="button"
                         >
                           <span
-                            class="bp3-tag bp3-intent-danger bp3-minimal TagInput--tag"
-                            data-tag-index="0"
+                            class="bp3-button-text"
                           >
                             <span
-                              class="bp3-text-overflow-ellipsis bp3-fill"
+                              class="bp3-icon StyledProps--main icon fixed"
+                              data-icon="fixed-input"
                             >
-                              harness-sample-k8s-delegate
+                              <svg
+                                height="12"
+                                viewBox="0 0 9 9"
+                                width="12"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M5.61 7.55c.62-.7.3-1.42.18-2.35a.32.32 0 01.1-.29l1.43-1.42a.76.76 0 01.28-.15c.39-.1 1 0 1.28-.29a.34.34 0 000-.51L6.46.12a.33.33 0 00-.52 0c-.28.29-.2.9-.28 1.3a.53.53 0 01-.13.23L4.09 3.12a.29.29 0 01-.28.09c-.89-.11-1.6-.49-2.27.11-.29.26-.29.43 0 .7l1.31 1.34.15.16-.15.15-2.7 2.69a.36.36 0 000 .54.36.36 0 00.54-.05l2.63-2.68.17-.17.17.16c.45.46.9.91 1.36 1.36.21.21.42.22.59.03z"
+                                  fill="currentColor"
+                                />
+                              </svg>
                             </span>
-                            <button
-                              class="bp3-tag-remove"
-                              type="button"
+                          </span>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                   
+                  <span
+                    class="bp3-text-muted"
+                  />
+                </label>
+                <div
+                  class="bp3-form-content"
+                >
+                  <div
+                    class="wrapper wrapper"
+                    data-name="DelegateSelectors"
+                  >
+                    <div
+                      class="bp3-popover-wrapper TagInput--tagInput delegatePopover bp3-fill"
+                    >
+                      <div
+                        class="bp3-popover-target"
+                      >
+                        <div
+                          class=""
+                        >
+                          <div
+                            class="bp3-input bp3-tag-input bp3-fill bp3-multi-select"
+                          >
+                            <div
+                              class="bp3-tag-input-values"
                             >
                               <span
-                                class="bp3-icon bp3-icon-small-cross"
-                                icon="small-cross"
+                                class="bp3-tag bp3-intent-danger bp3-minimal TagInput--tag"
+                                data-tag-index="0"
                               >
-                                <svg
-                                  data-icon="small-cross"
-                                  height="16"
-                                  viewBox="0 0 16 16"
-                                  width="16"
+                                <span
+                                  class="bp3-text-overflow-ellipsis bp3-fill"
                                 >
-                                  <desc>
-                                    small-cross
-                                  </desc>
-                                  <path
-                                    d="M9.41 8l2.29-2.29c.19-.18.3-.43.3-.71a1.003 1.003 0 00-1.71-.71L8 6.59l-2.29-2.3a1.003 1.003 0 00-1.42 1.42L6.59 8 4.3 10.29c-.19.18-.3.43-.3.71a1.003 1.003 0 001.71.71L8 9.41l2.29 2.29c.18.19.43.3.71.3a1.003 1.003 0 00.71-1.71L9.41 8z"
-                                    fill-rule="evenodd"
-                                  />
-                                </svg>
+                                  harness-sample-k8s-delegate
+                                </span>
+                                <button
+                                  class="bp3-tag-remove"
+                                  type="button"
+                                >
+                                  <span
+                                    class="bp3-icon bp3-icon-small-cross"
+                                    icon="small-cross"
+                                  >
+                                    <svg
+                                      data-icon="small-cross"
+                                      height="16"
+                                      viewBox="0 0 16 16"
+                                      width="16"
+                                    >
+                                      <desc>
+                                        small-cross
+                                      </desc>
+                                      <path
+                                        d="M9.41 8l2.29-2.29c.19-.18.3-.43.3-.71a1.003 1.003 0 00-1.71-.71L8 6.59l-2.29-2.3a1.003 1.003 0 00-1.42 1.42L6.59 8 4.3 10.29c-.19.18-.3.43-.3.71a1.003 1.003 0 001.71.71L8 9.41l2.29 2.29c.18.19.43.3.71.3a1.003 1.003 0 00.71-1.71L9.41 8z"
+                                        fill-rule="evenodd"
+                                      />
+                                    </svg>
+                                  </span>
+                                </button>
                               </span>
-                            </button>
-                          </span>
-                          <input
-                            class="bp3-input-ghost bp3-multi-select-tag-input-input"
-                            value=""
-                          />
+                              <input
+                                class="bp3-input-ghost bp3-multi-select-tag-input-input"
+                                value=""
+                              />
+                            </div>
+                          </div>
                         </div>
                       </div>
                     </div>
                   </div>
                 </div>
               </div>
-              <span
-                class="bp3-popover-wrapper MultiTypeInput--wrapper"
-              >
-                <span
-                  class="bp3-popover-target"
-                >
-                  <button
-                    class="MultiTypeInput--btn MultiTypeInput--FIXED"
-                  >
-                    <span
-                      class="bp3-icon StyledProps--main"
-                      data-icon="fixed-input"
-                    >
-                      <svg
-                        height="12"
-                        viewBox="0 0 9 9"
-                        width="12"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M5.61 7.55c.62-.7.3-1.42.18-2.35a.32.32 0 01.1-.29l1.43-1.42a.76.76 0 01.28-.15c.39-.1 1 0 1.28-.29a.34.34 0 000-.51L6.46.12a.33.33 0 00-.52 0c-.28.29-.2.9-.28 1.3a.53.53 0 01-.13.23L4.09 3.12a.29.29 0 01-.28.09c-.89-.11-1.6-.49-2.27.11-.29.26-.29.43 0 .7l1.31 1.34.15.16-.15.15-2.7 2.69a.36.36 0 000 .54.36.36 0 00.54-.05l2.63-2.68.17-.17.17.16c.45.46.9.91 1.36 1.36.21.21.42.22.59.03z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                    </span>
-                  </button>
-                </span>
-              </span>
             </div>
           </div>
         </div>

--- a/src/modules/70-pipeline/components/PipelineSteps/AdvancedSteps/__tests__/__snapshots__/AdvancedSteps.test.tsx.snap
+++ b/src/modules/70-pipeline/components/PipelineSteps/AdvancedSteps/__tests__/__snapshots__/AdvancedSteps.test.tsx.snap
@@ -46,73 +46,106 @@ exports[`<AdvancedSteps /> tests snapshot test 1`] = `
                   >
                     <div
                       class="bp3-form-group"
-                      data-id="undefined-0"
+                      data-id="delegateSelectors-0"
                     >
                       <div
                         class="bp3-form-content"
                       >
                         <div
-                          class="Layout--horizontal StyledProps--main MultiTypeInput--main"
-                          style="flex-grow: 1;"
+                          class="StyledProps--font StyledProps--main fieldSelectorContainer"
                         >
                           <div
-                            class="wrapper wrapper"
-                            data-name="DelegateSelectors"
+                            class="bp3-form-group"
+                            data-id="delegateSelectors-1"
+                            style="flex-grow: 1; margin-bottom: 0px;"
                           >
-                            <div
-                              class="bp3-popover-wrapper TagInput--tagInput delegatePopover bp3-fill"
+                            <label
+                              class="bp3-label"
+                              for="delegateSelectors"
                             >
                               <div
-                                class="bp3-popover-target"
+                                class="formLabel"
                               >
+                                <span
+                                  class="Tooltip--acenter"
+                                  data-tooltip-id="pipelineAdvancedSteps_delegateSelectors"
+                                >
+                                  common.defineDelegateSelector
+                                </span>
                                 <div
-                                  class=""
+                                  class="bp3-popover-wrapper typeSelectorWrapper"
                                 >
                                   <div
-                                    class="bp3-input bp3-tag-input bp3-fill bp3-multi-select"
+                                    class="bp3-popover-target typeSelector"
+                                  >
+                                    <button
+                                      class="bp3-button bp3-minimal Button--button StyledProps--font StyledProps--main btn Button--iconOnly Button--without-shadow"
+                                      type="button"
+                                    >
+                                      <span
+                                        class="bp3-button-text"
+                                      >
+                                        <span
+                                          class="bp3-icon StyledProps--main icon fixed"
+                                          data-icon="fixed-input"
+                                        >
+                                          <svg
+                                            height="12"
+                                            viewBox="0 0 9 9"
+                                            width="12"
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M5.61 7.55c.62-.7.3-1.42.18-2.35a.32.32 0 01.1-.29l1.43-1.42a.76.76 0 01.28-.15c.39-.1 1 0 1.28-.29a.34.34 0 000-.51L6.46.12a.33.33 0 00-.52 0c-.28.29-.2.9-.28 1.3a.53.53 0 01-.13.23L4.09 3.12a.29.29 0 01-.28.09c-.89-.11-1.6-.49-2.27.11-.29.26-.29.43 0 .7l1.31 1.34.15.16-.15.15-2.7 2.69a.36.36 0 000 .54.36.36 0 00.54-.05l2.63-2.68.17-.17.17.16c.45.46.9.91 1.36 1.36.21.21.42.22.59.03z"
+                                              fill="currentColor"
+                                            />
+                                          </svg>
+                                        </span>
+                                      </span>
+                                    </button>
+                                  </div>
+                                </div>
+                              </div>
+                               
+                              <span
+                                class="bp3-text-muted"
+                              />
+                            </label>
+                            <div
+                              class="bp3-form-content"
+                            >
+                              <div
+                                class="wrapper wrapper"
+                                data-name="DelegateSelectors"
+                              >
+                                <div
+                                  class="bp3-popover-wrapper TagInput--tagInput delegatePopover bp3-fill"
+                                >
+                                  <div
+                                    class="bp3-popover-target"
                                   >
                                     <div
-                                      class="bp3-tag-input-values"
+                                      class=""
                                     >
-                                      <input
-                                        class="bp3-input-ghost bp3-multi-select-tag-input-input"
-                                        placeholder="delegate.Delegate_Selector_placeholder"
-                                        value=""
-                                      />
+                                      <div
+                                        class="bp3-input bp3-tag-input bp3-fill bp3-multi-select"
+                                      >
+                                        <div
+                                          class="bp3-tag-input-values"
+                                        >
+                                          <input
+                                            class="bp3-input-ghost bp3-multi-select-tag-input-input"
+                                            placeholder="delegate.Delegate_Selector_placeholder"
+                                            value=""
+                                          />
+                                        </div>
+                                      </div>
                                     </div>
                                   </div>
                                 </div>
                               </div>
                             </div>
                           </div>
-                          <span
-                            class="bp3-popover-wrapper MultiTypeInput--wrapper"
-                          >
-                            <span
-                              class="bp3-popover-target"
-                            >
-                              <button
-                                class="MultiTypeInput--btn MultiTypeInput--FIXED"
-                              >
-                                <span
-                                  class="bp3-icon StyledProps--main"
-                                  data-icon="fixed-input"
-                                >
-                                  <svg
-                                    height="12"
-                                    viewBox="0 0 9 9"
-                                    width="12"
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M5.61 7.55c.62-.7.3-1.42.18-2.35a.32.32 0 01.1-.29l1.43-1.42a.76.76 0 01.28-.15c.39-.1 1 0 1.28-.29a.34.34 0 000-.51L6.46.12a.33.33 0 00-.52 0c-.28.29-.2.9-.28 1.3a.53.53 0 01-.13.23L4.09 3.12a.29.29 0 01-.28.09c-.89-.11-1.6-.49-2.27.11-.29.26-.29.43 0 .7l1.31 1.34.15.16-.15.15-2.7 2.69a.36.36 0 000 .54.36.36 0 00.54-.05l2.63-2.68.17-.17.17.16c.45.46.9.91 1.36 1.36.21.21.42.22.59.03z"
-                                      fill="currentColor"
-                                    />
-                                  </svg>
-                                </span>
-                              </button>
-                            </span>
-                          </span>
                         </div>
                       </div>
                     </div>

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/Approval/HarnessApproval.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/Approval/HarnessApproval.tsx
@@ -8,7 +8,7 @@
 import React from 'react'
 import * as Yup from 'yup'
 import { parse } from 'yaml'
-import { isEmpty, get } from 'lodash-es'
+import { isEmpty, get, compact } from 'lodash-es'
 import { CompletionItemKind } from 'vscode-languageserver-types'
 import { connect, FormikErrors, yupToFormErrors } from 'formik'
 import { getMultiTypeFromValue, IconName, MultiTypeInputType } from '@wings-software/uicore'
@@ -140,7 +140,7 @@ export class HarnessApproval extends PipelineStep<HarnessApprovalData> {
       typeof template?.spec?.approvers?.userGroups === 'string' &&
       isRequired &&
       getMultiTypeFromValue(template?.spec?.approvers.userGroups) === MultiTypeInputType.RUNTIME &&
-      isEmpty(data?.spec?.approvers.userGroups)
+      isEmpty(compact(data?.spec?.approvers.userGroups as string[]))
     ) {
       errors.spec = {
         ...errors.spec,

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/Approval/HarnessApprovalStepMode.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/Approval/HarnessApprovalStepMode.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react'
 import cx from 'classnames'
-import { isEmpty } from 'lodash-es'
+import { isEmpty, compact } from 'lodash-es'
 import * as Yup from 'yup'
 import { FieldArray, FormikProps } from 'formik'
 import {
@@ -266,7 +266,19 @@ function HarnessApprovalStepMode(
         spec: Yup.object().shape({
           approvalMessage: Yup.string().trim().required(getString('pipeline.approvalStep.validation.approvalMessage')),
           approvers: Yup.object().shape({
-            userGroups: Yup.string().required(getString('pipeline.approvalStep.validation.userGroups')),
+            userGroups: Yup.mixed()
+              .required(getString('pipeline.approvalStep.validation.userGroups'))
+              .test({
+                test(value: string | string[]) {
+                  if (Array.isArray(value) && isEmpty(compact(value))) {
+                    return this.createError({
+                      message: getString('pipeline.approvalStep.validation.userGroups')
+                    })
+                  }
+
+                  return true
+                }
+              }),
             minimumCount: Yup.string()
               .required(getString('pipeline.approvalStep.validation.minimumCountRequired'))
               .test({

--- a/src/modules/70-pipeline/strings/strings.en.yaml
+++ b/src/modules/70-pipeline/strings/strings.en.yaml
@@ -94,7 +94,7 @@ approvalStep:
     statusMsg: '{{ count }} of {{ total }} approvals complete'
   validation:
     approvalMessage: Approval message is required.
-    userGroups: 'Please provide user groups.'
+    userGroups: 'Atleast one user group is required'
     minimumCountOne: 'Minimum count cannot be less than one.'
     minimumCountRequired: 'Minimum count is required.'
   status:

--- a/src/stringTypes.ts
+++ b/src/stringTypes.ts
@@ -167,6 +167,7 @@ export interface StringsMap {
   'common.datePickerShortcuts.Yesterday': string
   'common.default': string
   'common.defaultExperience': string
+  'common.defineDelegateSelector': string
   'common.delegateForTask': string
   'common.delegateTokenLabel': string
   'common.delete': string

--- a/yarn.lock
+++ b/yarn.lock
@@ -1887,10 +1887,10 @@
   resolved "https://npm.pkg.github.com/download/@harness/telemetry/1.0.37/fbc5025fb5969920627473304e041288420f44d63aa9cce82e1d06416bb2cf07#800efb2a98fc01bde907543f2509f7009573a1d7"
   integrity sha512-oUwcx7FSbKD0VTs/5Ng/mrYLEGj8FDtpsDhLniVgnsY02i15HszImvAEx6o32Pur3TcF1BKL/MRFu4W6lSKiPA==
 
-"@harness/uicore@2.46.0":
-  version "2.46.0"
-  resolved "https://npm.pkg.github.com/download/@harness/uicore/2.46.0/9e8a71c25de83d1d738596261b9abac6367b594e4f3b5bb5c64ef5060f25d993#3c9fc61f7887cca6def8dcf4113d749c640b5b0e"
-  integrity sha512-TaNHL5M4duLr5NPzudbluHLXb+jBVmnU9whyWos9hQyxaNLwJvg0v0yITf1IDn3ovrHrQZB1KIEU+ZN+sO8Ljw==
+"@harness/uicore@2.47.0":
+  version "2.47.0"
+  resolved "https://npm.pkg.github.com/download/@harness/uicore/2.47.0/0f96a24ff36bcd26b1f94cdcd255a73e46ed7200e20c642a70ee9de92e8492c2#630ca1d5c0c391825943b6bed909f62b084366a5"
+  integrity sha512-rKh7YhkzKS0QkuNHi4zKxFntHhRwdsyZXo7YKKMweTr9U/whWusEZb3V+6fqgiI7M35x4uF5Bh4fBwTSSVxpDQ==
 
 "@harness/use-modal@1.1.0":
   version "1.1.0"


### PR DESCRIPTION
##### Summary:

Added support for expression list input for user groups.

##### Jira Links:

https://harness.atlassian.net/browse/CDS-25535

##### Screenshots:


https://user-images.githubusercontent.com/96409598/160409270-87b75cd6-cad8-4bb9-9e23-9ea1a708248f.mov

<img width="1786" alt="Screenshot 2022-03-28 at 6 34 46 PM" src="https://user-images.githubusercontent.com/96409598/160409345-6748b0a1-a83d-423b-b4d7-1721a7cbe508.png">

https://user-images.githubusercontent.com/96409598/160409348-569f1882-d61a-46af-91df-56a6b7e66429.mov


https://user-images.githubusercontent.com/96409598/160409362-b4fe7614-b7df-4f42-acb1-9cc48dc21460.mov



You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
