### PR TITLE
fix: [PL-24810]: Disallow ticking default SM for a read only SM in HashiCorp Vault modal

### DIFF
--- a/src/modules/35-connectors/components/CreateConnector/HashiCorpVault/views/VaultConfigForm.tsx
+++ b/src/modules/35-connectors/components/CreateConnector/HashiCorpVault/views/VaultConfigForm.tsx
@@ -141,7 +141,7 @@ const VaultConfigForm: React.FC<StepProps<StepDetailsProps> & ConnectorDetailsPr
           }),
           default: Yup.boolean().when('readOnly', {
             is: true,
-            then: Yup.boolean().oneOf([false], getString('connectors.hashiCorpVault.preventDefaultWhenReadOnly'))
+            then: Yup.boolean().equals([false], getString('connectors.hashiCorpVault.preventDefaultWhenReadOnly'))
           })
         })}
         onSubmit={formData => {

--- a/src/modules/35-connectors/components/CreateConnector/HashiCorpVault/views/VaultConfigForm.tsx
+++ b/src/modules/35-connectors/components/CreateConnector/HashiCorpVault/views/VaultConfigForm.tsx
@@ -138,6 +138,10 @@ const VaultConfigForm: React.FC<StepProps<StepDetailsProps> & ConnectorDetailsPr
           serviceAccountTokenPath: Yup.string().when('accessType', {
             is: HashiCorpVaultAccessTypes.K8s_AUTH,
             then: Yup.string().trim().required(getString('connectors.hashiCorpVault.serviceAccountRequired'))
+          }),
+          default: Yup.boolean().when('readOnly', {
+            is: true,
+            then: Yup.boolean().oneOf([false], getString('connectors.hashiCorpVault.preventDefaultWhenReadOnly'))
           })
         })}
         onSubmit={formData => {

--- a/src/modules/35-connectors/strings/strings.en.yaml
+++ b/src/modules/35-connectors/strings/strings.en.yaml
@@ -236,6 +236,7 @@ hashiCorpVault:
   serviceAccountTokenPath: Service Account Token Path
   vaultK8sAuthRoleRequired: Role Required
   serviceAccountRequired: Service Account Token Path Required
+  preventDefaultWhenReadOnly: Read only secret manager cannot be set as default
 nexus:
   nexusLabel: Nexus
   nexusServerUrl: 'Nexus Repository URL'

--- a/src/stringTypes.ts
+++ b/src/stringTypes.ts
@@ -1917,6 +1917,7 @@ export interface StringsMap {
   'connectors.hashiCorpVault.fetchEngines': string
   'connectors.hashiCorpVault.k8s_auth': string
   'connectors.hashiCorpVault.manuallyConfigureEngine': string
+  'connectors.hashiCorpVault.preventDefaultWhenReadOnly': string
   'connectors.hashiCorpVault.readOnly': string
   'connectors.hashiCorpVault.readOnlyVault': string
   'connectors.hashiCorpVault.renewal': string


### PR DESCRIPTION
##### Summary:

Added validation for default secret manager checkbox, to be equal to false when read only checkbox is ticked

##### Jira Links: 

https://harness.atlassian.net/browse/PL-24810

##### Screenshots:

<img width="1680" alt="Screenshot 2022-05-10 at 3 41 49 PM" src="https://user-images.githubusercontent.com/97941439/167606659-deec586f-9994-47a2-9acf-05930f217ad9.png">


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
