### PR TITLE
feat: [CDS-35642]: coverage improvement for files under pipelineStudio

### DIFF
--- a/src/modules/70-pipeline/components/PipelineStudio/ExecutionStrategy/__tests__/ExecutionStrategy.test.tsx
+++ b/src/modules/70-pipeline/components/PipelineStudio/ExecutionStrategy/__tests__/ExecutionStrategy.test.tsx
@@ -340,4 +340,45 @@ describe('ExecutionStrategy test', () => {
     await waitFor(() => expect(pipelineContextMockValue.updateStage).toHaveBeenCalled())
     expect(pipelineContextMockValue.updateStage).toHaveBeenCalledWith(defaultUpdateStageFnArg)
   })
+  test('isPropagating true and checkBox', () => {
+    pipelineContextMockValue = getDummyPipelineContextValue()
+    jest.spyOn(cdngServices, 'useGetExecutionStrategyYaml').mockImplementation((): any => {
+      return { data: {}, error: true }
+    })
+    const { container } = render(
+      <TestWrapper>
+        <PipelineContext.Provider value={pipelineContextMockValue}>
+          <ExecutionStrategy
+            selectedStage={
+              {
+                stage: {
+                  identifier: 'stage_1',
+                  name: 'stage 1',
+                  spec: {
+                    serviceConfig: {
+                      serviceDefinition: { type: 'Kubernetes' },
+                      serviceRef: 'service_3',
+                      useFromStage: {
+                        stage: 'deploy'
+                      }
+                    },
+                    execution: {
+                      steps: [],
+                      rollbackSteps: []
+                    }
+                  },
+                  type: 'Deployment'
+                }
+              } as StageElementWrapperConfig
+            }
+            ref={jest.fn()}
+          />
+        </PipelineContext.Provider>
+      </TestWrapper>
+    )
+    const checkBox = container.querySelector('[data-testid="enable-verification-options-switch"]')
+    expect(checkBox).not.toBeChecked()
+    fireEvent.click(checkBox!)
+    expect(checkBox).toBeChecked()
+  })
 })

--- a/src/modules/70-pipeline/components/PipelineStudio/RightDrawer/__tests__/RightDrawer.test.tsx
+++ b/src/modules/70-pipeline/components/PipelineStudio/RightDrawer/__tests__/RightDrawer.test.tsx
@@ -690,6 +690,7 @@ describe('Right Drawer tests', () => {
       act(() => {
         fireEvent.click(applyBtn)
       })
+
       expect(pipelineContextMock.updatePipelineView).toHaveBeenCalled()
       expect(pipelineContextMock.updatePipelineView).toHaveBeenCalledWith(updatePipelineViewFnArg1)
     })

--- a/src/modules/70-pipeline/components/PipelineStudio/RightDrawer/__tests__/RightDrawer.test.tsx
+++ b/src/modules/70-pipeline/components/PipelineStudio/RightDrawer/__tests__/RightDrawer.test.tsx
@@ -690,7 +690,6 @@ describe('Right Drawer tests', () => {
       act(() => {
         fireEvent.click(applyBtn)
       })
-
       expect(pipelineContextMock.updatePipelineView).toHaveBeenCalled()
       expect(pipelineContextMock.updatePipelineView).toHaveBeenCalledWith(updatePipelineViewFnArg1)
     })


### PR DESCRIPTION
##### Summary:

Added test cases

##### Jira Links:

https://harness.atlassian.net/browse/CDS-35642

##### Screenshots:
before :  
<img width="470" alt="Screenshot 2022-04-25 at 3 08 46 PM" src="https://user-images.githubusercontent.com/98325173/165063269-ca12900a-77df-4bcc-bac4-3fcb8c810483.png">
Now:
<img width="470" alt="Screenshot 2022-04-25 at 3 09 04 PM" src="https://user-images.githubusercontent.com/98325173/165063311-ef85c2d5-3cef-4bb2-a762-9ee009e0f4d4.png">


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
