### PR TITLE
feat: [CCM-7132]: sending vpc in place of region for gcp instance rule

### DIFF
--- a/src/modules/75-ce/components/AccessPoint/GCPAccessPoint/GCPAccessPointConfig.tsx
+++ b/src/modules/75-ce/components/AccessPoint/GCPAccessPoint/GCPAccessPointConfig.tsx
@@ -70,6 +70,7 @@ const GCPAccessPointConfig: React.FC<GCPAccessPointConfigProps> = ({
     moveForward()
   }
 
+  /* istanbul ignore next */
   const saveLb = async (lbToSave: AccessPoint): Promise<void> => {
     setLbCreationInProgress(true)
     try {

--- a/src/modules/75-ce/components/AccessPoint/GCPAccessPoint/GCPAccessPointConfig.tsx
+++ b/src/modules/75-ce/components/AccessPoint/GCPAccessPoint/GCPAccessPointConfig.tsx
@@ -15,7 +15,6 @@ import { AccessPoint, useCreateAccessPoint, useEditAccessPoint } from 'services/
 import type { AccessPointScreenMode } from '@ce/types'
 import type { AccountPathProps } from '@common/interfaces/RouteInterfaces'
 import { useStrings } from 'framework/strings'
-import useRBACError from '@rbac/utils/useRBACError/useRBACError'
 import GCPDnsMapping, { GcpDnsFormVal } from './GCPDnsMapping'
 import GCPAccessPointForm, { GcpApFormValue } from './GCPAccessPointForm'
 import css from './GCPAccessPoint.module.scss'
@@ -38,7 +37,6 @@ const GCPAccessPointConfig: React.FC<GCPAccessPointConfigProps> = ({
   step
 }) => {
   const { getString } = useStrings()
-  const { getRBACErrorMessage } = useRBACError()
   const { showError, showSuccess } = useToaster()
   const { accountId } = useParams<AccountPathProps>()
 
@@ -88,7 +86,7 @@ const GCPAccessPointConfig: React.FC<GCPAccessPointConfigProps> = ({
       }
     } catch (e) {
       setLbCreationInProgress(false)
-      showError(getRBACErrorMessage(e))
+      showError(e.data?.errors?.join('\n '))
     }
   }
 

--- a/src/modules/75-ce/components/COGatewayAccess/helper.ts
+++ b/src/modules/75-ce/components/COGatewayAccess/helper.ts
@@ -291,13 +291,15 @@ export const getSupportedResourcesQueryParams = ({
 }: BaseFetchDetails): AccessPointResourcesQueryParams => {
   const params: AccessPointResourcesQueryParams = {
     cloud_account_id: gatewayDetails.cloudAccount.id,
-    accountIdentifier: accountId,
-    region: ''
+    accountIdentifier: accountId
   }
+  const isGcpProvider = Utils.isProviderGcp(gatewayDetails.provider)
   if (!_isEmpty(gatewayDetails.routing.container_svc)) {
     params.region = _defaultTo(gatewayDetails.routing.container_svc?.region, '')
     params.cluster = _defaultTo(gatewayDetails.routing.container_svc?.cluster, '')
     params.service = _defaultTo(gatewayDetails.routing.container_svc?.service, '')
+  } else if (isGcpProvider && gatewayDetails.selectedInstances?.length) {
+    params.vpc = gatewayDetails.selectedInstances?.[0].vpc
   } else {
     params.region = gatewayDetails.selectedInstances?.length
       ? gatewayDetails.selectedInstances[0].region

--- a/src/services/lw/index.tsx
+++ b/src/services/lw/index.tsx
@@ -1052,7 +1052,8 @@ export const useAllAccessPoints = ({ account_id, ...props }: UseAllAccessPointsP
 
 export interface AccessPointResourcesQueryParams {
   cloud_account_id: string
-  region: string
+  region?: string
+  vpc?: string
   resource_group_name?: string
   accountIdentifier: string
   service?: string

--- a/src/services/lw/swagger.json
+++ b/src/services/lw/swagger.json
@@ -744,7 +744,13 @@
         {
           "name": "region",
           "in": "query",
-          "required": true,
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "vpc",
+          "in": "query",
+          "required": false,
           "type": "string"
         },
         {


### PR DESCRIPTION
##### Summary:

For fetching supported resources to select load balancer, client will now be sending `vpc` in place of `region` in query params only for GCP instance rules

##### Jira Links:

<!--- Add jira links for your changes here -->

##### Screenshots:

<!--- Add screenshots for your changes here -->

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
