### PR TITLE
fix: [CDS-37258]: list refetching in ACR artifract runtime form hotfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nextgenui",
   "description": "Harness Inc",
-  "version": "0.299.1",
+  "version": "0.299.2",
   "author": "Harness Inc",
   "license": "Harness Inc",
   "homepage": "http://app.harness.io/",

--- a/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/ArtifactSource/ACRArtifactSource/ACRArtifactSource.tsx
+++ b/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/ArtifactSource/ACRArtifactSource/ACRArtifactSource.tsx
@@ -337,9 +337,13 @@ const Content = (props: ACRRenderContent): JSX.Element => {
                 ) => {
                   resetTags(formik, `${path}.artifacts.${artifactPath}.spec.tag`)
                   if (value?.value && type === MultiTypeInputType.FIXED) {
+                    const connectorRef = defaultTo(
+                      get(formik?.values, `${path}.artifacts.${artifactPath}.spec.connectorRef`),
+                      artifact?.spec?.connectorRef
+                    )
                     refetchRegistries({
                       queryParams: {
-                        connectorRef: get(formik?.values, `${path}.artifacts.${artifactPath}.spec.connectorRef`),
+                        connectorRef,
                         accountIdentifier: accountId,
                         orgIdentifier,
                         projectIdentifier,
@@ -389,13 +393,21 @@ const Content = (props: ACRRenderContent): JSX.Element => {
                   resetTags(formik.values, `${path}.artifacts.${artifactPath}.spec.tag`)
 
                   if (value?.value && type === MultiTypeInputType.FIXED) {
+                    const connectorRef = defaultTo(
+                      get(formik?.values, `${path}.artifacts.${artifactPath}.spec.connectorRef`),
+                      artifact?.spec?.connectorRef
+                    )
+                    const subscriptionId = defaultTo(
+                      get(formik.values, `${path}.artifacts.${artifactPath}.spec.subscriptionId`),
+                      artifact?.spec?.subscriptionId
+                    )
                     refetchRepositories({
                       queryParams: {
-                        connectorRef: get(formik.values, `${path}.artifacts.${artifactPath}.spec.connectorRef`),
+                        connectorRef,
                         accountIdentifier: accountId,
                         orgIdentifier,
                         projectIdentifier,
-                        subscriptionId: get(formik.values, `${path}.artifacts.${artifactPath}.spec.subscriptionId`)
+                        subscriptionId
                       },
                       pathParams: {
                         registry: getValue(value)


### PR DESCRIPTION
##### Summary:

Fix props for refetching subscriptions, registries, repositories for ACR artifact runtime form

##### Jira Links:

(https://harness.atlassian.net/browse/CDS-37258)

##### Screenshots:

https://user-images.githubusercontent.com/96610348/167641290-c0b4823c-0d75-4d7c-b365-2da3aa722943.mov


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
