### PR TITLE
fix: [CDS-37143]: template propagated artifacts and manifests fixed

### DIFF
--- a/src/modules/75-cd/components/PipelineStudio/DeployServiceSpecifications/DeployServiceSpecifications.tsx
+++ b/src/modules/75-cd/components/PipelineStudio/DeployServiceSpecifications/DeployServiceSpecifications.tsx
@@ -21,13 +21,22 @@ import {
 } from '@wings-software/uicore'
 import { Color, Intent } from '@harness/design-system'
 import produce from 'immer'
-import { debounce, defaultTo, get, isEmpty, set, unset, noop } from 'lodash-es'
+import { debounce, defaultTo, get, isEmpty, set, unset, noop, find } from 'lodash-es'
+import { parse } from 'yaml'
+import { Spinner } from '@blueprintjs/core'
 import { StepViewType } from '@pipeline/components/AbstractSteps/Step'
 import { useStrings } from 'framework/strings'
 
-import type { ProjectPathProps } from '@common/interfaces/RouteInterfaces'
+import type { ProjectPathProps, GitQueryParams } from '@common/interfaces/RouteInterfaces'
 import { StepType } from '@pipeline/components/PipelineSteps/PipelineStepInterface'
-import { ServiceConfig, ServiceDefinition, StageElementConfig, useGetServiceList } from 'services/cd-ng'
+import {
+  ServiceConfig,
+  ServiceDefinition,
+  StageElementConfig,
+  StageElementWrapperConfig,
+  TemplateLinkConfig,
+  useGetServiceList
+} from 'services/cd-ng'
 import factory from '@pipeline/components/PipelineSteps/PipelineStepFactory'
 import { usePipelineContext } from '@pipeline/components/PipelineStudio/PipelineContext/PipelineContext'
 import {
@@ -45,7 +54,7 @@ import { useValidationErrors } from '@pipeline/components/PipelineStudio/Pipline
 import { DeployTabs } from '@pipeline/components/PipelineStudio/CommonUtils/DeployStageSetupShellUtils'
 import SelectDeploymentType from '@cd/components/PipelineStudio/DeployServiceSpecifications/SelectDeploymentType'
 import type { DeploymentStageElementConfig } from '@pipeline/utils/pipelineTypes'
-import { useDeepCompareEffect } from '@common/hooks'
+import { useDeepCompareEffect, useQueryParams } from '@common/hooks'
 import {
   deleteStageData,
   doesStageContainOtherData,
@@ -54,7 +63,10 @@ import {
   StageType
 } from '@pipeline/utils/stageHelpers'
 import { Scope } from '@common/interfaces/SecretsInterface'
-import { getIdentifierFromValue } from '@common/components/EntityReference/EntityReference'
+import { getIdentifierFromValue, getScopeFromValue } from '@common/components/EntityReference/EntityReference'
+import { useGetTemplate } from 'services/template-ng'
+import { Page } from '@common/exports'
+import { getScopeBasedQueryParams } from '@templates-library/utils/templatesUtils'
 import stageCss from '../DeployStageSetupShell/DeployStage.module.scss'
 
 export default function DeployServiceSpecifications(props: React.PropsWithChildren<unknown>): JSX.Element {
@@ -104,6 +116,12 @@ export default function DeployServiceSpecifications(props: React.PropsWithChildr
   const { stages } = getFlattenedStages(pipeline)
   const { submitFormsForTab } = useContext(StageErrorContext)
   const { errorMap } = useValidationErrors()
+
+  const { repoIdentifier, branch } = useQueryParams<GitQueryParams>()
+
+  const queryParams = useParams<ProjectPathProps>()
+
+  const [templateToFetch, setTemplateToFetch] = useState<TemplateLinkConfig>()
 
   const { openDialog: openStageDataDeleteWarningDialog } = useConfirmationDialog({
     cancelButtonText: getString('cancel'),
@@ -341,6 +359,64 @@ export default function DeployServiceSpecifications(props: React.PropsWithChildr
     [stage, updateStage]
   )
 
+  const {
+    data: templateDetails,
+    refetch: fetchTemplate,
+    loading: templateDetailsLoading,
+    error: templateDetailsError
+  } = useGetTemplate({
+    templateIdentifier: '',
+    lazy: true
+  })
+
+  const fetchTemplateDetails = (templateData?: TemplateLinkConfig) => {
+    if (templateData) {
+      const templateScope = getScopeFromValue(templateData.templateRef)
+
+      fetchTemplate({
+        queryParams: {
+          ...getScopeBasedQueryParams(queryParams, templateScope),
+          repoIdentifier,
+          branch,
+          getDefaultFromOtherRepo: true,
+          versionLabel: defaultTo(templateData?.versionLabel, '')
+        },
+        pathParams: {
+          templateIdentifier: getIdentifierFromValue(templateData?.templateRef || '')
+        }
+      })
+    }
+  }
+
+  useEffect(() => {
+    if (!isEmpty(templateDetails?.data)) {
+      const templateDeploymentType = get(
+        parse(defaultTo(templateDetails?.data?.yaml, '')),
+        'template.spec.spec.serviceConfig.serviceDefinition.type'
+      )
+      if (templateDeploymentType) {
+        setSelectedDeploymentType(templateDeploymentType)
+      }
+    }
+  }, [templateDetails?.data])
+
+  // Fetches deployment type if current stage is propagated from template based stage
+  useEffect(() => {
+    if (selectedPropagatedState?.value && checkedItems.overrideSetCheckbox) {
+      const stagePropagatedFrom = find(
+        stages,
+        stageData => stageData.stage?.identifier === selectedPropagatedState.value
+      ) as StageElementWrapperConfig
+      const isStagePropagatedFromTemplate = !isEmpty(stagePropagatedFrom.stage?.template?.templateRef)
+
+      if (isStagePropagatedFromTemplate) {
+        setTemplateToFetch((stagePropagatedFrom.stage as StageElementConfig).template)
+        fetchTemplateDetails((stagePropagatedFrom.stage as StageElementConfig).template)
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedPropagatedState?.value, checkedItems.overrideSetCheckbox])
+
   const getScopeBasedDefaultServiceRef = React.useCallback(() => {
     return scope === Scope.PROJECT ? '' : RUNTIME_INPUT_VALUE
   }, [scope])
@@ -421,27 +497,35 @@ export default function DeployServiceSpecifications(props: React.PropsWithChildr
                   />
                 </Layout.Horizontal>
               </>
+          ) : (
+            checkedItems.overrideSetCheckbox &&
+            selectedPropagatedState?.value &&
+            (templateDetailsLoading ? (
+              <Spinner size={Spinner.SIZE_SMALL} />
+            ) : templateDetailsError ? (
+              <Page.Error
+                message={(templateDetailsError?.data as Error)?.message}
+                onClick={() => fetchTemplateDetails(templateToFetch)}
+              />
             ) : (
-              checkedItems.overrideSetCheckbox &&
-              selectedPropagatedState?.value && (
-                <StepWidget<K8SDirectServiceStep>
-                  factory={factory}
-                  readonly={isReadonly}
-                  initialValues={{
-                    stageIndex,
-                    setupModeType
-                  }}
-                  allowableTypes={allowableTypes}
-                  type={StepType.K8sServiceSpec}
-                  stepViewType={StepViewType.Edit}
-                />
-              )
-            )}
-            {((setupModeType === setupMode.PROPAGATE && selectedPropagatedState?.value) ||
-              setupModeType === setupMode.DIFFERENT) && (
-              <Container margin={{ top: 'xxlarge' }}>{props.children}</Container>
-            )}
-          </div>
+              <StepWidget<K8SDirectServiceStep>
+                factory={factory}
+                readonly={isReadonly}
+                initialValues={{
+                  stageIndex,
+                  setupModeType,
+                  deploymentType: selectedDeploymentType as ServiceDefinition['type']
+                }}
+                allowableTypes={allowableTypes}
+                type={getStepTypeByDeploymentType(defaultTo(selectedDeploymentType, ''))}
+                stepViewType={StepViewType.Edit}
+              />
+            ))
+          )}
+          {((setupModeType === setupMode.PROPAGATE && selectedPropagatedState?.value) ||
+            setupModeType === setupMode.DIFFERENT) && (
+            <Container margin={{ top: 'xxlarge' }}>{props.children}</Container>
+          )}
         </div>
       </FormikForm>
     </Formik>

--- a/src/modules/75-cd/components/PipelineStudio/DeployServiceSpecifications/DeployServiceSpecifications.tsx
+++ b/src/modules/75-cd/components/PipelineStudio/DeployServiceSpecifications/DeployServiceSpecifications.tsx
@@ -497,35 +497,40 @@ export default function DeployServiceSpecifications(props: React.PropsWithChildr
                   />
                 </Layout.Horizontal>
               </>
-          ) : (
-            checkedItems.overrideSetCheckbox &&
-            selectedPropagatedState?.value &&
-            (templateDetailsLoading ? (
-              <Spinner size={Spinner.SIZE_SMALL} />
-            ) : templateDetailsError ? (
-              <Page.Error
-                message={(templateDetailsError?.data as Error)?.message}
-                onClick={() => fetchTemplateDetails(templateToFetch)}
-              />
             ) : (
-              <StepWidget<K8SDirectServiceStep>
-                factory={factory}
-                readonly={isReadonly}
-                initialValues={{
-                  stageIndex,
-                  setupModeType,
-                  deploymentType: selectedDeploymentType as ServiceDefinition['type']
-                }}
-                allowableTypes={allowableTypes}
-                type={getStepTypeByDeploymentType(defaultTo(selectedDeploymentType, ''))}
-                stepViewType={StepViewType.Edit}
-              />
-            ))
-          )}
-          {((setupModeType === setupMode.PROPAGATE && selectedPropagatedState?.value) ||
-            setupModeType === setupMode.DIFFERENT) && (
-            <Container margin={{ top: 'xxlarge' }}>{props.children}</Container>
-          )}
+              checkedItems.overrideSetCheckbox &&
+              selectedPropagatedState?.value &&
+              (templateDetailsLoading ? (
+                <Card className={stageCss.sectionCard}>
+                  <Spinner size={Spinner.SIZE_SMALL} />
+                </Card>
+              ) : templateDetailsError ? (
+                <Card className={stageCss.sectionCard}>
+                  <Page.Error
+                    message={(templateDetailsError?.data as Error)?.message}
+                    onClick={() => fetchTemplateDetails(templateToFetch)}
+                  />
+                </Card>
+              ) : (
+                <StepWidget<K8SDirectServiceStep>
+                  factory={factory}
+                  readonly={isReadonly}
+                  initialValues={{
+                    stageIndex,
+                    setupModeType,
+                    deploymentType: selectedDeploymentType as ServiceDefinition['type']
+                  }}
+                  allowableTypes={allowableTypes}
+                  type={getStepTypeByDeploymentType(defaultTo(selectedDeploymentType, ''))}
+                  stepViewType={StepViewType.Edit}
+                />
+              ))
+            )}
+            {((setupModeType === setupMode.PROPAGATE && selectedPropagatedState?.value) ||
+              setupModeType === setupMode.DIFFERENT) && (
+              <Container margin={{ top: 'xxlarge' }}>{props.children}</Container>
+            )}
+          </div>
         </div>
       </FormikForm>
     </Formik>


### PR DESCRIPTION
##### Summary:

If current stage is propagated from a template stage, due to the absence of deployment type in template data, the artifacts and manifests section was not getting rendered. In order to fix this, the template ref is being used to make the get template call and then the deployment type is being obtained from the received yaml.


 ##### Jira Links:

https://harness.atlassian.net/browse/CDS-37143

##### Screenshots:



https://user-images.githubusercontent.com/96409598/167615997-4a2f5ee7-f440-4cc3-b364-6eb783596202.mov


Loading and error updated behaviour --> 


https://user-images.githubusercontent.com/96409598/167731703-e4ded495-3eef-4ff5-bdb0-55ab2a629187.mov

<img width="1792" alt="Screenshot 2022-05-11 at 3 53 38 AM" src="https://user-images.githubusercontent.com/96409598/167731745-3fb8f93c-2064-4c97-a5ae-707a920fc229.png">






You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
