### PR TITLE
fix: [SRM-9997]: Fix Live Monittoring Error Cluster view

### DIFF
--- a/src/modules/85-cv/components/ErrorTrackingAnalysis/ErrorTrackingAnalysis.tsx
+++ b/src/modules/85-cv/components/ErrorTrackingAnalysis/ErrorTrackingAnalysis.tsx
@@ -20,7 +20,7 @@ import {
 } from '@wings-software/uicore'
 import { Color, FontVariation } from '@harness/design-system'
 import { useStrings } from 'framework/strings'
-import { useGetAllErrorTrackingData, useGetAllLogsClusterData } from 'services/cv'
+import { useGetAllErrorTrackingClusterData, useGetAllErrorTrackingData } from 'services/cv'
 import type { ProjectPathProps } from '@common/interfaces/RouteInterfaces'
 import { getErrorMessage } from '@cv/utils/CommonUtils'
 import { HealthSourceDropDown } from '@cv/components/HealthSourceDropDown/HealthSourceDropDown'
@@ -47,7 +47,7 @@ const ClusterChartContainer: React.FC<ErrorTrackingAnalysisContentProps> = ({
   const { getString } = useStrings()
   const { orgIdentifier, projectIdentifier, accountId } = useParams<ProjectPathProps>()
 
-  const { data, loading, error, refetch } = useGetAllLogsClusterData({
+  const { data, loading, error, refetch } = useGetAllErrorTrackingClusterData({
     queryParams: {
       accountId,
       orgIdentifier,

--- a/src/modules/85-cv/components/ErrorTrackingAnalysis/__tests__/ErrorTrackingAnalysis.test.tsx
+++ b/src/modules/85-cv/components/ErrorTrackingAnalysis/__tests__/ErrorTrackingAnalysis.test.tsx
@@ -48,7 +48,7 @@ describe('Unit tests for ErrorTrackingAnalysisContainer', () => {
       return { data: mockedHealthSourcesData, error: null, loading: false }
     })
 
-    jest.spyOn(cvServices, 'useGetAllLogsClusterData').mockImplementation((): any => {
+    jest.spyOn(cvServices, 'useGetAllErrorTrackingClusterData').mockImplementation((): any => {
       return { data: mockedClustersData, error: null, loading: false, refetch: fetchClusterData }
     })
 
@@ -65,7 +65,7 @@ describe('Unit tests for ErrorTrackingAnalysisContainer', () => {
       return { data: mockedHealthSourcesData, error: null, loading: false }
     })
 
-    jest.spyOn(cvServices, 'useGetAllLogsClusterData').mockImplementation((): any => {
+    jest.spyOn(cvServices, 'useGetAllErrorTrackingClusterData').mockImplementation((): any => {
       return { data: mockedClustersData, error: null, loading: false, refetch: fetchClusterData }
     })
 
@@ -88,7 +88,7 @@ describe('Unit tests for ErrorTrackingAnalysisContainer', () => {
       return { data: mockedHealthSourcesData, error: null, loading: false }
     })
 
-    jest.spyOn(cvServices, 'useGetAllLogsClusterData').mockImplementation((): any => {
+    jest.spyOn(cvServices, 'useGetAllErrorTrackingClusterData').mockImplementation((): any => {
       return { data: mockedClustersData, error: null, loading: false, refetch: fetchClusterData }
     })
     const { container, getByText, getAllByText } = render(<WrapperComponent {...mockProps} />)
@@ -153,7 +153,7 @@ describe('Unit tests for ErrorTrackingAnalysisContainer', () => {
     })
 
     jest
-      .spyOn(cvServices, 'useGetAllLogsClusterData')
+      .spyOn(cvServices, 'useGetAllErrorTrackingClusterData')
       .mockImplementation((props: cvServices.UseGetAllLogsClusterDataProps): any => {
         useGetAllLogsClusterDataQueryParams = props.queryParams
         return { data: mockedClustersData, error: null, loading: false, refetch: fetchClusterData }
@@ -186,7 +186,7 @@ describe('Unit tests for ErrorTrackingAnalysisContainer', () => {
       return { data: mockedHealthSourcesData, error: null, loading: false }
     })
 
-    jest.spyOn(cvServices, 'useGetAllLogsClusterData').mockImplementation((): any => {
+    jest.spyOn(cvServices, 'useGetAllErrorTrackingClusterData').mockImplementation((): any => {
       return { data: mockedClustersData, error: null, loading: false, refetch: fetchClusterData }
     })
 
@@ -204,7 +204,7 @@ describe('Unit tests for ErrorTrackingAnalysisContainer', () => {
       return { data: mockedHealthSourcesData, error: null, loading: false }
     })
 
-    jest.spyOn(cvServices, 'useGetAllLogsClusterData').mockImplementation((): any => {
+    jest.spyOn(cvServices, 'useGetAllErrorTrackingClusterData').mockImplementation((): any => {
       return { data: mockedClustersData, error: null, loading: false, refetch: fetchClusterData }
     })
 
@@ -231,7 +231,7 @@ describe('Unit tests for ErrorTrackingAnalysisContainer', () => {
       return { data: mockedHealthSourcesData, error: null, loading: false }
     })
 
-    jest.spyOn(cvServices, 'useGetAllLogsClusterData').mockImplementation((): any => {
+    jest.spyOn(cvServices, 'useGetAllErrorTrackingClusterData').mockImplementation((): any => {
       return { data: undefined, error: null, loading: false, refetch: fetchClusterData }
     })
 
@@ -249,7 +249,7 @@ describe('Unit tests for ErrorTrackingAnalysisContainer', () => {
       return { data: mockedHealthSourcesData, error: null, loading: false }
     })
 
-    jest.spyOn(cvServices, 'useGetAllLogsClusterData').mockImplementation((): any => {
+    jest.spyOn(cvServices, 'useGetAllErrorTrackingClusterData').mockImplementation((): any => {
       return {
         data: undefined,
         error: { message: 'a new problem has occurred' },

--- a/src/modules/85-cv/pages/monitored-service/components/ServiceHealth/components/ErrorTracking/__tests__/ErrorTracking.test.tsx
+++ b/src/modules/85-cv/pages/monitored-service/components/ServiceHealth/components/ErrorTracking/__tests__/ErrorTracking.test.tsx
@@ -35,7 +35,7 @@ jest.mock('services/cv', () => ({
   useGetAllHealthSourcesForMonitoredServiceIdentifier: jest.fn().mockImplementation(() => {
     return { data: mockedHealthSourcesData, error: null, loading: false }
   }),
-  useGetAllLogsClusterData: jest.fn().mockImplementation(() => {
+  useGetAllErrorTrackingClusterData: jest.fn().mockImplementation(() => {
     return { data: mockedClustersData, error: null, loading: false, refetch: fetchClusterData }
   })
 }))


### PR DESCRIPTION
##### Summary:

Live Monitoring Error Tracking Cluster view issue fixed

##### Jira Links:

https://harness.atlassian.net/browse/SRM-9997

##### Screenshots:

Before:
<img width="656" alt="image" src="https://user-images.githubusercontent.com/2991478/163445243-2fe53c90-12e5-4189-8d63-18f68dd09d18.png">

After:
<img width="654" alt="image" src="https://user-images.githubusercontent.com/2991478/163445650-9fc58eda-ba79-4a75-958c-73652712577a.png">


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
