### PR TITLE
fix: [CDS-25562]: on opening Jira Create fields,fields will be as per…

### DIFF
--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraCreate/__tests__/JiraCreateHelper.test.ts
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraCreate/__tests__/JiraCreateHelper.test.ts
@@ -5,8 +5,9 @@
  * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
  */
 
-import { processFormData } from '../helper'
-import type { JiraCreateData } from '../types'
+import type { JiraFieldNG } from 'services/cd-ng'
+import { getInitialValueForSelectedField, processFormData } from '../helper'
+import type { JiraCreateData, JiraCreateFieldType } from '../types'
 
 describe('Jira Create process form data tests', () => {
   test('if duplicate fields are not sent', () => {
@@ -157,5 +158,81 @@ describe('Jira Create process form data tests', () => {
         ]
       }
     })
+  })
+
+  test('Selected Fields initial value test', () => {
+    const savedFields: JiraCreateFieldType[] = [
+      {
+        name: 'comment',
+        value: 'test'
+      },
+      {
+        name: 'priority',
+        value: ''
+      },
+      {
+        name: 'nextgen',
+        value: ''
+      }
+    ]
+    const field: JiraFieldNG = {
+      allowedValues: [],
+      key: 'customfield_1',
+      name: 'comment',
+      schema: {
+        array: false,
+        type: 'string',
+        typeStr: ''
+      }
+    }
+    const selectOptionfield: JiraFieldNG = {
+      allowedValues: [
+        {
+          id: 'P1',
+          name: 'P1',
+          value: 'P1'
+        }
+      ],
+      key: 'customfield_2',
+      name: 'priority',
+      schema: {
+        array: false,
+        type: 'option',
+        typeStr: ''
+      }
+    }
+    const multiselectOptionfield: JiraFieldNG = {
+      allowedValues: [
+        {
+          id: '1',
+          value: 'yes'
+        },
+        {
+          id: '2',
+          value: 'no'
+        }
+      ],
+      key: 'customfield_3',
+      name: 'nextgen',
+      schema: {
+        array: true,
+        type: 'option',
+        typeStr: 'option'
+      }
+    }
+    let returned = getInitialValueForSelectedField(savedFields, field)
+    expect(returned).toStrictEqual('test')
+    savedFields[0].value = 1
+    returned = getInitialValueForSelectedField(savedFields, field)
+    expect(returned).toStrictEqual(1)
+    savedFields[1].value = 'P1'
+    returned = getInitialValueForSelectedField(savedFields, selectOptionfield)
+    expect(returned).toStrictEqual({ label: 'P1', value: 'P1' })
+    savedFields[2].value = 'yes,no'
+    returned = getInitialValueForSelectedField(savedFields, multiselectOptionfield)
+    expect(returned).toStrictEqual([
+      { label: 'yes', value: 'yes' },
+      { label: 'no', value: 'no' }
+    ])
   })
 })

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraCreate/helper.ts
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraCreate/helper.ts
@@ -72,23 +72,20 @@ export const getInitialValueForSelectedField = (
     return savedValue as number
   } else if (typeof savedValue === 'string') {
     if (
+      getMultiTypeFromValue(savedValue) === MultiTypeInputType.FIXED &&
       field.allowedValues &&
-      field.schema.type === 'option' &&
-      field.schema.array &&
-      getMultiTypeFromValue(savedValue) === MultiTypeInputType.FIXED
+      field.schema.type === 'option'
     ) {
-      // multiselect
-      // return multiselectoption[]
-      const splitValues = (savedValue as string).split(',')
-      return splitValues.map(splitvalue => ({ label: splitvalue, value: splitvalue })) as MultiSelectOption[]
-    } else if (
-      field.allowedValues &&
-      field.schema.type === 'option' &&
-      getMultiTypeFromValue(savedValue) === MultiTypeInputType.FIXED
-    ) {
-      // singleselect
-      // return selectoption
-      return { label: savedValue, value: savedValue } as SelectOption
+      if (field.schema.array) {
+        // multiselect
+        // return multiselectoption[]
+        const splitValues = (savedValue as string).split(',')
+        return splitValues.map(splitvalue => ({ label: splitvalue, value: splitvalue })) as MultiSelectOption[]
+      } else {
+        // singleselect
+        // return selectoption
+        return { label: savedValue, value: savedValue } as SelectOption
+      }
     }
     return savedValue as string
   }

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraCreate/helper.ts
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraCreate/helper.ts
@@ -70,13 +70,17 @@ export const getInitialValueForSelectedField = (
   const savedValue = savedFields.find(sf => sf.name === field.name)?.value
   if (typeof savedValue === 'number') {
     return savedValue as number
-  } else if (typeof savedValue === 'string') {
+  } else if (typeof savedValue === 'string' && getMultiTypeFromValue(savedValue) === MultiTypeInputType.FIXED) {
     if (field.allowedValues && field.schema.type === 'option' && field.schema.array) {
       // multiselect
       // return multiselectoption[]
       const splitValues = (savedValue as string).split(',')
       return splitValues.map(splitvalue => ({ label: splitvalue, value: splitvalue })) as MultiSelectOption[]
-    } else if (field.allowedValues && field.schema.type === 'option') {
+    } else if (
+      field.allowedValues &&
+      field.schema.type === 'option' &&
+      getMultiTypeFromValue(savedValue) === MultiTypeInputType.FIXED
+    ) {
       // singleselect
       // return selectoption
       return { label: savedValue, value: savedValue } as SelectOption

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraCreate/helper.ts
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraCreate/helper.ts
@@ -70,8 +70,13 @@ export const getInitialValueForSelectedField = (
   const savedValue = savedFields.find(sf => sf.name === field.name)?.value
   if (typeof savedValue === 'number') {
     return savedValue as number
-  } else if (typeof savedValue === 'string' && getMultiTypeFromValue(savedValue) === MultiTypeInputType.FIXED) {
-    if (field.allowedValues && field.schema.type === 'option' && field.schema.array) {
+  } else if (typeof savedValue === 'string') {
+    if (
+      field.allowedValues &&
+      field.schema.type === 'option' &&
+      field.schema.array &&
+      getMultiTypeFromValue(savedValue) === MultiTypeInputType.FIXED
+    ) {
       // multiselect
       // return multiselectoption[]
       const splitValues = (savedValue as string).split(',')


### PR DESCRIPTION
… their type

 Summary:
Jira field which is of type dropdown(priority, NextGen) and making it as expression, we see them as dropdown after reopening the step and the type of field show as fixed value on UI.
Now, fixed this and will display as per the selected MultitypeInput of the fields.

Jira Links:

https://harness.atlassian.net/browse/CDS-25562

 Screenshots:


https://user-images.githubusercontent.com/98508399/163803917-81f26051-9d0f-4969-87b5-81c14c727d56.mov



You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
