### PR TITLE
fix: [PL-24046]: Trimming branch name as done by Github

### DIFF
--- a/src/modules/10-common/components/SaveToGitForm/SaveToGitForm.tsx
+++ b/src/modules/10-common/components/SaveToGitForm/SaveToGitForm.tsx
@@ -336,7 +336,7 @@ const SaveToGitForm: React.FC<ModalConfigureProps & SaveToGitFormProps> = props 
             props.onSuccess?.({
               ...pick(formData, ['repoIdentifier', 'rootFolder', 'filePath', 'commitMsg', 'createPr', 'targetBranch']),
               isNewBranch,
-              branch: isNewBranch ? formData.branch : defaultInitialFormData.branch
+              branch: isNewBranch ? formData.branch.trim() : defaultInitialFormData.branch
             })
           }}
         >

--- a/src/modules/40-gitsync/components/FullSyncForm/FullSyncForm.tsx
+++ b/src/modules/40-gitsync/components/FullSyncForm/FullSyncForm.tsx
@@ -293,7 +293,11 @@ const FullSyncForm: React.FC<ModalConfigureProps & FullSyncFormProps> = props =>
                   orgIdentifier,
                   projectIdentifier
                 },
-                { ...formData, baseBranch: getBaseBranch(gitSyncRepos, formData.repoIdentifier) },
+                {
+                  ...formData,
+                  baseBranch: getBaseBranch(gitSyncRepos, formData.repoIdentifier),
+                  branch: formData.branch?.trim()
+                },
                 isNewBranch,
                 configResponse,
                 { showSuccess, onSuccess, getString },

--- a/src/modules/40-gitsync/components/gitSyncRepoForm/GitSyncRepoForm.tsx
+++ b/src/modules/40-gitsync/components/gitSyncRepoForm/GitSyncRepoForm.tsx
@@ -215,7 +215,8 @@ const GitSyncRepoForm: React.FC<ModalConfigureProps & GitSyncRepoFormProps> = pr
             })}
             onSubmit={formData => {
               const gitSyncRepoData = {
-                ...pick(formData, ['gitConnectorType', 'branch', 'name', 'identifier']),
+                ...pick(formData, ['gitConnectorType', 'name', 'identifier']),
+                branch: formData.branch?.trim(),
                 repo: getRepoUrlForConnectorType(formData),
                 gitConnectorRef: (formData.gitConnector as ConnectorSelectedValue)?.value,
                 gitSyncFolderConfigDTOs: [


### PR DESCRIPTION
##### Summary:

Trimming leading and trailing space in branch name similar to GitHub

##### Jira Links:
https://harness.atlassian.net/browse/PL-24046

##### Screenshots:

<!--- Add screenshots for your changes here -->

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
