### PR TITLE
feat: [SRM-9868]: Add ET copy config to monitored services

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "strings:genTypes": "node scripts/strings/generateTypesCli.mjs",
     "strings:loaders": "node scripts/strings/generateStrings.mjs",
     "prepare": "husky install && patch-package",
-    "fmt": "prettier --write \"./src/**/*.{ts,tsx,css}\"",
+    "fmt": "prettier --write \"./src/**/*.{ts,tsx,css,scss}\"",
     "generate-merged-coverage": "node mergedCoverage.js",
     "generate-microfrontend-types": "rm -rf src/microfrontends/dist && webpack --config src/microfrontends/webpack.config.js",
     "publish-types": "yarn generate-microfrontend-types; yarn publish src/microfrontends;",

--- a/src/modules/85-cv/components/ContextMenuActions/ContextMenuActions.module.scss
+++ b/src/modules/85-cv/components/ContextMenuActions/ContextMenuActions.module.scss
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+.bp3-menu-item {
+  > .contextCopyIcon {
+    margin-top: 2px;
+    margin-right: 7px;
+  }
+}

--- a/src/modules/85-cv/components/ContextMenuActions/ContextMenuActions.module.scss.d.ts
+++ b/src/modules/85-cv/components/ContextMenuActions/ContextMenuActions.module.scss.d.ts
@@ -1,0 +1,13 @@
+/* eslint-disable */
+/**
+ * Copyright 2021 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ **/
+// this is an auto-generated file, do not update this manually
+declare const styles: {
+  readonly bp3MenuItem: string
+  readonly contextCopyIcon: string
+}
+export default styles

--- a/src/modules/85-cv/components/ContextMenuActions/ContextMenuActions.tsx
+++ b/src/modules/85-cv/components/ContextMenuActions/ContextMenuActions.tsx
@@ -7,19 +7,22 @@
 
 import React, { useState } from 'react'
 import { Menu, Popover, Position } from '@blueprintjs/core'
-import { Button, ButtonVariation, useConfirmationDialog } from '@wings-software/uicore'
+import { Button, ButtonVariation, Icon, useConfirmationDialog } from '@wings-software/uicore'
 import { Color } from '@harness/design-system'
 import { String, useStrings } from 'framework/strings'
 import type { ContextMenuActionsProps } from '@cv/pages/monitored-service/CVMonitoredService/CVMonitoredService.types'
 import RbacMenuItem from '@rbac/components/MenuItem/MenuItem'
+import css from './ContextMenuActions.module.scss'
 
 export default function ContextMenuActions({
   onEdit,
+  onCopy,
   onDelete,
   titleText,
   contentText,
   confirmButtonText,
   deleteLabel,
+  copyLabel,
   editLabel,
   RbacPermissions
 }: ContextMenuActionsProps): JSX.Element {
@@ -52,6 +55,14 @@ export default function ContextMenuActions({
               text={editLabel ?? <String stringID="edit" />}
               onClick={onEdit}
               permission={RbacPermissions?.edit}
+            />
+          )}
+          {!!onCopy && (
+            <RbacMenuItem
+              className={css.bp3MenuItem}
+              icon={<Icon className={css.contextCopyIcon} name="copy-alt" />}
+              text={copyLabel ?? <String stringID="common.copy" />}
+              onClick={onCopy}
             />
           )}
           {!!onDelete && (

--- a/src/modules/85-cv/pages/monitored-service/CVMonitoredService/CVMonitoredService.types.ts
+++ b/src/modules/85-cv/pages/monitored-service/CVMonitoredService/CVMonitoredService.types.ts
@@ -18,11 +18,13 @@ interface ContextMenuRbacPermissions {
 
 export interface ContextMenuActionsProps {
   onEdit?(): void
+  onCopy?(): void
   onDelete?(): void
   titleText: string
   contentText: string | JSX.Element
   confirmButtonText?: string
   deleteLabel?: string
+  copyLabel?: string
   editLabel?: string
   RbacPermissions?: ContextMenuRbacPermissions
 }

--- a/src/modules/85-cv/pages/monitored-service/CVMonitoredService/components/MonitoredServiceListView/MonitoredServiceListView.tsx
+++ b/src/modules/85-cv/pages/monitored-service/CVMonitoredService/components/MonitoredServiceListView/MonitoredServiceListView.tsx
@@ -8,7 +8,7 @@
 import React from 'react'
 import { useParams, Link } from 'react-router-dom'
 import type { CellProps, Renderer } from 'react-table'
-import { Container, Text, Layout, TableV2, NoDataCard, Heading } from '@wings-software/uicore'
+import { Container, Text, Layout, TableV2, NoDataCard, Heading, Utils } from '@wings-software/uicore'
 import { FontVariation, Color } from '@harness/design-system'
 import { useStrings } from 'framework/strings'
 import { ResourceType } from '@rbac/interfaces/ResourceType'
@@ -187,7 +187,7 @@ const MonitoredServiceListView: React.FC<MonitoredServiceListViewProps> = ({
 }) => {
   const { getString } = useStrings()
 
-  const { projectIdentifier } = useParams<ProjectPathProps>()
+  const { projectIdentifier, orgIdentifier, accountId } = useParams<ProjectPathProps>()
 
   const { content, pageSize = 0, pageIndex = 0, totalPages = 0, totalItems = 0 } = monitoredServiceListData || {}
   const RenderStatusToggle: Renderer<CellProps<MonitoredServiceListItemDTO>> = ({ row }) => {
@@ -203,6 +203,17 @@ const MonitoredServiceListView: React.FC<MonitoredServiceListViewProps> = ({
       },
       [projectIdentifier]
     )
+
+    const onCopy = (): void => {
+      const environmentVariables = `ET_COLLECTOR_URL: <check documentation for value>
+ET_PROJECT_ID: ${projectIdentifier}
+ET_ACCOUNT_ID: ${accountId}
+ET_ORG_ID: ${orgIdentifier}
+ET_ENV_ID: ${monitoredService.environmentRef}
+ET_APPLICATION_NAME: ${monitoredService.serviceRef}
+ET_DEPLOYMENT_NAME: <replace with deployment version>`
+      Utils.copy(environmentVariables)
+    }
 
     return (
       <Layout.Horizontal flex={{ alignItems: 'center' }}>
@@ -226,6 +237,8 @@ const MonitoredServiceListView: React.FC<MonitoredServiceListViewProps> = ({
           onEdit={() => {
             onEditService(monitoredService.identifier as string)
           }}
+          copyLabel={getString('cv.monitoredServices.copyET')}
+          onCopy={() => onCopy()}
           RbacPermissions={{
             edit: {
               permission: PermissionIdentifier.EDIT_MONITORED_SERVICE,

--- a/src/modules/85-cv/pages/monitored-service/CVMonitoredService/components/MonitoredServiceListView/MonitoredServiceListView.tsx
+++ b/src/modules/85-cv/pages/monitored-service/CVMonitoredService/components/MonitoredServiceListView/MonitoredServiceListView.tsx
@@ -238,7 +238,7 @@ ET_DEPLOYMENT_NAME: <replace with deployment version>`
             onEditService(monitoredService.identifier as string)
           }}
           copyLabel={getString('cv.monitoredServices.copyET')}
-          onCopy={() => onCopy()}
+          onCopy={onCopy}
           RbacPermissions={{
             edit: {
               permission: PermissionIdentifier.EDIT_MONITORED_SERVICE,

--- a/src/modules/85-cv/strings/strings.en.yaml
+++ b/src/modules/85-cv/strings/strings.en.yaml
@@ -452,6 +452,7 @@ monitoredServices:
   editService: Edit service
   deleteMonitoredServiceWarning: Deleting your monitored service ‘{{ name }}’ will also delete its resources.
   deleteService: Delete service
+  copyET: Copy Error Tracking Config
   monitoredServiceDeleted: Monitored service successfully deleted
   monitoredServiceCreated: Monitored Service created
   monitoredServiceUpdated: Monitored Service updated

--- a/src/stringTypes.ts
+++ b/src/stringTypes.ts
@@ -5418,6 +5418,7 @@ export interface StringsMap {
   'cv.monitoredServices.changeMonitoredServiceTypeMessage': string
   'cv.monitoredServices.changesTable.impact': string
   'cv.monitoredServices.continuousVerification': string
+  'cv.monitoredServices.copyET': string
   'cv.monitoredServices.deleteMonitoredServiceWarning': string
   'cv.monitoredServices.deleteService': string
   'cv.monitoredServices.dependenciesHealth': string


### PR DESCRIPTION
##### Summary:

Add the ability to copy Error Tracking config from the Monitored Service

##### Jira Links:

https://harness.atlassian.net/browse/SRM-9868

##### Screenshots:

Before:

![Screen Shot 2022-05-09 at 9 04 32 PM](https://user-images.githubusercontent.com/2991478/167522275-8ad91b7a-5f5b-40dd-9c9d-e9963212fe27.png)

After:

![Screen Shot 2022-05-09 at 9 06 19 PM](https://user-images.githubusercontent.com/2991478/167522406-94df3dbf-2eab-451a-978d-6cad286c8900.png)

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
