### PR TITLE
feat: [OPA-191]: passing gitsync components to MFE and adding a close…

### DIFF
--- a/src/modules/10-common/modals/SaveToGitDialog/useSaveToGitDialog.tsx
+++ b/src/modules/10-common/modals/SaveToGitDialog/useSaveToGitDialog.tsx
@@ -38,6 +38,7 @@ export interface UseSaveToGitDialogProps<T> {
     isEdit?: boolean
   ) => Promise<UseSaveSuccessResponse>
   onClose?: () => void
+  onProgessOverlayClose?: () => void
 }
 
 export interface OpenSaveToGitDialogValue<T> {
@@ -202,6 +203,7 @@ export function useSaveToGitDialog<T = Record<string, string>>(
           onClose={() => {
             hideCreateUpdateWithPRCreationModal()
             handleCreateUpdateSuccess(createUpdateStatus)
+            props.onProgessOverlayClose?.()
           }}
         />
       </Dialog>
@@ -227,6 +229,7 @@ export function useSaveToGitDialog<T = Record<string, string>>(
           onClose={() => {
             hideCreateUpdateModal()
             handleCreateUpdateSuccess(createUpdateStatus)
+            props.onProgessOverlayClose?.()
           }}
         />
       </Dialog>

--- a/src/modules/25-governance/GovernanceApp.jsx
+++ b/src/modules/25-governance/GovernanceApp.jsx
@@ -8,6 +8,8 @@
 import React, { Suspense, lazy } from 'react'
 import { useHistory, useRouteMatch } from 'react-router-dom'
 import { Container } from '@wings-software/uicore'
+import { useSaveToGitDialog } from '@common/modals/SaveToGitDialog/useSaveToGitDialog'
+import GitFilters from '@common/components/GitFilters/GitFilters'
 import routes from '@common/RouteDefinitions'
 import { returnUrlParams } from '@common/utils/routeUtils'
 import { NGBreadcrumbs } from '@common/components/NGBreadcrumbs/NGBreadcrumbs'
@@ -15,11 +17,14 @@ import AppErrorBoundary from 'framework/utils/AppErrorBoundary/AppErrorBoundary'
 import { useStrings } from 'framework/strings'
 import AppStorage from 'framework/utils/AppStorage'
 import { getLoginPageURL } from 'framework/utils/SessionUtils'
+import { GitSyncStoreProvider, GitSyncStoreContext, useGitSyncStore } from 'framework/GitRepoStore/GitSyncStoreContext'
+import { AppStoreContext, useAppStore } from 'framework/AppStore/AppStoreContext'
 import RbacButton from '@rbac/components/Button/Button'
 import RbacOptionsMenuButton from '@rbac/components/RbacOptionsMenuButton/RbacOptionsMenuButton'
 import { usePermission } from '@rbac/hooks/usePermission'
 import { useFeatureFlags } from '@common/hooks/useFeatureFlag'
 import { useGetSchemaYaml } from 'services/pipeline-ng'
+import { useGetListOfBranchesWithStatus } from 'services/cd-ng'
 
 // Due to some typing complexity, governance/App is lazily imported
 // from a .js file for now
@@ -53,12 +58,18 @@ export const GovernanceRemoteComponentMounter = props => {
           hooks={{
             usePermission,
             useGetSchemaYaml,
-            useFeatureFlags
+            useFeatureFlags,
+            useAppStore,
+            useGitSyncStore,
+            useSaveToGitDialog,
+            useGetListOfBranchesWithStatus
           }}
           components={{
             NGBreadcrumbs,
             RbacButton,
-            RbacOptionsMenuButton
+            RbacOptionsMenuButton,
+            GitFilters,
+            GitSyncStoreProvider
           }}
         >
           {component}


### PR DESCRIPTION
… prop to git dialog

##### Summary:

Passing GitSync components to MFE.

Added in an onProgessOverlayClose optional prop that gets called when the ProgressOverlay component is called. I needed to add this callback to do some state changes.

##### Jira Links:

https://harness.atlassian.net/browse/OPA-191

##### Screenshots:

<!--- Add screenshots for your changes here -->

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
