### PR TITLE
feat: [CDS-34833]: RequiredFields will be rendered depending on issue…

### DIFF
--- a/cypress/fixtures/ng/api/jiraIssueTypes.json
+++ b/cypress/fixtures/ng/api/jiraIssueTypes.json
@@ -13,21 +13,31 @@
             "description": "A problem or error.",
             "statuses": [],
             "fields": {
-              "Comment": {
-                "key": "comment",
-                "name": "Comment",
-                "required": false,
+              "Description": {
+                "key": "description",
+                "name": "Description",
+                "required": true,
                 "schema": {
                   "array": false,
-                  "typeStr": null,
+                  "typeStr": "string",
                   "type": "string",
                   "customType": null
                 },
                 "allowedValues": [],
                 "custom": false
+              },
+              "Summary": {
+                "key": "summary",
+                "name": "Summary",
+                "required": true,
+                "schema": {
+                  "array": false,
+                  "typeStr": "string",
+                  "type": "string",
+                  "customType": null
+                }
               }
-            },
-            "subTask": false
+            }
           }
         }
       }

--- a/cypress/integration/70-pipeline/RunPipeline.spec.ts
+++ b/cypress/integration/70-pipeline/RunPipeline.spec.ts
@@ -314,7 +314,6 @@ describe.skip('RUN PIPELINE MODAL', () => {
         cy.contains('span', 'Jira Connector is required').should('be.visible').should('have.class', 'FormError--error')
         cy.contains('span', 'Project is required').should('be.visible').should('have.class', 'FormError--error')
         cy.contains('span', 'Issue Type is required').should('be.visible').should('have.class', 'FormError--error')
-        cy.contains('span', 'Summary is required').should('be.visible').should('have.class', 'FormError--error')
       })
 
       it('Submit form after filling details', () => {
@@ -336,7 +335,9 @@ describe.skip('RUN PIPELINE MODAL', () => {
         cy.get('input[name="spec.issueType"]').click({ force: true })
         cy.contains('p', 'Bug').click({ force: true })
         cy.wait(1000)
-        cy.fillField('spec.summary', 'Test_Summary')
+        cy.fillField('spec.selectedRequiredFields[0].value', 'Test_Description')
+        cy.wait(1000)
+        cy.fillField('spec.selectedRequiredFields[1].value', 'Test_Summary')
         cy.wait(1000)
         cy.contains('span', 'Apply Changes').click({ force: true })
       })

--- a/cypress/integration/70-pipeline/RunPipeline.spec.ts
+++ b/cypress/integration/70-pipeline/RunPipeline.spec.ts
@@ -11,7 +11,7 @@ import {
   pipelineSaveCall
 } from '../../support/70-pipeline/constants'
 
-describe.skip('RUN PIPELINE MODAL', () => {
+describe('RUN PIPELINE MODAL', () => {
   const gitSyncCall =
     '/ng/api/git-sync/git-sync-enabled?accountIdentifier=accountId&orgIdentifier=default&projectIdentifier=project1'
   const resolvedPipelineDetailsCall =
@@ -52,7 +52,7 @@ describe.skip('RUN PIPELINE MODAL', () => {
     cy.clickSubmit()
   })
 
-  describe('Tests close without saving dialog for pipeline', () => {
+  describe.skip('Tests close without saving dialog for pipeline', () => {
     it('should display the close without saving dialog for pipeline', () => {
       cy.contains('p', 'Pipelines').click()
       cy.contains('p', 'Close without saving?').should('be.visible')
@@ -62,7 +62,7 @@ describe.skip('RUN PIPELINE MODAL', () => {
     })
   })
 
-  describe('For deploy stage', () => {
+  describe.skip('For deploy stage', () => {
     beforeEach(() => {
       switch (Cypress.currentTest.title) {
         case 'error validations on pipeline save from API':
@@ -203,7 +203,7 @@ describe.skip('RUN PIPELINE MODAL', () => {
       })
     })
   })
-  describe('For approval stage', () => {
+  describe.skip('For approval stage', () => {
     beforeEach(() => {
       cy.get('[icon="plus"]').click()
       cy.findByTestId('stage-Approval').click()
@@ -289,7 +289,7 @@ describe.skip('RUN PIPELINE MODAL', () => {
       cy.intercept('GET', jirayamlSnippetCall, { fixture: 'pipeline/api/jiraStage/stageYamlSnippet' }).as('stageYaml')
       cy.intercept('POST', stepsCall, { fixture: 'pipeline/api/approvals/steps' })
     })
-    it('should display the delete pipeline stage modal', () => {
+    it.skip('should display the delete pipeline stage modal', () => {
       cy.wait('@stageYaml')
       cy.wait(1000)
       cy.get('[icon="play"]').click({ force: true, multiple: true })
@@ -314,6 +314,30 @@ describe.skip('RUN PIPELINE MODAL', () => {
         cy.contains('span', 'Jira Connector is required').should('be.visible').should('have.class', 'FormError--error')
         cy.contains('span', 'Project is required').should('be.visible').should('have.class', 'FormError--error')
         cy.contains('span', 'Issue Type is required').should('be.visible').should('have.class', 'FormError--error')
+      })
+
+      it('Submit form with empty required fields validations', () => {
+        cy.intercept('GET', jiraConnectorsCall, { fixture: 'ng/api/jiraConnectors' })
+        cy.intercept('GET', jiraProjectsCall, { fixture: 'ng/api/jiraProjects' })
+        cy.intercept('GET', jiraIssueTypesCall, { fixture: 'ng/api/jiraIssueTypes' })
+        cy.wait(2000)
+        cy.contains('span', 'Execution').click({ force: true })
+        cy.wait(4000)
+        cy.contains('p', 'Jira Create').click()
+        cy.wait(4000)
+        cy.contains('span', 'Select Connector').click({ force: true })
+        cy.contains('p', 'Jira cloudJira cloudJira cloudJira cloudJira cloudJira cloud').click({ force: true })
+        cy.contains('span', 'Apply Selected').click({ force: true })
+        cy.wait(1000)
+        cy.get('input[name="spec.projectKey"]').click({ force: true })
+        cy.contains('p', 'ART').click({ force: true })
+        cy.wait(1000)
+        cy.get('input[name="spec.issueType"]').click({ force: true })
+        cy.contains('p', 'Bug').click({ force: true })
+        cy.wait(1000)
+        cy.contains('span', 'Apply Changes').click({ force: true })
+        cy.contains('span', 'This is a required field').should('be.visible').should('have.class', 'FormError--error')
+        cy.wait(1000)
       })
 
       it('Submit form after filling details', () => {

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraCreate/JiraCreate.module.scss
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraCreate/JiraCreate.module.scss
@@ -6,7 +6,7 @@
  */
 
 .md {
-  width: 75%;
+  width: 390px;
 }
 
 .connector {

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraCreate/JiraCreate.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraCreate/JiraCreate.tsx
@@ -46,8 +46,6 @@ export class JiraCreate extends PipelineStep<JiraCreateData> {
       connectorRef: '',
       projectKey: '',
       issueType: '',
-      summary: '',
-      description: '',
       fields: []
     }
   }
@@ -60,9 +58,6 @@ export class JiraCreate extends PipelineStep<JiraCreateData> {
   }: ValidateInputSetProps<JiraCreateData>): FormikErrors<JiraCreateData> {
     const errors: FormikErrors<JiraCreateData> = {}
     const isRequired = viewType === StepViewType.DeploymentForm || viewType === StepViewType.TriggerForm
-    const isSummaryRuntime =
-      getMultiTypeFromValue(template?.spec?.fields?.find(field => field.name === 'Summary')?.value as string) ===
-      MultiTypeInputType.RUNTIME
 
     if (
       typeof template?.spec?.connectorRef === 'string' &&
@@ -96,13 +91,6 @@ export class JiraCreate extends PipelineStep<JiraCreateData> {
       errors.spec = {
         ...errors.spec,
         issueType: getString?.('pipeline.jiraApprovalStep.validations.issueType')
-      }
-    }
-
-    if (isSummaryRuntime && isEmpty(data?.spec?.summary) && isRequired) {
-      errors.spec = {
-        ...errors.spec,
-        summary: getString?.('pipeline.jiraCreateStep.validations.summary')
       }
     }
 

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraCreate/JiraCreateDeploymentMode.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraCreate/JiraCreateDeploymentMode.tsx
@@ -20,7 +20,6 @@ import { useQueryParams } from '@common/hooks'
 import { FormMultiTypeDurationField } from '@common/components/MultiTypeDuration/MultiTypeDuration'
 import { useVariablesExpression } from '@pipeline/components/PipelineStudio/PiplineHooks/useVariablesExpression'
 import { FormMultiTypeConnectorField } from '@connectors/components/ConnectorReferenceField/FormMultiTypeConnectorField'
-import { FormMultiTypeTextAreaField } from '@common/components'
 import { JiraProjectBasicNG, JiraProjectNG, useGetJiraIssueCreateMetadata, useGetJiraProjects } from 'services/cd-ng'
 import { getGenuineValue, setIssueTypeOptions } from '../JiraApproval/helper'
 import type { JiraProjectSelectOption } from '../JiraApproval/types'
@@ -209,36 +208,6 @@ function FormContent(formContentProps: JiraCreateDeploymentModeFormContentInterf
               items: setIssueTypeOptions(projectMetadata?.issuetypes)
             }
           }}
-        />
-      ) : null}
-
-      {getMultiTypeFromValue(template?.spec?.fields?.find(field => field.name === 'Summary')?.value as string) ===
-      MultiTypeInputType.RUNTIME ? (
-        <FormInput.MultiTextInput
-          label={getString('summary')}
-          className={css.deploymentViewMedium}
-          name={`${prefix}spec.summary`}
-          disabled={isApprovalStepFieldDisabled(readonly)}
-          placeholder={getString('pipeline.jiraCreateStep.summaryPlaceholder')}
-          multiTextInputProps={{
-            allowableTypes,
-            expressions
-          }}
-        />
-      ) : null}
-
-      {getMultiTypeFromValue(template?.spec?.fields?.find(field => field.name === 'Description')?.value as string) ===
-      MultiTypeInputType.RUNTIME ? (
-        <FormMultiTypeTextAreaField
-          multiTypeTextArea={{
-            expressions,
-            allowableTypes
-          }}
-          label={getString('description')}
-          className={css.deploymentViewMedium}
-          name={`${prefix}spec.description`}
-          disabled={isApprovalStepFieldDisabled(readonly)}
-          placeholder={getString('common.descriptionPlaceholder')}
         />
       ) : null}
     </React.Fragment>

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraCreate/JiraCreateStepMode.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraCreate/JiraCreateStepMode.tsx
@@ -47,7 +47,6 @@ import type {
   PipelineType
 } from '@common/interfaces/RouteInterfaces'
 import { FormMultiTypeConnectorField } from '@connectors/components/ConnectorReferenceField/FormMultiTypeConnectorField'
-import { FormMultiTypeTextAreaField } from '@common/components'
 import { useQueryParams } from '@common/hooks'
 import { ConfigureOptions } from '@common/components/ConfigureOptions/ConfigureOptions'
 import type { JiraProjectSelectOption } from '../JiraApproval/types'
@@ -130,9 +129,10 @@ function FormContent({
     } else if (connectorRefFixedValue !== undefined) {
       // Undefined check is needed so that form is not set to dirty as soon as we open
       // This means we've cleared the value or marked runtime/expression
-      // Flush the selected additional fields, and move everything to key value fields
+      // Flush the selected optional fields, and move everything to key value fields
       // formik.setFieldValue('spec.fields', getKVFields(formik.values))
-      formik.setFieldValue('spec.selectedFields', [])
+      formik.setFieldValue('spec.selectedRequiredFields', [])
+      formik.setFieldValue('spec.selectedOptionalFields', [])
     }
   }, [connectorRefFixedValue])
 
@@ -149,9 +149,10 @@ function FormContent({
     } else if (connectorRefFixedValue !== undefined && projectKeyFixedValue !== undefined) {
       // Undefined check is needed so that form is not set to dirty as soon as we open
       // This means we've cleared the value or marked runtime/expression
-      // Flush the selected additional fields, and move everything to key value fields
+      // Flush the selected optional and required fields, and move everything to key value fields
       // formik.setFieldValue('spec.fields', getKVFields(formik.values))
-      formik.setFieldValue('spec.selectedFields', [])
+      formik.setFieldValue('spec.selectedRequiredFields', [])
+      formik.setFieldValue('spec.selectedOptionalFields', [])
     }
   }, [projectKeyFixedValue])
 
@@ -160,27 +161,41 @@ function FormContent({
     if (issueTypeFixedValue) {
       const issueTypeData = projectMetadata?.issuetypes[issueTypeFixedValue]
       const fieldKeys = Object.keys(issueTypeData?.fields || {})
-      const formikSelectedFields: JiraFieldNGWithValue[] = []
+      const formikOptionalFields: JiraFieldNGWithValue[] = []
+      const formikRequiredFields: JiraFieldNGWithValue[] = []
       fieldKeys.forEach(keyy => {
         const field = issueTypeData?.fields[keyy]
-        if (field && keyy !== 'Summary' && keyy !== 'Description') {
+        if (field) {
           const savedValueForThisField = getInitialValueForSelectedField(formik.values.spec.fields, field)
-          if (savedValueForThisField) {
-            formikSelectedFields.push({ ...field, value: savedValueForThisField })
+          if (savedValueForThisField && !field.required) {
+            formikOptionalFields.push({ ...field, value: savedValueForThisField })
           } else if (field.required) {
-            formikSelectedFields.push({ ...field, value: !isEmpty(field.allowedValues) ? [] : '' })
+            formikRequiredFields.push({
+              ...field,
+              //this check is needed for multiselect or single select fields
+              //as these fields accepts value in the form of array and if savedValueForThisField which is
+              //of string is empty, we need to ensure the value is set to empty array
+              value: !isEmpty(field.allowedValues) && !savedValueForThisField ? [] : savedValueForThisField
+            })
           }
         }
       })
-      formik.setFieldValue('spec.selectedFields', formikSelectedFields)
-      const toBeUpdatedKVFields = getKVFieldsToBeAddedInForm(formik.values.spec.fields, [], formikSelectedFields)
+      formik.setFieldValue('spec.selectedRequiredFields', formikRequiredFields)
+      formik.setFieldValue('spec.selectedOptionalFields', formikOptionalFields)
+      const toBeUpdatedKVFields = getKVFieldsToBeAddedInForm(
+        formik.values.spec.fields,
+        [],
+        formikOptionalFields,
+        formikRequiredFields
+      )
       formik.setFieldValue('spec.fields', toBeUpdatedKVFields)
     } else if (issueTypeFixedValue !== undefined) {
       // Undefined check is needed so that form is not set to dirty as soon as we open
       // This means we've cleared the value or marked runtime/expression
       // Flush the selected additional fields, and move everything to key value fields
       // formik.setFieldValue('spec.fields', getKVFields(formik.values))
-      formik.setFieldValue('spec.selectedFields', [])
+      formik.setFieldValue('spec.selectedRequiredFields', [])
+      formik.setFieldValue('spec.selectedOptionalFields', [])
     }
   }, [issueTypeFixedValue, projectMetadata])
 
@@ -219,13 +234,13 @@ function FormContent({
           selectedIssueTypeKey={issueTypeFixedValue || ''}
           jiraType={jiraType}
           projectOptions={projectOptions}
-          selectedFields={formik.values.spec.selectedFields}
+          selectedFields={formik.values.spec.selectedOptionalFields}
           addSelectedFields={(fieldsToBeAdded: JiraFieldNG[]) => {
             formik.setFieldValue(
-              'spec.selectedFields',
+              'spec.selectedOptionalFields',
               getSelectedFieldsToBeAddedInForm(
                 fieldsToBeAdded,
-                formik.values.spec.selectedFields,
+                formik.values.spec.selectedOptionalFields,
                 formik.values.spec.fields
               )
             )
@@ -234,7 +249,7 @@ function FormContent({
           provideFieldList={(fields: JiraCreateFieldType[]) => {
             formik.setFieldValue(
               'spec.fields',
-              getKVFieldsToBeAddedInForm(fields, formik.values.spec.fields, formik.values.spec.selectedFields)
+              getKVFieldsToBeAddedInForm(fields, formik.values.spec.fields, formik.values.spec.selectedOptionalFields)
             )
             hideDynamicFieldsModal()
           }}
@@ -242,7 +257,7 @@ function FormContent({
         />
       </Dialog>
     )
-  }, [projectOptions, connectorRefFixedValue, formik.values.spec.selectedFields, formik.values.spec.fields])
+  }, [projectOptions, connectorRefFixedValue, formik.values.spec.selectedOptionalFields, formik.values.spec.fields])
 
   function AddFieldsButton(): React.ReactElement {
     return (
@@ -452,29 +467,12 @@ function FormContent({
             />
           )}
         </div>
-        <div className={cx(stepCss.formGroup, stepCss.lg)}>
-          <FormInput.MultiTextInput
-            label={getString('summary')}
-            name="spec.summary"
-            placeholder={getString('pipeline.jiraCreateStep.summaryPlaceholder')}
-            multiTextInputProps={{
-              expressions,
-              allowableTypes
-            }}
-            disabled={isApprovalStepFieldDisabled(readonly)}
+        <div>
+          <JiraFieldsRenderer
+            selectedFields={formik.values.spec.selectedRequiredFields}
+            renderRequiredFields={true}
+            readonly={readonly}
           />
-          {getMultiTypeFromValue(formik.values.spec.summary) === MultiTypeInputType.RUNTIME && (
-            <ConfigureOptions
-              value={formik.values.spec.summary || ''}
-              type="String"
-              variableName="spec.summary"
-              showRequiredField={false}
-              showDefaultField={false}
-              showAdvanced={true}
-              onChange={value => formik.setFieldValue('spec.summary', value)}
-              isReadonly={readonly}
-            />
-          )}
         </div>
 
         <div className={stepCss.noLookDivider} />
@@ -486,40 +484,18 @@ function FormContent({
           summary={getString('common.optionalConfig')}
           details={
             <div>
-              <div className={cx(stepCss.formGroup)}>
-                <FormMultiTypeTextAreaField
-                  name="spec.description"
-                  label={getString('description')}
-                  className={cx(css.descriptionField)}
-                  multiTypeTextArea={{ enableConfigureOptions: false, expressions, allowableTypes }}
-                  placeholder={getString('common.descriptionPlaceholder')}
-                  disabled={isApprovalStepFieldDisabled(readonly)}
-                />
-                {getMultiTypeFromValue(formik.values.spec.description) === MultiTypeInputType.RUNTIME && (
-                  <ConfigureOptions
-                    value={formik.values.spec.description || ''}
-                    type="String"
-                    variableName="spec.description"
-                    showRequiredField={false}
-                    showDefaultField={false}
-                    showAdvanced={true}
-                    onChange={value => formik.setFieldValue('spec.description', value)}
-                    isReadonly={readonly}
-                  />
-                )}
-              </div>
               {fetchingProjectMetadata ? (
                 <PageSpinner message={getString('pipeline.jiraCreateStep.fetchingFields')} className={css.fetching} />
               ) : (
                 <>
                   <JiraFieldsRenderer
-                    selectedFields={formik.values.spec.selectedFields}
+                    selectedFields={formik.values.spec.selectedOptionalFields}
                     readonly={readonly}
                     onDelete={(index, selectedField) => {
-                      const selectedFieldsAfterRemoval = formik.values.spec.selectedFields?.filter(
+                      const selectedOptionalFieldsAfterRemoval = formik.values.spec.selectedOptionalFields?.filter(
                         (_unused, i) => i !== index
                       )
-                      formik.setFieldValue('spec.selectedFields', selectedFieldsAfterRemoval)
+                      formik.setFieldValue('spec.selectedOptionalFields', selectedOptionalFieldsAfterRemoval)
                       const customFields = formik.values.spec.fields?.filter(field => field.name !== selectedField.name)
                       formik.setFieldValue('spec.fields', customFields)
                     }}
@@ -636,7 +612,11 @@ function JiraCreateStepMode(props: JiraCreateStepModeProps, formikRef: StepFormi
           connectorRef: Yup.string().required(getString('pipeline.jiraApprovalStep.validations.connectorRef')),
           projectKey: Yup.string().required(getString('pipeline.jiraApprovalStep.validations.project')),
           issueType: Yup.string().required(getString('pipeline.jiraApprovalStep.validations.issueType')),
-          summary: Yup.string().trim().required(getString('pipeline.jiraCreateStep.validations.summary'))
+          selectedRequiredFields: Yup.array().of(
+            Yup.object().shape({
+              value: Yup.string().required(getString('pipeline.jiraApprovalStep.validations.requiredField'))
+            })
+          )
         })
       })}
     >

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraCreate/JiraCreateStepMode.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraCreate/JiraCreateStepMode.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useEffect, useState } from 'react'
-import { isEmpty } from 'lodash-es'
+import { defaultTo, isEmpty } from 'lodash-es'
 import { useParams } from 'react-router-dom'
 import { Dialog, Intent } from '@blueprintjs/core'
 import cx from 'classnames'
@@ -204,9 +204,9 @@ function FormContent({
     const projectResponseList: JiraProjectBasicNG[] = projectsResponse?.data || []
     options =
       projectResponseList.map((project: JiraProjectBasicNG) => ({
-        label: project.name || '',
-        value: project.id || '',
-        key: project.key || ''
+        label: defaultTo(project.name, ''),
+        value: defaultTo(project.id, ''),
+        key: defaultTo(project.key, '')
       })) || []
 
     setProjectOptions(options)

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraCreate/JiraDynamicFieldsSelector.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraCreate/JiraDynamicFieldsSelector.tsx
@@ -95,7 +95,7 @@ function SelectFieldList(props: JiraDynamicFieldsSelectorContentInterface) {
       fieldKeys.sort().forEach(keyy => {
         if (issueTypeData?.fields[keyy]) {
           if (
-            (jiraType === 'createMode' && keyy !== 'Summary' && keyy !== 'Description') ||
+            (jiraType === 'createMode' && issueTypeData?.fields[keyy]?.required === false) ||
             jiraType === 'updateMode'
           ) {
             fieldListToSet.push(issueTypeData?.fields[keyy])

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraCreate/JiraDynamicFieldsSelector.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraCreate/JiraDynamicFieldsSelector.tsx
@@ -94,10 +94,7 @@ function SelectFieldList(props: JiraDynamicFieldsSelectorContentInterface) {
       const fieldKeys = Object.keys(issueTypeData?.fields || {})
       fieldKeys.sort().forEach(keyy => {
         if (issueTypeData?.fields[keyy]) {
-          if (
-            (jiraType === 'createMode' && issueTypeData?.fields[keyy]?.required === false) ||
-            jiraType === 'updateMode'
-          ) {
+          if ((jiraType === 'createMode' && !issueTypeData?.fields[keyy]?.required) || jiraType === 'updateMode') {
             fieldListToSet.push(issueTypeData?.fields[keyy])
           }
         }

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraCreate/__tests__/JiraCreate.test.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraCreate/__tests__/JiraCreate.test.tsx
@@ -23,7 +23,8 @@ import {
   mockProjectsResponse,
   mockProjectsErrorResponse,
   getJiraCreateEditModePropsWithConnectorId,
-  getJiraFieldRendererProps
+  getJiraRequiredFieldRendererProps,
+  getJiraOptionalFieldRendererProps
 } from './JiraCreateTestHelper'
 import { JiraFieldsRenderer } from '../JiraFieldsRenderer'
 
@@ -190,21 +191,12 @@ describe('Jira Create tests', () => {
       expect(queryByText('pipeline.jiraApprovalStep.validations.project')).toBeTruthy()
       expect(queryByText('pipeline.jiraApprovalStep.validations.issueType')).toBeTruthy()
     })
-    await waitFor(() => expect(queryByText('pipeline.jiraCreateStep.validations.summary')).toBeTruthy())
   })
 
   test('Open a saved step - edit stage view', async () => {
     const ref = React.createRef<StepFormikRef<unknown>>()
     const props = { ...getJiraCreateEditModePropsWithValues() }
-    const {
-      container,
-      getByText,
-      getByTestId,
-      queryByPlaceholderText,
-      getByPlaceholderText,
-      queryByDisplayValue,
-      queryByText
-    } = render(
+    const { container, getByText, getByTestId, queryByDisplayValue, queryByText } = render(
       <TestStepWidget
         initialValues={props.initialValues}
         type={StepType.JiraCreate}
@@ -219,7 +211,6 @@ describe('Jira Create tests', () => {
     expect(queryByDisplayValue('1d')).toBeTruthy()
     expect(queryByDisplayValue('pid1')).toBeTruthy()
     expect(queryByDisplayValue('itd1')).toBeTruthy()
-    expect(queryByDisplayValue('summaryval')).toBeTruthy()
 
     fireEvent.click(getByText('common.optionalConfig'))
 
@@ -227,10 +218,6 @@ describe('Jira Create tests', () => {
     expect(queryByDisplayValue('value1')).toBeTruthy()
     expect(queryByDisplayValue('2233')).toBeTruthy()
     expect(queryByDisplayValue('23-march')).toBeTruthy()
-
-    fireEvent.change(getByPlaceholderText('pipeline.jiraCreateStep.summaryPlaceholder'), {
-      target: { value: 'summary' }
-    })
 
     // Open the fields selector dialog
     act(() => {
@@ -249,15 +236,9 @@ describe('Jira Create tests', () => {
     fireEvent.click(icon![1])
     fireEvent.click(getByText('it1'))
 
-    // Click the new custom field
-    fireEvent.click(getByText('f1'))
-
     // Add the field to jira create form
     const button = dialogContainer?.querySelector('.bp3-button-text')
     fireEvent.click(button!)
-
-    // The selected field should be now added to the main form
-    expect(queryByPlaceholderText('f1')).toBeTruthy()
 
     // Open the fields selector dialog again
     act(() => {
@@ -296,7 +277,6 @@ describe('Jira Create tests', () => {
         fields: [
           { name: 'Summary', value: 'summary' },
           { name: 'Description', value: 'descriptionval' },
-          { name: 'f1', value: '' },
           { name: 'f21', value: 'value1' },
           { name: 'f2', value: 2233 },
           { name: 'date', value: '23-march' },
@@ -307,8 +287,18 @@ describe('Jira Create tests', () => {
     })
   })
 
-  test('Jira Fields Renderer Test', () => {
-    const props = getJiraFieldRendererProps()
+  test('Jira Optional Fields Renderer Test', () => {
+    const props = getJiraOptionalFieldRendererProps()
+    const { container } = render(
+      <TestWrapper>
+        <JiraFieldsRenderer {...props}></JiraFieldsRenderer>
+      </TestWrapper>
+    )
+    expect(container).toMatchSnapshot()
+  })
+
+  test('Jira Required Fields Renderer Test', () => {
+    const props = getJiraRequiredFieldRendererProps()
     const { container } = render(
       <TestWrapper>
         <JiraFieldsRenderer {...props}></JiraFieldsRenderer>
@@ -328,10 +318,8 @@ describe('Jira Create tests', () => {
           connectorRef: '',
           projectKey: '',
           issueType: '',
-          summary: '',
-          description: '',
           fields: [],
-          selectedFields: [],
+          selectedRequiredFields: [],
           delegateSelectors: undefined
         }
       },
@@ -344,10 +332,8 @@ describe('Jira Create tests', () => {
           connectorRef: '',
           projectKey: '',
           issueType: '',
-          summary: '',
-          description: '',
           fields: [],
-          selectedFields: [],
+          selectedRequiredFields: [],
           delegateSelectors: undefined
         }
       },

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraCreate/__tests__/JiraCreateHelper.test.ts
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraCreate/__tests__/JiraCreateHelper.test.ts
@@ -30,7 +30,7 @@ describe('Jira Create process form data tests', () => {
             value: { label: 'vb2', value: 'vb2' }
           }
         ],
-        selectedFields: [
+        selectedOptionalFields: [
           {
             name: 'f2',
             value: { label: 'vb2', value: 'vb2' },
@@ -71,14 +71,6 @@ describe('Jira Create process form data tests', () => {
         issueType: 'iss',
         fields: [
           {
-            name: 'Summary',
-            value: ''
-          },
-          {
-            name: 'Description',
-            value: ''
-          },
-          {
             name: 'f2',
             value: 'vb2'
           },
@@ -112,7 +104,7 @@ describe('Jira Create process form data tests', () => {
             value: '<+a.b>'
           }
         ],
-        selectedFields: [
+        selectedOptionalFields: [
           {
             name: 'f2',
             value: '<+x.y>',
@@ -139,14 +131,6 @@ describe('Jira Create process form data tests', () => {
         delegateSelectors: undefined,
         issueType: '<+input>',
         fields: [
-          {
-            name: 'Summary',
-            value: ''
-          },
-          {
-            name: 'Description',
-            value: ''
-          },
           {
             name: 'f2',
             value: '<+x.y>'

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraCreate/__tests__/JiraCreateTestHelper.ts
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraCreate/__tests__/JiraCreateTestHelper.ts
@@ -66,11 +66,11 @@ export const getJiraCreateEditModePropsWithValues = (): JiraCreateStepModeProps 
       projectKey: 'pid1',
       issueType: 'itd1',
       fields: [
+        { name: 'Summary', value: 'summary' },
+        { name: 'Description', value: 'descriptionval' },
         { name: 'f21', value: 'value1' },
         { name: 'f2', value: 2233 },
-        { name: 'date', value: '23-march' },
-        { name: 'Summary', value: 'summaryval' },
-        { name: 'Description', value: 'descriptionval' }
+        { name: 'date', value: '23-march' }
       ]
     }
   },
@@ -332,32 +332,71 @@ export const mockProjectMetadataResponse: UseGetMockData<ResponseJiraIssueCreate
     }
   }
 }
-export const getJiraFieldRendererProps = (): JiraFieldsRendererProps => ({
+export const getJiraOptionalFieldRendererProps = (): JiraFieldsRendererProps => ({
+  selectedFields: [
+    {
+      name: 'f3',
+      value: '',
+      key: 'f3',
+      allowedValues: [],
+      schema: {
+        typeStr: 'date',
+        type: 'date'
+      },
+      required: false
+    },
+    {
+      name: 'f4',
+      value: '',
+      key: 'f4',
+      allowedValues: [],
+      schema: {
+        typeStr: 'datetime',
+        type: 'datetime'
+      },
+      required: false
+    },
+    {
+      name: 'f5',
+      value: '',
+      key: 'f5',
+      allowedValues: [],
+      schema: {
+        typeStr: 'number',
+        type: 'number'
+      },
+      required: false
+    },
+    {
+      name: 'f6',
+      value: '',
+      key: 'f6',
+      allowedValues: [],
+      schema: {
+        typeStr: 'option',
+        type: 'option',
+        array: true
+      },
+      required: false
+    }
+  ],
+  readonly: false,
+  onDelete: jest.fn()
+})
+
+export const getJiraRequiredFieldRendererProps = (): JiraFieldsRendererProps => ({
   selectedFields: [
     {
       name: 'f2',
-      value: { label: 'vb2', value: 'vb2' },
+      value: 'val2',
       key: 'f2',
       allowedValues: [],
       schema: {
         typeStr: '',
         type: 'string'
-      }
-    },
-    {
-      name: 'f3',
-      value: [
-        { label: 'v3', value: 'v3' },
-        { label: 'v32', value: 'v32' }
-      ],
-      key: 'f3',
-      allowedValues: [],
-      schema: {
-        typeStr: '',
-        type: 'option'
-      }
+      },
+      required: true
     }
   ],
-  readonly: false,
-  onDelete: jest.fn()
+  renderRequiredFields: true
 })

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraCreate/__tests__/__snapshots__/JiraCreate.test.tsx.snap
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraCreate/__tests__/__snapshots__/JiraCreate.test.tsx.snap
@@ -579,78 +579,7 @@ exports[`Jira Create fetch projects show error if failed to fetch projects 1`] =
             </div>
           </div>
         </div>
-        <div
-          class="formGroup lg"
-        >
-          <div
-            class="bp3-form-group"
-            data-id="spec.summary-5"
-          >
-            <label
-              class="bp3-label"
-              for="spec.summary"
-            >
-              <span
-                class="Tooltip--acenter"
-                data-tooltip-id="jiraCreate_spec.summary"
-              >
-                summary
-              </span>
-               
-              <span
-                class="bp3-text-muted"
-              />
-            </label>
-            <div
-              class="bp3-form-content"
-            >
-              <div
-                class="Layout--horizontal StyledProps--main MultiTypeInput--main"
-              >
-                <div
-                  class="bp3-input-group MultiTypeInput--input"
-                >
-                  <input
-                    autocomplete="off"
-                    class="bp3-input"
-                    name="spec.summary"
-                    placeholder="pipeline.jiraCreateStep.summaryPlaceholder"
-                    type="text"
-                    value=""
-                  />
-                </div>
-                <span
-                  class="bp3-popover-wrapper MultiTypeInput--wrapper"
-                >
-                  <span
-                    class="bp3-popover-target"
-                  >
-                    <button
-                      class="MultiTypeInput--btn MultiTypeInput--FIXED"
-                    >
-                      <span
-                        class="bp3-icon StyledProps--main"
-                        data-icon="fixed-input"
-                      >
-                        <svg
-                          height="12"
-                          viewBox="0 0 9 9"
-                          width="12"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M5.61 7.55c.62-.7.3-1.42.18-2.35a.32.32 0 01.1-.29l1.43-1.42a.76.76 0 01.28-.15c.39-.1 1 0 1.28-.29a.34.34 0 000-.51L6.46.12a.33.33 0 00-.52 0c-.28.29-.2.9-.28 1.3a.53.53 0 01-.13.23L4.09 3.12a.29.29 0 01-.28.09c-.89-.11-1.6-.49-2.27.11-.29.26-.29.43 0 .7l1.31 1.34.15.16-.15.15-2.7 2.69a.36.36 0 000 .54.36.36 0 00.54-.05l2.63-2.68.17-.17.17.16c.45.46.9.91 1.36 1.36.21.21.42.22.59.03z"
-                            fill="currentColor"
-                          />
-                        </svg>
-                      </span>
-                    </button>
-                  </span>
-                </span>
-              </div>
-            </div>
-          </div>
-        </div>
+        <div />
         <div
           class="noLookDivider"
         />
@@ -988,142 +917,6 @@ exports[`Jira Create tests Basic snapshot - deploymentform mode: jira-create-dep
               </button>
             </span>
           </span>
-        </div>
-      </div>
-    </div>
-    <div
-      class="bp3-form-group deploymentViewMedium"
-    >
-      <label
-        class="bp3-label"
-        for="spec.summary"
-      >
-        <span
-          class="Tooltip--acenter"
-          data-tooltip-id="stepTestUtilForm_spec.summary"
-        >
-          summary
-        </span>
-         
-        <span
-          class="bp3-text-muted"
-        />
-      </label>
-      <div
-        class="bp3-form-content"
-      >
-        <div
-          class="Layout--horizontal StyledProps--main MultiTypeInput--main"
-        >
-          <div
-            class="bp3-input-group MultiTypeInput--input"
-          >
-            <input
-              autocomplete="off"
-              class="bp3-input"
-              name="spec.summary"
-              placeholder="pipeline.jiraCreateStep.summaryPlaceholder"
-              type="text"
-              value=""
-            />
-          </div>
-          <span
-            class="bp3-popover-wrapper MultiTypeInput--wrapper"
-          >
-            <span
-              class="bp3-popover-target"
-            >
-              <button
-                class="MultiTypeInput--btn MultiTypeInput--FIXED"
-              >
-                <span
-                  class="bp3-icon StyledProps--main"
-                  data-icon="fixed-input"
-                >
-                  <svg
-                    height="12"
-                    viewBox="0 0 9 9"
-                    width="12"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M5.61 7.55c.62-.7.3-1.42.18-2.35a.32.32 0 01.1-.29l1.43-1.42a.76.76 0 01.28-.15c.39-.1 1 0 1.28-.29a.34.34 0 000-.51L6.46.12a.33.33 0 00-.52 0c-.28.29-.2.9-.28 1.3a.53.53 0 01-.13.23L4.09 3.12a.29.29 0 01-.28.09c-.89-.11-1.6-.49-2.27.11-.29.26-.29.43 0 .7l1.31 1.34.15.16-.15.15-2.7 2.69a.36.36 0 000 .54.36.36 0 00.54-.05l2.63-2.68.17-.17.17.16c.45.46.9.91 1.36 1.36.21.21.42.22.59.03z"
-                      fill="currentColor"
-                    />
-                  </svg>
-                </span>
-              </button>
-            </span>
-          </span>
-        </div>
-      </div>
-    </div>
-    <div
-      class="bp3-form-group deploymentViewMedium"
-    >
-      <label
-        class="bp3-label"
-        for="spec.description"
-      >
-        <span
-          class="Tooltip--acenter"
-          data-tooltip-id="stepTestUtilForm_spec.description"
-        >
-          description
-        </span>
-         
-        <span
-          class="bp3-text-muted"
-        />
-      </label>
-      <div
-        class="bp3-form-content"
-      >
-        <div
-          class="StyledProps--font StyledProps--main"
-        >
-          <div
-            style="display: flex; align-items: center;"
-          >
-            <div
-              class="Layout--horizontal StyledProps--main MultiTypeInput--main"
-              style="flex-grow: 1;"
-            >
-              <textarea
-                class="bp3-input input"
-                name="spec.description"
-                placeholder="common.descriptionPlaceholder"
-              />
-              <span
-                class="bp3-popover-wrapper MultiTypeInput--wrapper"
-              >
-                <span
-                  class="bp3-popover-target"
-                >
-                  <button
-                    class="MultiTypeInput--btn MultiTypeInput--FIXED multiButtonForFixedType"
-                  >
-                    <span
-                      class="bp3-icon StyledProps--main"
-                      data-icon="fixed-input"
-                    >
-                      <svg
-                        height="12"
-                        viewBox="0 0 9 9"
-                        width="12"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M5.61 7.55c.62-.7.3-1.42.18-2.35a.32.32 0 01.1-.29l1.43-1.42a.76.76 0 01.28-.15c.39-.1 1 0 1.28-.29a.34.34 0 000-.51L6.46.12a.33.33 0 00-.52 0c-.28.29-.2.9-.28 1.3a.53.53 0 01-.13.23L4.09 3.12a.29.29 0 01-.28.09c-.89-.11-1.6-.49-2.27.11-.29.26-.29.43 0 .7l1.31 1.34.15.16-.15.15-2.7 2.69a.36.36 0 000 .54.36.36 0 00.54-.05l2.63-2.68.17-.17.17.16c.45.46.9.91 1.36 1.36.21.21.42.22.59.03z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                    </span>
-                  </button>
-                </span>
-              </span>
-            </div>
-          </div>
         </div>
       </div>
     </div>
@@ -1664,173 +1457,6 @@ exports[`Jira Create tests Basic snapshot - inputset mode: input set with errors
         </div>
       </div>
     </div>
-    <div
-      class="bp3-form-group bp3-intent-danger deploymentViewMedium"
-    >
-      <label
-        class="bp3-label"
-        for="spec.summary"
-      >
-        <span
-          class="Tooltip--acenter"
-          data-tooltip-id="stepTestUtilForm_spec.summary"
-        >
-          summary
-        </span>
-         
-        <span
-          class="bp3-text-muted"
-        />
-      </label>
-      <div
-        class="bp3-form-content"
-      >
-        <div
-          class="Layout--horizontal StyledProps--main MultiTypeInput--main"
-        >
-          <div
-            class="bp3-input-group MultiTypeInput--input"
-          >
-            <input
-              autocomplete="off"
-              class="bp3-input"
-              name="spec.summary"
-              placeholder="pipeline.jiraCreateStep.summaryPlaceholder"
-              type="text"
-              value=""
-            />
-          </div>
-          <span
-            class="bp3-popover-wrapper MultiTypeInput--wrapper"
-          >
-            <span
-              class="bp3-popover-target"
-            >
-              <button
-                class="MultiTypeInput--btn MultiTypeInput--FIXED"
-              >
-                <span
-                  class="bp3-icon StyledProps--main"
-                  data-icon="fixed-input"
-                >
-                  <svg
-                    height="12"
-                    viewBox="0 0 9 9"
-                    width="12"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M5.61 7.55c.62-.7.3-1.42.18-2.35a.32.32 0 01.1-.29l1.43-1.42a.76.76 0 01.28-.15c.39-.1 1 0 1.28-.29a.34.34 0 000-.51L6.46.12a.33.33 0 00-.52 0c-.28.29-.2.9-.28 1.3a.53.53 0 01-.13.23L4.09 3.12a.29.29 0 01-.28.09c-.89-.11-1.6-.49-2.27.11-.29.26-.29.43 0 .7l1.31 1.34.15.16-.15.15-2.7 2.69a.36.36 0 000 .54.36.36 0 00.54-.05l2.63-2.68.17-.17.17.16c.45.46.9.91 1.36 1.36.21.21.42.22.59.03z"
-                      fill="currentColor"
-                    />
-                  </svg>
-                </span>
-              </button>
-            </span>
-          </span>
-        </div>
-        <div
-          class="bp3-form-helper-text"
-        >
-          <div
-            class="FormError--errorDiv"
-            data-name="spec.summary"
-          >
-            <span
-              class="bp3-icon StyledProps--main FormError--errorTextIcon StyledProps--intent-danger"
-              data-icon="circle-cross"
-            >
-              <svg
-                height="12"
-                viewBox="0 0 13 13"
-                width="12"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  clip-rule="evenodd"
-                  d="M.167 6.501a6.333 6.333 0 1012.666 0 6.333 6.333 0 00-12.666 0zm4.071-3.003l2.26 2.263 2.264-2.263c.495-.495 1.236.248.741.743L7.24 6.504l2.254 2.258c.495.495-.247 1.238-.742.743L6.497 7.246 4.238 9.505c-.495.495-1.236-.249-.741-.744l2.258-2.258-2.259-2.262c-.494-.495.248-1.238.742-.743z"
-                  fill-rule="evenodd"
-                />
-              </svg>
-            </span>
-            <span
-              class="FormError--error"
-            >
-              pipeline.jiraCreateStep.validations.summary
-            </span>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="bp3-form-group deploymentViewMedium"
-    >
-      <label
-        class="bp3-label"
-        for="spec.description"
-      >
-        <span
-          class="Tooltip--acenter"
-          data-tooltip-id="stepTestUtilForm_spec.description"
-        >
-          description
-        </span>
-         
-        <span
-          class="bp3-text-muted"
-        />
-      </label>
-      <div
-        class="bp3-form-content"
-      >
-        <div
-          class="StyledProps--font StyledProps--main"
-        >
-          <div
-            style="display: flex; align-items: center;"
-          >
-            <div
-              class="Layout--horizontal StyledProps--main MultiTypeInput--main"
-              style="flex-grow: 1;"
-            >
-              <textarea
-                class="bp3-input input"
-                name="spec.description"
-                placeholder="common.descriptionPlaceholder"
-              />
-              <span
-                class="bp3-popover-wrapper MultiTypeInput--wrapper"
-              >
-                <span
-                  class="bp3-popover-target"
-                >
-                  <button
-                    class="MultiTypeInput--btn MultiTypeInput--FIXED multiButtonForFixedType"
-                  >
-                    <span
-                      class="bp3-icon StyledProps--main"
-                      data-icon="fixed-input"
-                    >
-                      <svg
-                        height="12"
-                        viewBox="0 0 9 9"
-                        width="12"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M5.61 7.55c.62-.7.3-1.42.18-2.35a.32.32 0 01.1-.29l1.43-1.42a.76.76 0 01.28-.15c.39-.1 1 0 1.28-.29a.34.34 0 000-.51L6.46.12a.33.33 0 00-.52 0c-.28.29-.2.9-.28 1.3a.53.53 0 01-.13.23L4.09 3.12a.29.29 0 01-.28.09c-.89-.11-1.6-.49-2.27.11-.29.26-.29.43 0 .7l1.31 1.34.15.16-.15.15-2.7 2.69a.36.36 0 000 .54.36.36 0 00.54-.05l2.63-2.68.17-.17.17.16c.45.46.9.91 1.36 1.36.21.21.42.22.59.03z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                    </span>
-                  </button>
-                </span>
-              </span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
     <p
       class="StyledProps--font StyledProps--main"
     >
@@ -1841,8 +1467,7 @@ exports[`Jira Create tests Basic snapshot - inputset mode: input set with errors
   "spec": {
     "connectorRef": "pipeline.jiraApprovalStep.validations.connectorRef",
     "projectKey": "pipeline.jiraApprovalStep.validations.project",
-    "issueType": "pipeline.jiraApprovalStep.validations.issueType",
-    "summary": "pipeline.jiraCreateStep.validations.summary"
+    "issueType": "pipeline.jiraApprovalStep.validations.issueType"
   }
 }
     </pre>
@@ -2156,142 +1781,6 @@ exports[`Jira Create tests Deploymentform readonly mode: jira-create-deploymentf
               </button>
             </span>
           </span>
-        </div>
-      </div>
-    </div>
-    <div
-      class="bp3-form-group deploymentViewMedium"
-    >
-      <label
-        class="bp3-label"
-        for="spec.summary"
-      >
-        <span
-          class="Tooltip--acenter"
-          data-tooltip-id="stepTestUtilForm_spec.summary"
-        >
-          summary
-        </span>
-         
-        <span
-          class="bp3-text-muted"
-        />
-      </label>
-      <div
-        class="bp3-form-content"
-      >
-        <div
-          class="Layout--horizontal StyledProps--main MultiTypeInput--main"
-        >
-          <div
-            class="bp3-input-group MultiTypeInput--input"
-          >
-            <input
-              autocomplete="off"
-              class="bp3-input"
-              name="spec.summary"
-              placeholder="pipeline.jiraCreateStep.summaryPlaceholder"
-              type="text"
-              value=""
-            />
-          </div>
-          <span
-            class="bp3-popover-wrapper MultiTypeInput--wrapper"
-          >
-            <span
-              class="bp3-popover-target"
-            >
-              <button
-                class="MultiTypeInput--btn MultiTypeInput--FIXED"
-              >
-                <span
-                  class="bp3-icon StyledProps--main"
-                  data-icon="fixed-input"
-                >
-                  <svg
-                    height="12"
-                    viewBox="0 0 9 9"
-                    width="12"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M5.61 7.55c.62-.7.3-1.42.18-2.35a.32.32 0 01.1-.29l1.43-1.42a.76.76 0 01.28-.15c.39-.1 1 0 1.28-.29a.34.34 0 000-.51L6.46.12a.33.33 0 00-.52 0c-.28.29-.2.9-.28 1.3a.53.53 0 01-.13.23L4.09 3.12a.29.29 0 01-.28.09c-.89-.11-1.6-.49-2.27.11-.29.26-.29.43 0 .7l1.31 1.34.15.16-.15.15-2.7 2.69a.36.36 0 000 .54.36.36 0 00.54-.05l2.63-2.68.17-.17.17.16c.45.46.9.91 1.36 1.36.21.21.42.22.59.03z"
-                      fill="currentColor"
-                    />
-                  </svg>
-                </span>
-              </button>
-            </span>
-          </span>
-        </div>
-      </div>
-    </div>
-    <div
-      class="bp3-form-group deploymentViewMedium"
-    >
-      <label
-        class="bp3-label"
-        for="spec.description"
-      >
-        <span
-          class="Tooltip--acenter"
-          data-tooltip-id="stepTestUtilForm_spec.description"
-        >
-          description
-        </span>
-         
-        <span
-          class="bp3-text-muted"
-        />
-      </label>
-      <div
-        class="bp3-form-content"
-      >
-        <div
-          class="StyledProps--font StyledProps--main"
-        >
-          <div
-            style="display: flex; align-items: center;"
-          >
-            <div
-              class="Layout--horizontal StyledProps--main MultiTypeInput--main"
-              style="flex-grow: 1;"
-            >
-              <textarea
-                class="bp3-input input"
-                name="spec.description"
-                placeholder="common.descriptionPlaceholder"
-              />
-              <span
-                class="bp3-popover-wrapper MultiTypeInput--wrapper"
-              >
-                <span
-                  class="bp3-popover-target"
-                >
-                  <button
-                    class="MultiTypeInput--btn MultiTypeInput--FIXED multiButtonForFixedType"
-                  >
-                    <span
-                      class="bp3-icon StyledProps--main"
-                      data-icon="fixed-input"
-                    >
-                      <svg
-                        height="12"
-                        viewBox="0 0 9 9"
-                        width="12"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M5.61 7.55c.62-.7.3-1.42.18-2.35a.32.32 0 01.1-.29l1.43-1.42a.76.76 0 01.28-.15c.39-.1 1 0 1.28-.29a.34.34 0 000-.51L6.46.12a.33.33 0 00-.52 0c-.28.29-.2.9-.28 1.3a.53.53 0 01-.13.23L4.09 3.12a.29.29 0 01-.28.09c-.89-.11-1.6-.49-2.27.11-.29.26-.29.43 0 .7l1.31 1.34.15.16-.15.15-2.7 2.69a.36.36 0 000 .54.36.36 0 00.54-.05l2.63-2.68.17-.17.17.16c.45.46.9.91 1.36 1.36.21.21.42.22.59.03z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                    </span>
-                  </button>
-                </span>
-              </span>
-            </div>
-          </div>
         </div>
       </div>
     </div>
@@ -2842,72 +2331,7 @@ exports[`Jira Create tests Edit Stage - readonly view: edit-stage-readonly 1`] =
             </div>
           </div>
         </div>
-        <div
-          class="formGroup lg"
-        >
-          <div
-            class="bp3-form-group bp3-disabled"
-            data-id="spec.summary-5"
-          >
-            <label
-              class="bp3-label"
-              for="spec.summary"
-            >
-              <span
-                class="Tooltip--acenter"
-                data-tooltip-id="jiraCreate_spec.summary"
-              >
-                summary
-              </span>
-               
-              <span
-                class="bp3-text-muted"
-              />
-            </label>
-            <div
-              class="bp3-form-content"
-            >
-              <div
-                class="Layout--horizontal StyledProps--main MultiTypeInput--main MultiTypeInput--disabled"
-              >
-                <div
-                  class="bp3-input-group bp3-disabled MultiTypeInput--input"
-                >
-                  <input
-                    autocomplete="off"
-                    class="bp3-input"
-                    disabled=""
-                    name="spec.summary"
-                    placeholder="pipeline.jiraCreateStep.summaryPlaceholder"
-                    type="text"
-                    value=""
-                  />
-                </div>
-                <button
-                  class="MultiTypeInput--btn MultiTypeInput--FIXED"
-                  disabled=""
-                >
-                  <span
-                    class="bp3-icon StyledProps--main"
-                    data-icon="fixed-input"
-                  >
-                    <svg
-                      height="12"
-                      viewBox="0 0 9 9"
-                      width="12"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M5.61 7.55c.62-.7.3-1.42.18-2.35a.32.32 0 01.1-.29l1.43-1.42a.76.76 0 01.28-.15c.39-.1 1 0 1.28-.29a.34.34 0 000-.51L6.46.12a.33.33 0 00-.52 0c-.28.29-.2.9-.28 1.3a.53.53 0 01-.13.23L4.09 3.12a.29.29 0 01-.28.09c-.89-.11-1.6-.49-2.27.11-.29.26-.29.43 0 .7l1.31 1.34.15.16-.15.15-2.7 2.69a.36.36 0 000 .54.36.36 0 00.54-.05l2.63-2.68.17-.17.17.16c.45.46.9.91 1.36 1.36.21.21.42.22.59.03z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                  </span>
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
+        <div />
         <div
           class="noLookDivider"
         />
@@ -2949,7 +2373,7 @@ exports[`Jira Create tests Edit Stage - readonly view: edit-stage-readonly 1`] =
 </div>
 `;
 
-exports[`Jira Create tests Jira Fields Renderer Test 1`] = `
+exports[`Jira Create tests Jira Optional Fields Renderer Test 1`] = `
 <div>
   <div
     class="Layout--horizontal StyledProps--main alignCenter"
@@ -2959,9 +2383,9 @@ exports[`Jira Create tests Jira Fields Renderer Test 1`] = `
     >
       <label
         class="bp3-label"
-        for="spec.selectedFields[0].value"
+        for="spec.selectedOptionalFields[0].value"
       >
-        f2
+        f3
          
         <span
           class="bp3-text-muted"
@@ -2979,8 +2403,8 @@ exports[`Jira Create tests Jira Fields Renderer Test 1`] = `
             <input
               autocomplete="off"
               class="bp3-input"
-              name="spec.selectedFields[0].value"
-              placeholder="f2"
+              name="spec.selectedOptionalFields[0].value"
+              placeholder="f3"
               type="text"
               value=""
             />
@@ -3046,13 +2470,13 @@ exports[`Jira Create tests Jira Fields Renderer Test 1`] = `
     class="Layout--horizontal StyledProps--main alignCenter"
   >
     <div
-      class="bp3-form-group multiSelect md"
+      class="bp3-form-group md"
     >
       <label
         class="bp3-label"
-        for="spec.selectedFields[1].value"
+        for="spec.selectedOptionalFields[1].value"
       >
-        f3
+        f4
          
         <span
           class="bp3-text-muted"
@@ -3065,48 +2489,16 @@ exports[`Jira Create tests Jira Fields Renderer Test 1`] = `
           class="Layout--horizontal StyledProps--main MultiTypeInput--main"
         >
           <div
-            class="bp3-popover-wrapper MultiTypeInput--select MultiTypeInput--fixedValueInput Select--main bp3-fill"
+            class="bp3-input-group MultiTypeInput--input"
           >
-            <div
-              class="bp3-popover-target"
-            >
-              <div
-                class="bp3-input-group"
-              >
-                <input
-                  autocomplete="off"
-                  class="bp3-input"
-                  name="spec.selectedFields[1].value"
-                  placeholder="f3"
-                  style="padding-right: 0px;"
-                  type="text"
-                  value=""
-                />
-                <span
-                  class="bp3-input-action"
-                >
-                  <span
-                    class="bp3-icon bp3-icon-chevron-down StyledProps--main StyledProps--padding-small"
-                    icon="chevron-down"
-                  >
-                    <svg
-                      data-icon="chevron-down"
-                      height="14"
-                      viewBox="0 0 16 16"
-                      width="14"
-                    >
-                      <desc>
-                        chevron-down
-                      </desc>
-                      <path
-                        d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
-                        fill-rule="evenodd"
-                      />
-                    </svg>
-                  </span>
-                </span>
-              </div>
-            </div>
+            <input
+              autocomplete="off"
+              class="bp3-input"
+              name="spec.selectedOptionalFields[1].value"
+              placeholder="f4"
+              type="text"
+              value=""
+            />
           </div>
           <span
             class="bp3-popover-wrapper MultiTypeInput--wrapper"
@@ -3164,6 +2556,259 @@ exports[`Jira Create tests Jira Fields Renderer Test 1`] = `
         </svg>
       </span>
     </button>
+  </div>
+  <div
+    class="Layout--horizontal StyledProps--main alignCenter"
+  >
+    <div
+      class="bp3-form-group md"
+    >
+      <label
+        class="bp3-label"
+        for="spec.selectedOptionalFields[2].value"
+      >
+        f5
+         
+        <span
+          class="bp3-text-muted"
+        />
+      </label>
+      <div
+        class="bp3-form-content"
+      >
+        <div
+          class="Layout--horizontal StyledProps--main MultiTypeInput--main"
+        >
+          <div
+            class="bp3-input-group MultiTypeInput--input"
+          >
+            <input
+              autocomplete="off"
+              class="bp3-input"
+              name="spec.selectedOptionalFields[2].value"
+              placeholder="f5"
+              type="text"
+              value=""
+            />
+          </div>
+          <span
+            class="bp3-popover-wrapper MultiTypeInput--wrapper"
+          >
+            <span
+              class="bp3-popover-target"
+            >
+              <button
+                class="MultiTypeInput--btn MultiTypeInput--FIXED"
+              >
+                <span
+                  class="bp3-icon StyledProps--main"
+                  data-icon="fixed-input"
+                >
+                  <svg
+                    height="12"
+                    viewBox="0 0 9 9"
+                    width="12"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M5.61 7.55c.62-.7.3-1.42.18-2.35a.32.32 0 01.1-.29l1.43-1.42a.76.76 0 01.28-.15c.39-.1 1 0 1.28-.29a.34.34 0 000-.51L6.46.12a.33.33 0 00-.52 0c-.28.29-.2.9-.28 1.3a.53.53 0 01-.13.23L4.09 3.12a.29.29 0 01-.28.09c-.89-.11-1.6-.49-2.27.11-.29.26-.29.43 0 .7l1.31 1.34.15.16-.15.15-2.7 2.69a.36.36 0 000 .54.36.36 0 00.54-.05l2.63-2.68.17-.17.17.16c.45.46.9.91 1.36 1.36.21.21.42.22.59.03z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </span>
+          </span>
+        </div>
+      </div>
+    </div>
+    <button
+      class="bp3-button bp3-minimal Button--button StyledProps--font StyledProps--main Button--with-current-color Button--iconOnly Button--without-shadow Button--withLeftIcon"
+      data-testid="remove-selectedField-2"
+      type="button"
+    >
+      <span
+        class="bp3-icon bp3-icon-trash StyledProps--main"
+        icon="trash"
+      >
+        <svg
+          data-icon="trash"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+        >
+          <desc>
+            trash
+          </desc>
+          <path
+            d="M14.49 3.99h-13c-.28 0-.5.22-.5.5s.22.5.5.5h.5v10c0 .55.45 1 1 1h10c.55 0 1-.45 1-1v-10h.5c.28 0 .5-.22.5-.5s-.22-.5-.5-.5zm-8.5 9c0 .55-.45 1-1 1s-1-.45-1-1v-6c0-.55.45-1 1-1s1 .45 1 1v6zm3 0c0 .55-.45 1-1 1s-1-.45-1-1v-6c0-.55.45-1 1-1s1 .45 1 1v6zm3 0c0 .55-.45 1-1 1s-1-.45-1-1v-6c0-.55.45-1 1-1s1 .45 1 1v6zm2-12h-4c0-.55-.45-1-1-1h-2c-.55 0-1 .45-1 1h-4c-.55 0-1 .45-1 1v1h14v-1c0-.55-.45-1-1-1z"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </span>
+    </button>
+  </div>
+  <div
+    class="Layout--horizontal StyledProps--main alignCenter"
+  >
+    <div
+      class="bp3-form-group md"
+    >
+      <label
+        class="bp3-label"
+        for="spec.selectedOptionalFields[3].value"
+      >
+        f6
+         
+        <span
+          class="bp3-text-muted"
+        />
+      </label>
+      <div
+        class="bp3-form-content"
+      >
+        <div
+          class="Layout--horizontal StyledProps--main MultiTypeInput--main"
+        >
+          <div
+            class="bp3-input-group MultiTypeInput--input"
+          >
+            <input
+              autocomplete="off"
+              class="bp3-input"
+              name="spec.selectedOptionalFields[3].value"
+              placeholder="f6"
+              type="text"
+              value=""
+            />
+          </div>
+          <span
+            class="bp3-popover-wrapper MultiTypeInput--wrapper"
+          >
+            <span
+              class="bp3-popover-target"
+            >
+              <button
+                class="MultiTypeInput--btn MultiTypeInput--FIXED"
+              >
+                <span
+                  class="bp3-icon StyledProps--main"
+                  data-icon="fixed-input"
+                >
+                  <svg
+                    height="12"
+                    viewBox="0 0 9 9"
+                    width="12"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M5.61 7.55c.62-.7.3-1.42.18-2.35a.32.32 0 01.1-.29l1.43-1.42a.76.76 0 01.28-.15c.39-.1 1 0 1.28-.29a.34.34 0 000-.51L6.46.12a.33.33 0 00-.52 0c-.28.29-.2.9-.28 1.3a.53.53 0 01-.13.23L4.09 3.12a.29.29 0 01-.28.09c-.89-.11-1.6-.49-2.27.11-.29.26-.29.43 0 .7l1.31 1.34.15.16-.15.15-2.7 2.69a.36.36 0 000 .54.36.36 0 00.54-.05l2.63-2.68.17-.17.17.16c.45.46.9.91 1.36 1.36.21.21.42.22.59.03z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </span>
+          </span>
+        </div>
+      </div>
+    </div>
+    <button
+      class="bp3-button bp3-minimal Button--button StyledProps--font StyledProps--main Button--with-current-color Button--iconOnly Button--without-shadow Button--withLeftIcon"
+      data-testid="remove-selectedField-3"
+      type="button"
+    >
+      <span
+        class="bp3-icon bp3-icon-trash StyledProps--main"
+        icon="trash"
+      >
+        <svg
+          data-icon="trash"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+        >
+          <desc>
+            trash
+          </desc>
+          <path
+            d="M14.49 3.99h-13c-.28 0-.5.22-.5.5s.22.5.5.5h.5v10c0 .55.45 1 1 1h10c.55 0 1-.45 1-1v-10h.5c.28 0 .5-.22.5-.5s-.22-.5-.5-.5zm-8.5 9c0 .55-.45 1-1 1s-1-.45-1-1v-6c0-.55.45-1 1-1s1 .45 1 1v6zm3 0c0 .55-.45 1-1 1s-1-.45-1-1v-6c0-.55.45-1 1-1s1 .45 1 1v6zm3 0c0 .55-.45 1-1 1s-1-.45-1-1v-6c0-.55.45-1 1-1s1 .45 1 1v6zm2-12h-4c0-.55-.45-1-1-1h-2c-.55 0-1 .45-1 1h-4c-.55 0-1 .45-1 1v1h14v-1c0-.55-.45-1-1-1z"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </span>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`Jira Create tests Jira Required Fields Renderer Test 1`] = `
+<div>
+  <div
+    class="Layout--horizontal StyledProps--main alignCenter"
+  >
+    <div
+      class="bp3-form-group md"
+    >
+      <label
+        class="bp3-label"
+        for="spec.selectedRequiredFields[0].value"
+      >
+        f2
+         
+        <span
+          class="bp3-text-muted"
+        />
+      </label>
+      <div
+        class="bp3-form-content"
+      >
+        <div
+          class="Layout--horizontal StyledProps--main MultiTypeInput--main"
+        >
+          <div
+            class="bp3-input-group MultiTypeInput--input"
+          >
+            <input
+              autocomplete="off"
+              class="bp3-input"
+              name="spec.selectedRequiredFields[0].value"
+              placeholder="f2"
+              type="text"
+              value=""
+            />
+          </div>
+          <span
+            class="bp3-popover-wrapper MultiTypeInput--wrapper"
+          >
+            <span
+              class="bp3-popover-target"
+            >
+              <button
+                class="MultiTypeInput--btn MultiTypeInput--FIXED"
+              >
+                <span
+                  class="bp3-icon StyledProps--main"
+                  data-icon="fixed-input"
+                >
+                  <svg
+                    height="12"
+                    viewBox="0 0 9 9"
+                    width="12"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M5.61 7.55c.62-.7.3-1.42.18-2.35a.32.32 0 01.1-.29l1.43-1.42a.76.76 0 01.28-.15c.39-.1 1 0 1.28-.29a.34.34 0 000-.51L6.46.12a.33.33 0 00-.52 0c-.28.29-.2.9-.28 1.3a.53.53 0 01-.13.23L4.09 3.12a.29.29 0 01-.28.09c-.89-.11-1.6-.49-2.27.11-.29.26-.29.43 0 .7l1.31 1.34.15.16-.15.15-2.7 2.69a.36.36 0 000 .54.36.36 0 00.54-.05l2.63-2.68.17-.17.17.16c.45.46.9.91 1.36 1.36.21.21.42.22.59.03z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </span>
+          </span>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 `;

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraCreate/helper.ts
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraCreate/helper.ts
@@ -27,33 +27,25 @@ export const resetForm = (formik: FormikProps<JiraCreateData>, parent: string) =
   }
 }
 
-export const omitSummaryDescription = (fields: JiraCreateFieldType[]): JiraCreateFieldType[] =>
-  fields?.filter(field => field.name !== 'Summary' && field.name !== 'Description')
-
 export const processFieldsForSubmit = (values: JiraCreateData): JiraCreateFieldType[] => {
-  const toReturn: JiraCreateFieldType[] = [
-    {
-      name: 'Summary',
-      value: values.spec.summary || ''
-    },
-    {
-      name: 'Description',
-      value: values.spec.description || ''
-    }
-  ]
-  values.spec.selectedFields?.forEach((field: JiraFieldNGWithValue) => {
-    const name = field.name
-    const value =
-      typeof field.value === 'string' || typeof field.value === 'number'
-        ? field.value
-        : Array.isArray(field.value)
-        ? (field.value as MultiSelectOption[]).map(opt => opt.value.toString()).join(',')
-        : typeof field.value === 'object'
-        ? (field.value as SelectOption).value?.toString()
-        : ''
-    // The return value should be comma separated string or a number
-    toReturn.push({ name, value })
-  })
+  const toReturn: JiraCreateFieldType[] = []
+  const processRequiredOptionalFields = (selectedFields: JiraFieldNGWithValue[] | undefined): void => {
+    selectedFields?.forEach((field: JiraFieldNGWithValue) => {
+      const name = field.name
+      const value =
+        typeof field.value === 'string' || typeof field.value === 'number'
+          ? field.value
+          : Array.isArray(field.value)
+          ? (field.value as MultiSelectOption[]).map(opt => opt.value.toString()).join(',')
+          : typeof field.value === 'object'
+          ? (field.value as SelectOption).value?.toString()
+          : ''
+      // The return value should be comma separated string or a number
+      toReturn.push({ name, value })
+    })
+  }
+  processRequiredOptionalFields(values.spec.selectedOptionalFields)
+  processRequiredOptionalFields(values.spec?.selectedRequiredFields)
   values.spec.fields?.forEach((kvField: JiraCreateFieldType) => {
     const alreadyExists = toReturn.find(ff => ff.name === kvField.name)
     if (!alreadyExists) {
@@ -115,7 +107,7 @@ export const processFormData = (values: JiraCreateData): JiraCreateData => {
 }
 
 export const getKVFields = (values: JiraCreateData): JiraCreateFieldType[] => {
-  return omitSummaryDescription(processFieldsForSubmit(values))
+  return processFieldsForSubmit(values)
 }
 
 export const processInitialValues = (values: JiraCreateData): JiraCreateData => {
@@ -140,9 +132,7 @@ export const processInitialValues = (values: JiraCreateData): JiraCreateData => 
               key: values.spec.issueType.toString()
             }
           : values.spec.issueType,
-      summary: values.spec.fields?.find(field => field.name === 'Summary')?.value.toString(),
-      description: values.spec.fields?.find(field => field.name === 'Description')?.value.toString(),
-      fields: omitSummaryDescription(values.spec.fields)
+      fields: values.spec.fields
     }
   }
 }
@@ -168,13 +158,15 @@ export const getSelectedFieldsToBeAddedInForm = (
 export const getKVFieldsToBeAddedInForm = (
   newFields: JiraCreateFieldType[],
   existingFields: JiraCreateFieldType[] = [],
-  existingSelectedFields: JiraFieldNGWithValue[] = []
+  existingSelectedFields: JiraFieldNGWithValue[] = [],
+  requiredSelectedFields: JiraFieldNGWithValue[] = []
 ): JiraCreateFieldType[] => {
   const toReturn: JiraCreateFieldType[] = [...existingFields]
   newFields.forEach(field => {
     const alreadyPresent = existingFields.find(existing => existing.name === field.name)
-    const alreadyPresentSelectedField = existingSelectedFields.find(existing => existing.name === field.name)
-    if (!alreadyPresent && !alreadyPresentSelectedField) {
+    const alreadyPresentOptionalField = existingSelectedFields.find(existing => existing.name === field.name)
+    const alreadyPresentRequiredField = requiredSelectedFields.find(existing => existing.name === field.name)
+    if (!alreadyPresent && !alreadyPresentOptionalField && !alreadyPresentRequiredField) {
       toReturn.push(field)
     }
   })

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraCreate/types.ts
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraCreate/types.ts
@@ -35,10 +35,9 @@ export interface JiraCreateData extends StepElementConfig {
     connectorRef: string | SelectOption
     projectKey: string | JiraProjectSelectOption
     issueType: string | JiraProjectSelectOption
-    summary?: string
-    description?: string
     fields: JiraCreateFieldType[]
-    selectedFields?: JiraFieldNGWithValue[]
+    selectedRequiredFields?: JiraFieldNGWithValue[]
+    selectedOptionalFields?: JiraFieldNGWithValue[]
     delegateSelectors?: string[]
   }
 }

--- a/src/modules/70-pipeline/strings/strings.en.yaml
+++ b/src/modules/70-pipeline/strings/strings.en.yaml
@@ -140,6 +140,7 @@ jiraApprovalStep:
     project: Project is required
     issueKey: Issue Key is required
     issueType: Issue Type is required
+    requiredField: This is a required field.
 jiraCreateStep:
   fields: Jira Fields
   summaryPlaceholder: Enter a Title or Summary

--- a/src/stringTypes.ts
+++ b/src/stringTypes.ts
@@ -2834,6 +2834,7 @@ export interface StringsMap {
   'pipeline.jiraApprovalStep.validations.issueKey': string
   'pipeline.jiraApprovalStep.validations.issueType': string
   'pipeline.jiraApprovalStep.validations.project': string
+  'pipeline.jiraApprovalStep.validations.requiredField': string
   'pipeline.jiraCreateStep.addFields': string
   'pipeline.jiraCreateStep.fetchingFields': string
   'pipeline.jiraCreateStep.fieldSelectorAdd': string


### PR DESCRIPTION
…Type

##### Summary:

Jira Fields which are required for Jira create step will now be rendered when we choose an issueType. It will be required to fill before submitting the form.
Jira Fields which are optional will be the part of optional configuration only.

Jira Links:
https://harness.atlassian.net/browse/CDS-34833

##### Screenshots:


https://user-images.githubusercontent.com/98508399/167708334-5f07bf1d-d13d-455a-b9de-113e4cb413b4.mov



You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
