### PR TITLE
fix: [CDS-36876]: git sync errors not showing up in modal issue fixed

### DIFF
--- a/src/modules/72-templates-library/components/TemplateStudio/TemplateStudio.tsx
+++ b/src/modules/72-templates-library/components/TemplateStudio/TemplateStudio.tsx
@@ -282,7 +282,7 @@ export function TemplateStudio(): React.ReactElement {
         size={'small'}
         title={<TemplateStudioHeader templateType={templateType as TemplateType} />}
       />
-      <Page.Body key={key} className={css.rightMargin}>
+      <Page.Body className={css.rightMargin}>
         {isLoading && <PageSpinner />}
         <Layout.Vertical height={'100%'}>
           {!isLoading && isEmpty(template) && !isGitSyncEnabled && <GenericErrorHandler />}
@@ -296,7 +296,7 @@ export function TemplateStudio(): React.ReactElement {
                 getErrors={getErrors}
                 onGitBranchChange={onGitBranchChange}
               />
-              <Container className={css.canvasContainer}>
+              <Container key={key} className={css.canvasContainer}>
                 {view === SelectedView.VISUAL ? (
                   /* istanbul ignore next */
                   templateFactory.getTemplate(templateType)?.renderTemplateCanvas({ formikRef: templateFormikRef })

--- a/src/modules/72-templates-library/components/TemplateStudio/TemplateStudio.tsx
+++ b/src/modules/72-templates-library/components/TemplateStudio/TemplateStudio.tsx
@@ -95,9 +95,11 @@ export function TemplateStudio(): React.ReactElement {
     titleText: getString('common.template.updateTemplate.templateUpdated'),
     confirmButtonText: getString('update'),
     onCloseDialog: isConfirmed => {
+      /* istanbul ignore next */
       if (isConfirmed) {
         fetchTemplate({ forceFetch: true, forceUpdate: true })
       } else {
+        /* istanbul ignore next */
         setDiscardBEUpdate(true)
       }
     }
@@ -109,6 +111,7 @@ export function TemplateStudio(): React.ReactElement {
     titleText: getString(navigationTitleText),
     confirmButtonText: getString('confirm'),
     onCloseDialog: async isConfirmed => {
+      /* istanbul ignore next */
       if (isConfirmed) {
         deleteTemplateCache(gitDetails).then(() => {
           history.push(
@@ -126,6 +129,7 @@ export function TemplateStudio(): React.ReactElement {
           location.reload()
         })
       } else {
+        /* istanbul ignore next */
         setSelectedBranch(defaultTo(branch, ''))
       }
       setBlockNavigation(false)


### PR DESCRIPTION
##### Summary:

Unmounting and re mounting of TemplateStudioSubHeader was causing the git sync errors modal in child component to be closed before showing the errors.
Fix - Have now moved the unmount key from page body parent to the container child which requires it to ensure TemplateStudioSubHeader does not get unmounted.

##### Jira Links:

This fixes the following tickets -->

https://harness.atlassian.net/browse/CDS-36876
https://harness.atlassian.net/browse/CDS-36875
https://harness.atlassian.net/browse/CDS-36832

##### Screenshots:


https://user-images.githubusercontent.com/96409598/166675130-ab99f36b-5fbb-44f6-9fdb-ff42ab5140c9.mov

<img width="1792" alt="Screenshot 2022-05-04 at 5 08 06 PM" src="https://user-images.githubusercontent.com/96409598/166675228-ef9ac521-7351-41ea-8fe2-c19fcad46e1b.png">
<img width="1792" alt="Screenshot 2022-05-04 at 5 09 10 PM" src="https://user-images.githubusercontent.com/96409598/166675233-26d75460-8309-4f35-9341-980adf376362.png">


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
