### PR TITLE
fix: [CDS-36981]: add optional chaining to initialValues in ServerlessAwsLambdaManifest file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nextgenui",
   "description": "Harness Inc",
-  "version": "0.298.2",
+  "version": "0.298.3",
   "author": "Harness Inc",
   "license": "Harness Inc",
   "homepage": "http://app.harness.io/",

--- a/src/modules/70-pipeline/components/ManifestSelection/ManifestWizardSteps/ServerlessAwsLambdaManifest/ServerlessAwsLambdaManifest.tsx
+++ b/src/modules/70-pipeline/components/ManifestSelection/ManifestWizardSteps/ServerlessAwsLambdaManifest/ServerlessAwsLambdaManifest.tsx
@@ -88,8 +88,8 @@ function ServerlessAwsLambdaManifest({
     if (specValues) {
       return {
         ...specValues,
-        identifier: initialValues.identifier,
-        configOverridePath: initialValues.spec?.configOverridePath,
+        identifier: initialValues?.identifier,
+        configOverridePath: initialValues?.spec?.configOverridePath,
         repoName: getRepositoryName(prevStepData, initialValues),
         paths:
           typeof specValues.paths === 'string'
@@ -155,7 +155,7 @@ function ServerlessAwsLambdaManifest({
         validationSchema={Yup.object().shape({
           ...ManifestIdentifierValidation(
             manifestIdsList,
-            initialValues.identifier,
+            initialValues?.identifier,
             getString('pipeline.uniqueIdentifier')
           ),
           branch: Yup.string().when('gitFetchType', {


### PR DESCRIPTION
##### Summary:
- initialValues was required prop in the component, so it was not desired to keep optional check before accessing any value from that.
- We need to keep types properly. For now, issue is fixed by adding optional chaining. Types will be fixed later and optional chaining will be removed.

##### Jira Links:
https://harness.atlassian.net/browse/CDS-36981

##### Screenshots:
**Before:**
<img width="1792" alt="Screenshot 2022-05-02 at 11 08 09 PM" src="https://user-images.githubusercontent.com/81295223/166297120-39424323-ca0b-46ad-b38f-81a2ceb96831.png">

**After:**
<img width="1792" alt="Screenshot 2022-05-02 at 11 08 18 PM" src="https://user-images.githubusercontent.com/81295223/166296948-0b0fdbd9-7329-4448-9d35-aad174e1b0a7.png">


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
