### PR TITLE
fix: [PIE-3785]: Wait for 3 sec when cypress loading page

### DIFF
--- a/cypress/integration/70-pipeline/ExecutionHistory.spec.ts
+++ b/cypress/integration/70-pipeline/ExecutionHistory.spec.ts
@@ -24,6 +24,8 @@ describe('Pipeline Execution History', () => {
   })
 
   it('loads a pipeline with no executions', () => {
+    cy.wait(3000) // page load sometimes takes time
+
     cy.findByText('There are no deployments in your project').should('exist')
     cy.findByText('Your Pipeline does not have any executions yet. Click the button below to run a pipeline.').should(
       'exist'


### PR DESCRIPTION
##### Summary:
When cypress runs the test first time, page loads takes a while leading to timeout of element not found

##### Jira Links:
https://harness.atlassian.net/browse/PIE-3785

##### Screenshots:

<!--- Add screenshots for your changes here -->

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
