### PR TITLE
fix: [CI-4342]: validation trim namespace and service account name

### DIFF
--- a/src/modules/70-pipeline/strings/strings.en.yaml
+++ b/src/modules/70-pipeline/strings/strings.en.yaml
@@ -946,6 +946,7 @@ ci:
     keyUnique: Key should be unique
     invalidSize: Invalid Size. To learn more, hover over the Size tooltip.
     pathRequiredForHostPath: 'Path is required for Type Host Path'
+    stringTrimmingRequired: '{{label}} requires whitespaces to be trimmed'
 imageVersionDeprecated: Image version outdated
 unsupportedImagesWarning: 'You are using unsupported Harness CI images. Harness allows builds to use these images, but we cannot ensure that builds will not fail. Please update the versions of the following image(s) {{summary}}'
 invalidRequest: Invalid Request

--- a/src/modules/75-ci/components/PipelineStudio/BuildInfraSpecifications/BuildInfraSpecifications.tsx
+++ b/src/modules/75-ci/components/PipelineStudio/BuildInfraSpecifications/BuildInfraSpecifications.tsx
@@ -71,6 +71,8 @@ import stepCss from '@pipeline/components/PipelineSteps/Steps/Steps.module.scss'
 const logger = loggerFor(ModuleName.CD)
 const k8sClusterKeyRef = 'connectors.title.k8sCluster'
 const namespaceKeyRef = 'pipelineSteps.build.infraSpecifications.namespace'
+const stringTrimmingRequiredRef = 'pipeline.ci.validations.stringTrimmingRequired'
+const serviceAccountNameRef = 'pipeline.infraSpecifications.serviceAccountName'
 const poolIdKeyRef = 'pipeline.buildInfra.poolId'
 
 interface BuildInfraTypeItem {
@@ -173,6 +175,11 @@ const validateUniqueList = ({
   } else {
     return yup.string()
   }
+}
+
+const validateRequiresTrimming = (value?: string): boolean => {
+  const requiresTrimming = value && (value.startsWith(' ') || value.endsWith(' '))
+  return !requiresTrimming
 }
 
 const getMapValues: (value: MultiTypeMapUIType) => MultiTypeMapType = value => {
@@ -1002,7 +1009,7 @@ export default function BuildInfraSpecifications({ children }: React.PropsWithCh
                 margin={{ bottom: 'xsmall' }}
                 tooltipProps={{ dataTooltipId: 'serviceAccountName' }}
               >
-                {getString('pipeline.infraSpecifications.serviceAccountName')}
+                {getString(serviceAccountNameRef)}
               </Text>
             }
             name="serviceAccountName"
@@ -1130,7 +1137,22 @@ export default function BuildInfraSpecifications({ children }: React.PropsWithCh
                   }
                   return true
                 }
-              ),
+              )
+              .test({
+                test: value => validateRequiresTrimming(value),
+                message: getString(stringTrimmingRequiredRef, {
+                  label: getString(namespaceKeyRef)
+                })
+              }),
+            serviceAccountName: yup
+              .string()
+              .nullable()
+              .test({
+                test: value => validateRequiresTrimming(value),
+                message: getString(stringTrimmingRequiredRef, {
+                  label: getString(serviceAccountNameRef)
+                })
+              }),
             useFromStage: yup
               .string()
               .nullable()
@@ -1362,7 +1384,7 @@ export default function BuildInfraSpecifications({ children }: React.PropsWithCh
                                                   margin={{ bottom: 'xsmall' }}
                                                   tooltipProps={{ dataTooltipId: 'serviceAccountName' }}
                                                 >
-                                                  {getString('pipeline.infraSpecifications.serviceAccountName')}
+                                                  {getString(serviceAccountNameRef)}
                                                 </Text>
                                                 <Text color="black" margin={{ bottom: 'medium' }}>
                                                   {

--- a/src/stringTypes.ts
+++ b/src/stringTypes.ts
@@ -2477,6 +2477,7 @@ export interface StringsMap {
   'pipeline.ci.validations.pathRequiredForHostPath': string
   'pipeline.ci.validations.port': string
   'pipeline.ci.validations.serviceDependencyIdentifier': string
+  'pipeline.ci.validations.stringTrimmingRequired': string
   'pipeline.ciCodebase.buildType': string
   'pipeline.ciCodebase.prCloneStrategy': string
   'pipeline.ciCodebase.pullRequestNumber': string


### PR DESCRIPTION
##### Summary:

<!--- Add summary of your changes here -->

##### Jira Links:

<!--- Add jira links for your changes here -->

##### Screenshots:

<!--- Add screenshots for your changes here -->
<img width="751" alt="image" src="https://user-images.githubusercontent.com/43422351/166079415-3b67ac3d-3999-4162-b683-bbf6d9dd29c9.png">
Existing validation still works
<img width="557" alt="image" src="https://user-images.githubusercontent.com/43422351/166079440-dfeefa86-5373-4e1b-88fe-1baa44da0467.png">

<img width="515" alt="image" src="https://user-images.githubusercontent.com/43422351/166079448-bb886a40-e597-452a-9def-2a549b9c9a5a.png">

Highlighting to be added later in Triggers
<img width="760" alt="image" src="https://user-images.githubusercontent.com/43422351/166079484-609f3079-cb53-406e-9a7c-2c2e9df1bfa5.png">

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
