### PR TITLE
Revert "feat: [SRM-9821]: error tracking remove url input (#8344)"

### DIFF
--- a/src/modules/35-connectors/components/CreateConnector/ErrorTrackingConnector/CreateErrorTrackingConnector.tsx
+++ b/src/modules/35-connectors/components/CreateConnector/ErrorTrackingConnector/CreateErrorTrackingConnector.tsx
@@ -7,7 +7,7 @@
 
 import React, { useEffect, useState } from 'react'
 import * as Yup from 'yup'
-import { Container, FormikForm, Layout, Formik, Button, PageSpinner } from '@wings-software/uicore'
+import { Container, FormikForm, Layout, FormInput, Formik, Button, PageSpinner } from '@wings-software/uicore'
 import { buildErrorTrackingPayload } from '@connectors/pages/connectors/utils/ConnectorUtils'
 import type { ConnectorConfigDTO } from 'services/cd-ng'
 import { useStrings } from 'framework/strings'
@@ -23,6 +23,7 @@ export function ErrorTrackingConfigStep(props: ConnectionConfigProps): JSX.Eleme
   const { nextStep, prevStepData, connectorInfo, projectIdentifier, orgIdentifier, accountId } = props
   const { getString } = useStrings()
   const [initialValues, setInitialValues] = useState<ConnectorConfigDTO>({
+    url: '',
     apiKeyRef: {},
     accountId,
     projectIdentifier,
@@ -50,12 +51,14 @@ export function ErrorTrackingConfigStep(props: ConnectionConfigProps): JSX.Eleme
         enableReinitialize
         initialValues={{ ...initialValues }}
         validationSchema={Yup.object().shape({
+          url: Yup.string().trim().required(getString('connectors.errorTracking.urlValidation')),
           apiKeyRef: Yup.string().trim().required(getString('connectors.encryptedAPIKeyValidation'))
         })}
         onSubmit={(formData: ConnectorConfigDTO) => nextStep?.({ ...connectorInfo, ...prevStepData, ...formData })}
       >
         <FormikForm className={css.form}>
           <Layout.Vertical spacing="large" height={450}>
+            <FormInput.Text label={getString('UrlLabel')} name="url" />
             <SecretInput label={getString('connectors.encryptedAPIKeyLabel')} name="apiKeyRef" />
           </Layout.Vertical>
           <Layout.Horizontal spacing="xlarge">

--- a/src/modules/35-connectors/components/CreateConnector/ErrorTrackingConnector/utils.ts
+++ b/src/modules/35-connectors/components/CreateConnector/ErrorTrackingConnector/utils.ts
@@ -10,6 +10,7 @@ import { setSecretField } from '@secrets/utils/SecretField'
 import type { ConnectorConfigDTO } from 'services/cd-ng'
 
 export interface SpecData {
+  url: string
   apiKeyRef: string
   delegateSelectors: string
 }
@@ -40,6 +41,7 @@ export async function initializeErrorTrackingConnectorWithStepData(
     ...prevData
   }
 
+  updateInitialValue(prevData as PrevData, spec as SpecData, updatedInitialValues, 'url' as AllowedKeyList)
   updateInitialValue(prevData as PrevData, spec as SpecData, updatedInitialValues, 'apiKeyRef' as AllowedKeyList)
 
   const initValueWithSecrets = await setErrorTrackingSecrets(updatedInitialValues, accountId)

--- a/src/modules/35-connectors/pages/connectors/utils/ConnectorUtils.ts
+++ b/src/modules/35-connectors/pages/connectors/utils/ConnectorUtils.ts
@@ -1373,6 +1373,7 @@ export const buildErrorTrackingPayload = (formData: FormData): Connector => {
     projectIdentifier,
     orgIdentifier,
     delegateSelectors,
+    url,
     apiKeyRef: { referenceString: apiReferenceKey },
     description,
     tags
@@ -1387,7 +1388,7 @@ export const buildErrorTrackingPayload = (formData: FormData): Connector => {
       description,
       tags,
       spec: {
-        url: window.location.href.split('#')[0],
+        url,
         apiKeyRef: apiReferenceKey,
         delegateSelectors: delegateSelectors || {}
       } as ErrorTrackingConnectorDTO


### PR DESCRIPTION
##### Summary:
Adds the url entry for the Error Tracking connector back in for the UI

##### Jira Links:
https://harness.atlassian.net/browse/SRM-9821

##### Screenshots:

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
