### PR TITLE
fix: [PL-24902]: avoid redirect to project page

### DIFF
--- a/src/framework/AppStore/AppStoreContext.tsx
+++ b/src/framework/AppStore/AppStoreContext.tsx
@@ -225,14 +225,19 @@ export function AppStoreProvider(props: React.PropsWithChildren<unknown>): React
 
   // When projectIdentifier in URL changes, fetch projectDetails, and update selectedProject & savedProject-preference
   useEffect(() => {
+    const controller = new AbortController()
+    const { signal } = controller
     if (projectIdentifier && orgIdentifier) {
-      getProjectPromise({
-        identifier: projectIdentifier,
-        queryParams: {
-          accountIdentifier: accountId,
-          orgIdentifier
-        }
-      }).then(response => {
+      getProjectPromise(
+        {
+          identifier: projectIdentifier,
+          queryParams: {
+            accountIdentifier: accountId,
+            orgIdentifier
+          }
+        },
+        signal
+      ).then(response => {
         const project = response?.data?.project
 
         if (project) {
@@ -259,6 +264,9 @@ export function AppStoreProvider(props: React.PropsWithChildren<unknown>): React
           }
         }
       })
+    }
+    return () => {
+      controller.abort()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [projectIdentifier, orgIdentifier])

--- a/src/framework/AppStore/AppStoreContext.tsx
+++ b/src/framework/AppStore/AppStoreContext.tsx
@@ -253,8 +253,10 @@ export function AppStoreProvider(props: React.PropsWithChildren<unknown>): React
             selectedOrg: undefined,
             selectedProject: undefined
           }))
-          // if user is on a URL with projectId and orgId in path, show toast error & redirect
-          showErrorAndRedirect(response as Error)
+          if (LOCAL_FF_PREFERENCE_STORE_ENABLED) {
+            // if user is on a URL with projectId and orgId in path, show toast error & redirect
+            showErrorAndRedirect(response as Error)
+          }
         }
       })
     }


### PR DESCRIPTION
##### Summary:

dont show error and redirect when project api call is cancelled/failed

##### Jira Links:

<!--- Add jira links for your changes here -->

##### Screenshots:

<!--- Add screenshots for your changes here -->

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
