### PR TITLE
fix: [CDS-37145]: initialisation of subscriptionId field for Azure

### DIFF
--- a/src/modules/70-pipeline/components/ArtifactsSelection/ArtifactRepository/ArtifactLastSteps/ACRArtifact/ACRArtifact.tsx
+++ b/src/modules/70-pipeline/components/ArtifactsSelection/ArtifactRepository/ArtifactLastSteps/ACRArtifact/ACRArtifact.tsx
@@ -218,25 +218,25 @@ export function ACRArtifact({
   })
 
   useEffect(() => {
-    /* istanbul ignore else */
-    if (!loadingSubscriptions) {
-      const subscriptionValues = [] as SelectOption[]
-      defaultTo(subscriptionsData?.data?.subscriptions, []).map(sub =>
-        subscriptionValues.push({ label: `${sub.subscriptionName}: ${sub.subscriptionId}`, value: sub.subscriptionId })
-      )
+    const subscriptionValues = [] as SelectOption[]
+    defaultTo(subscriptionsData?.data?.subscriptions, []).map(sub =>
+      subscriptionValues.push({ label: `${sub.subscriptionName}: ${sub.subscriptionId}`, value: sub.subscriptionId })
+    )
 
-      setSubscriptions(subscriptionValues as SelectOption[])
+    setSubscriptions(subscriptionValues as SelectOption[])
+  }, [subscriptionsData])
 
-      const values = getArtifactFormData(
-        initialValues,
-        selectedArtifact as ArtifactType,
-        context === ModalViewFor.SIDECAR
-      ) as ACRArtifactType
+  useEffect(() => {
+    const values = getArtifactFormData(
+      initialValues,
+      selectedArtifact as ArtifactType,
+      context === ModalViewFor.SIDECAR
+    ) as ACRArtifactType
 
-      formikRef?.current?.setFieldValue('subscriptionId', getSubscription(values))
-    }
+    formikRef?.current?.setFieldValue('subscriptionId', getSubscription(values))
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [subscriptionsData, loadingSubscriptions])
+  }, [subscriptions])
 
   const {
     data: registiresData,

--- a/src/modules/70-pipeline/components/ArtifactsSelection/ArtifactRepository/ArtifactLastSteps/ACRArtifact/ACRArtifact.tsx
+++ b/src/modules/70-pipeline/components/ArtifactsSelection/ArtifactRepository/ArtifactLastSteps/ACRArtifact/ACRArtifact.tsx
@@ -29,7 +29,8 @@ import {
   useGetBuildDetailsForACRRepository,
   useGetAzureSubscriptions,
   useGetACRRegistriesBySubscription,
-  useGetACRRepositories
+  useGetACRRepositories,
+  AzureSubscriptionDTO
 } from 'services/cd-ng'
 import { useStrings } from 'framework/strings'
 import { EXPRESSION_STRING } from '@pipeline/utils/constants'
@@ -218,12 +219,18 @@ export function ACRArtifact({
   })
 
   useEffect(() => {
-    const subscriptionValues = [] as SelectOption[]
-    defaultTo(subscriptionsData?.data?.subscriptions, []).map(sub =>
-      subscriptionValues.push({ label: `${sub.subscriptionName}: ${sub.subscriptionId}`, value: sub.subscriptionId })
+    setSubscriptions(
+      defaultTo(subscriptionsData?.data?.subscriptions, []).reduce(
+        (subscriptionValues: SelectOption[], subscription: AzureSubscriptionDTO) => {
+          subscriptionValues.push({
+            label: `${subscription.subscriptionName}: ${subscription.subscriptionId}`,
+            value: subscription.subscriptionId
+          })
+          return subscriptionValues
+        },
+        []
+      )
     )
-
-    setSubscriptions(subscriptionValues as SelectOption[])
   }, [subscriptionsData])
 
   useEffect(() => {

--- a/src/modules/75-cd/components/PipelineSteps/AzureInfrastructureStep/AzureInfrastructureStep.tsx
+++ b/src/modules/75-cd/components/PipelineSteps/AzureInfrastructureStep/AzureInfrastructureStep.tsx
@@ -544,18 +544,19 @@ const AzureInfrastructureSpecEditable: React.FC<AzureInfrastructureSpecEditableP
   })
 
   React.useEffect(() => {
-    /* istanbul ignore else */
-    if (!loadingSubscriptions) {
-      const subscriptionValues = [] as SelectOption[]
-      defaultTo(subscriptionsData?.data?.subscriptions, []).map(sub =>
-        subscriptionValues.push({ label: `${sub.subscriptionName}: ${sub.subscriptionId}`, value: sub.subscriptionId })
-      )
+    const subscriptionValues = [] as SelectOption[]
+    defaultTo(subscriptionsData?.data?.subscriptions, []).map(sub =>
+      subscriptionValues.push({ label: `${sub.subscriptionName}: ${sub.subscriptionId}`, value: sub.subscriptionId })
+    )
 
-      setSubscriptions(subscriptionValues as SelectOption[])
-      formikRef?.current?.setFieldValue('subscriptionId', getSubscription(initialValues))
-    }
+    setSubscriptions(subscriptionValues as SelectOption[])
+  }, [subscriptionsData])
+
+  useEffect(() => {
+    formikRef?.current?.setFieldValue('subscriptionId', getSubscription(initialValues))
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [subscriptionsData, loadingSubscriptions])
+  }, [subscriptions])
 
   React.useEffect(() => {
     if (initialValues.connectorRef && getMultiTypeFromValue(initialValues.connectorRef) === MultiTypeInputType.FIXED) {

--- a/src/modules/75-cd/components/PipelineSteps/AzureInfrastructureStep/AzureInfrastructureStep.tsx
+++ b/src/modules/75-cd/components/PipelineSteps/AzureInfrastructureStep/AzureInfrastructureStep.tsx
@@ -30,6 +30,7 @@ import { StepViewType, StepProps, ValidateInputSetProps } from '@pipeline/compon
 import { DeployTabs } from '@pipeline/components/PipelineStudio/CommonUtils/DeployStageSetupShellUtils'
 import { ConfigureOptions } from '@common/components/ConfigureOptions/ConfigureOptions'
 import {
+  AzureSubscriptionDTO,
   getAzureClustersPromise,
   getAzureResourceGroupsBySubscriptionPromise,
   getAzureSubscriptionsPromise,
@@ -134,12 +135,18 @@ const AzureInfrastructureSpecInputForm: React.FC<AzureInfrastructureSpecEditable
   })
 
   useEffect(() => {
-    const subscriptionValues = [] as SelectOption[]
-    defaultTo(subscriptionsData?.data?.subscriptions, []).map(sub =>
-      subscriptionValues.push({ label: `${sub.subscriptionName}: ${sub.subscriptionId}`, value: sub.subscriptionId })
+    setSubscriptions(
+      defaultTo(subscriptionsData?.data?.subscriptions, []).reduce(
+        (subscriptionValues: SelectOption[], subscription: AzureSubscriptionDTO) => {
+          subscriptionValues.push({
+            label: `${subscription.subscriptionName}: ${subscription.subscriptionId}`,
+            value: subscription.subscriptionId
+          })
+          return subscriptionValues
+        },
+        []
+      )
     )
-
-    setSubscriptions(subscriptionValues as SelectOption[])
   }, [subscriptionsData])
 
   useEffect(() => {


### PR DESCRIPTION
##### Summary:

initialisation of subscriptionId field for ACR artifact and Azure infrastructure when subscriptionId exists in the list of subscriptions

##### Jira Links:
https://harness.atlassian.net/browse/CDS-37145

##### Screenshots:
https://user-images.githubusercontent.com/96610348/167442654-39a426cd-cbfc-4509-9d26-9d7d8093152c.mov

https://user-images.githubusercontent.com/96610348/167442692-79918398-db6f-41d8-81eb-95d0bd289cde.mov


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
