### PR TITLE
fix: [PIE-3816]: continue disabled till connectors are fetched

### DIFF
--- a/src/modules/35-connectors/components/ConnectorReferenceField/FormMultiTypeConnectorField.tsx
+++ b/src/modules/35-connectors/components/ConnectorReferenceField/FormMultiTypeConnectorField.tsx
@@ -75,6 +75,7 @@ export interface MultiTypeConnectorFieldProps extends Omit<ConnectorReferenceFie
   tooltipProps?: DataTooltipInterface
   multitypeInputValue?: MultiTypeInputType
   connectorLabelClass?: string
+  onLoadingFinish?: () => void
 }
 export interface ConnectorReferenceDTO extends ConnectorInfoDTO {
   status: ConnectorResponse['status']
@@ -227,12 +228,17 @@ export const MultiTypeConnectorField = (props: MultiTypeConnectorFieldProps): Re
           formik?.setFieldValue(name, value)
         }
         setSelectedValue(value)
+        props?.onLoadingFinish?.()
       } else if (error) {
         if (!setRefValue) {
           formik?.setFieldValue(name, '')
         }
         setSelectedValue('')
+        props?.onLoadingFinish?.()
       }
+    } else {
+      // enabling for expressions/runtime
+      !loading && props?.onLoadingFinish?.()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loading])
@@ -397,6 +403,7 @@ export const MultiTypeConnectorField = (props: MultiTypeConnectorFieldProps): Re
             formik?.setFieldValue(name, val || '')
             setSelectedValue(val || '')
           }
+          props?.onLoadingFinish?.()
           setMultiType(type1)
           onChange?.(val, valueType, type1)
         }}

--- a/src/modules/35-connectors/components/ConnectorReferenceField/__tests__/FormMultiTypeConnectorField.test.tsx
+++ b/src/modules/35-connectors/components/ConnectorReferenceField/__tests__/FormMultiTypeConnectorField.test.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import React from 'react'
+import { render } from '@testing-library/react'
+import { MultiTypeInputType } from '@wings-software/uicore'
+import { TestWrapper } from '@common/utils/testUtils'
+import { FormMultiTypeConnectorField } from '../FormMultiTypeConnectorField'
+
+jest.mock('services/cd-ng', () => ({
+  useGetConnector: jest.fn().mockImplementation(() => ({ data: {} }))
+}))
+describe('FormMultiTypeConnectorField tests', () => {
+  test(`renders without crashing`, () => {
+    const { container } = render(
+      <TestWrapper>
+        <FormMultiTypeConnectorField
+          key={'Github'}
+          onLoadingFinish={jest.fn()}
+          name="connectorRef"
+          label={'connector'}
+          placeholder={`Select Connector`}
+          accountIdentifier={'dummy'}
+          projectIdentifier={'dummy'}
+          orgIdentifier={'dummy'}
+          width={400}
+          multiTypeProps={{ expressions: [], allowableTypes: [MultiTypeInputType.FIXED, MultiTypeInputType.RUNTIME] }}
+          createNewLabel={'newConnectorLabel'}
+          enableConfigureOptions={true}
+          gitScope={{ repo: 'repoIdentifier', branch: 'branch', getDefaultFromOtherRepo: true }}
+        />
+      </TestWrapper>
+    )
+    expect(container).toMatchSnapshot()
+  })
+})

--- a/src/modules/35-connectors/components/ConnectorReferenceField/__tests__/__snapshots__/FormMultiTypeConnectorField.test.tsx.snap
+++ b/src/modules/35-connectors/components/ConnectorReferenceField/__tests__/__snapshots__/FormMultiTypeConnectorField.test.tsx.snap
@@ -1,0 +1,97 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FormMultiTypeConnectorField tests renders without crashing 1`] = `
+<div>
+  <div
+    class="connectorLabel"
+  >
+    <div
+      class="StyledProps--font StyledProps--main"
+      style="margin-bottom: 5px;"
+    >
+      connector
+    </div>
+    <div
+      style="display: flex; align-items: center;"
+    >
+      <div
+        class="bp3-form-group"
+        style="margin-bottom: 0px;"
+      >
+        <div
+          class="bp3-form-content"
+        >
+          <div
+            class="Layout--horizontal StyledProps--main MultiTypeInput--main"
+            style="width: 400px;"
+          >
+            <button
+              class="bp3-button bp3-minimal Button--button StyledProps--font StyledProps--main container Button--iconOnly Button--without-shadow Button--withRightIcon"
+              data-testid="cr-field-connectorRef"
+              style="width: 400px;"
+              type="button"
+            >
+              <span
+                class="bp3-button-text"
+              >
+                <span
+                  class="placeholder"
+                >
+                  Select Connector
+                </span>
+              </span>
+              <span
+                class="bp3-icon bp3-icon-chevron-down StyledProps--main"
+                icon="chevron-down"
+              >
+                <svg
+                  data-icon="chevron-down"
+                  height="14"
+                  viewBox="0 0 16 16"
+                  width="14"
+                >
+                  <desc>
+                    chevron-down
+                  </desc>
+                  <path
+                    d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
+            </button>
+            <span
+              class="bp3-popover-wrapper MultiTypeInput--wrapper"
+            >
+              <span
+                class="bp3-popover-target"
+              >
+                <button
+                  class="MultiTypeInput--btn MultiTypeInput--FIXED"
+                >
+                  <span
+                    class="bp3-icon StyledProps--main"
+                    data-icon="fixed-input"
+                  >
+                    <svg
+                      height="12"
+                      viewBox="0 0 9 9"
+                      width="12"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M5.61 7.55c.62-.7.3-1.42.18-2.35a.32.32 0 01.1-.29l1.43-1.42a.76.76 0 01.28-.15c.39-.1 1 0 1.28-.29a.34.34 0 000-.51L6.46.12a.33.33 0 00-.52 0c-.28.29-.2.9-.28 1.3a.53.53 0 01-.13.23L4.09 3.12a.29.29 0 01-.28.09c-.89-.11-1.6-.49-2.27.11-.29.26-.29.43 0 .7l1.31 1.34.15.16-.15.15-2.7 2.69a.36.36 0 000 .54.36.36 0 00.54-.05l2.63-2.68.17-.17.17.16c.45.46.9.91 1.36 1.36.21.21.42.22.59.03z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </span>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/modules/70-pipeline/components/ManifestSelection/ManifestWizardSteps/ManifestStore.tsx
+++ b/src/modules/70-pipeline/components/ManifestSelection/ManifestWizardSteps/ManifestStore.tsx
@@ -73,7 +73,7 @@ function ManifestStore({
   const { accountId, projectIdentifier, orgIdentifier } = useParams<ProjectPathProps>()
   const { repoIdentifier, branch } = useQueryParams<GitQueryParams>()
   const { getString } = useStrings()
-
+  const [isLoadingConnectors, setIsLoadingConnectors] = React.useState<boolean>(true)
   const [selectedStore, setSelectedStore] = useState(prevStepData?.store ?? initialValues.store)
   const [multitypeInputValue, setMultiTypeValue] = useState<MultiTypeInputType | undefined>(undefined)
 
@@ -195,6 +195,9 @@ function ManifestStore({
                   >
                     <FormMultiTypeConnectorField
                       key={formik.values.store}
+                      onLoadingFinish={() => {
+                        setIsLoadingConnectors(false)
+                      }}
                       name="connectorRef"
                       label={`${getString(
                         ManifestToConnectorLabelMap[formik.values.store as ManifestStoreExcludingInheritFromManifest]
@@ -265,7 +268,10 @@ function ManifestStore({
                   type="submit"
                   text={getString('continue')}
                   rightIcon="chevron-right"
-                  disabled={!shouldGotoNextStep(formik.values.connectorRef as ConnectorSelectedValue | string)}
+                  disabled={
+                    isLoadingConnectors ||
+                    !shouldGotoNextStep(formik.values.connectorRef as ConnectorSelectedValue | string)
+                  }
                 />
               </Layout.Horizontal>
             </Layout.Vertical>

--- a/src/modules/70-pipeline/components/ManifestSelection/__tests__/ManifestStore.test.tsx
+++ b/src/modules/70-pipeline/components/ManifestSelection/__tests__/ManifestStore.test.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import React from 'react'
+import { render } from '@testing-library/react'
+import { MultiTypeInputType } from '@wings-software/uicore'
+import { TestWrapper } from '@common/utils/testUtils'
+import ManifestStore from '../ManifestWizardSteps/ManifestStore'
+import type { ManifestStepInitData } from '../ManifestInterface'
+
+jest.mock('services/cd-ng', () => ({
+  useGetConnector: jest.fn().mockImplementation(() => ({ data: {} }))
+}))
+describe('ManifestSelection tests', () => {
+  test(`renders without crashing`, () => {
+    const { container } = render(
+      <TestWrapper>
+        <ManifestStore
+          name={'manifestSource'}
+          stepName={'second step'}
+          expressions={[]}
+          allowableTypes={[MultiTypeInputType.FIXED, MultiTypeInputType.RUNTIME, MultiTypeInputType.EXPRESSION]}
+          isReadonly={false}
+          manifestStoreTypes={['Git', 'Github', 'GitLab', 'Bitbucket']}
+          handleConnectorViewChange={jest.fn()}
+          handleStoreChange={jest.fn()}
+          initialValues={{} as ManifestStepInitData}
+        />
+      </TestWrapper>
+    )
+    expect(container).toMatchSnapshot()
+  })
+
+  test(`renders K8 Manifest Store`, () => {
+    const { container } = render(
+      <TestWrapper>
+        <ManifestStore
+          name={'manifestSource'}
+          stepName={'second step'}
+          expressions={[]}
+          allowableTypes={[MultiTypeInputType.FIXED, MultiTypeInputType.RUNTIME, MultiTypeInputType.EXPRESSION]}
+          isReadonly={false}
+          manifestStoreTypes={['Git', 'Github', 'GitLab', 'Bitbucket']}
+          handleConnectorViewChange={jest.fn()}
+          handleStoreChange={jest.fn()}
+          initialValues={
+            {
+              connectorRef: {
+                label: 'test',
+                value: 'test',
+                scope: 'project',
+                live: true,
+                connector: {
+                  name: 'test',
+                  identifier: 'test',
+                  description: '',
+                  orgIdentifier: 'default',
+                  projectIdentifier: 'default',
+                  tags: {},
+                  type: 'Github',
+                  spec: {
+                    url: 'http://github.com/default',
+                    validationRepo: 'Gdummy-repo',
+                    authentication: {
+                      type: 'Http',
+                      spec: {
+                        type: 'UsernameToken',
+                        spec: {
+                          username: 'default',
+                          usernameRef: null,
+                          tokenRef: 'secret'
+                        }
+                      }
+                    },
+                    apiAccess: null,
+                    delegateSelectors: [],
+                    executeOnDelegate: false,
+                    type: 'Account'
+                  }
+                }
+              },
+              gitFetchType: 'Branch',
+              paths: ['dsfs'],
+              repoName: 'demoRepo',
+              branch: 'demoBranch',
+              store: 'Github',
+              selectedManifest: 'K8sManifest'
+            } as ManifestStepInitData
+          }
+        />
+      </TestWrapper>
+    )
+    expect(container).toMatchSnapshot()
+  })
+})

--- a/src/modules/70-pipeline/components/ManifestSelection/__tests__/__snapshots__/ManifestStore.test.tsx.snap
+++ b/src/modules/70-pipeline/components/ManifestSelection/__tests__/__snapshots__/ManifestStore.test.tsx.snap
@@ -1,0 +1,704 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ManifestSelection tests renders K8 Manifest Store 1`] = `
+<div>
+  <div
+    class="Layout--vertical Layout--layout-spacing-medium StyledProps--main optionsViewContainer"
+    style="height: inherit;"
+  >
+    <p
+      class="StyledProps--font StyledProps--main StyledProps--font-variation-h3 StyledProps--margin-bottom-medium"
+    >
+      second step
+    </p>
+    <div
+      class="OverlaySpinner--overlaySpinner"
+    >
+      <form
+        action="#"
+        class="FormikForm--main"
+      >
+        <div>
+          <div
+            class="Layout--vertical StyledProps--main manifestForm StyledProps--flex StyledProps--flex-justifyContent-space-between StyledProps--flex-alignItems-flex-start"
+          >
+            <div
+              class="Layout--vertical StyledProps--main"
+            >
+              <div
+                class="Layout--horizontal Layout--layout-spacing-large StyledProps--main"
+              >
+                <div
+                  class="bp3-form-group ThumbnailSelect--mainContainer thumbnailSelect"
+                  data-id="store-0"
+                >
+                  <div
+                    class="bp3-form-content"
+                  >
+                    <div
+                      class="Layout--horizontal Layout--layout-spacing-medium StyledProps--main"
+                    >
+                      <label
+                        class="Thumbnail--squareCardContainer"
+                      >
+                        <div
+                          class="bp3-card bp3-elevation-0 Card--card Thumbnail--squareCard Card--selected"
+                        >
+                          <span
+                            class="Card--corner"
+                          >
+                            <span
+                              class="Card--badge"
+                            />
+                            <span
+                              class="bp3-icon StyledProps--main StyledProps--color StyledProps--color-white"
+                              data-icon="main-tick"
+                            >
+                              <svg
+                                height="10"
+                                viewBox="0 0 11 8"
+                                width="10"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M9.219.894c.356-.38.982-.413 1.398-.072.391.32.457.857.167 1.236l-.06.07-5.138 5.486c-.362.386-.993.41-1.403.068l-.07-.064-3.2-3.214A.88.88 0 01.95 3.098a1.045 1.045 0 011.328-.003l.074.067 2.443 2.454L9.22.894z"
+                                  fill="currentColor"
+                                />
+                              </svg>
+                            </span>
+                          </span>
+                          <span
+                            class="bp3-icon StyledProps--main"
+                            data-icon="github"
+                          >
+                            <svg
+                              height="26"
+                              viewBox="0 0 24 24"
+                              width="26"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"
+                              />
+                            </svg>
+                          </span>
+                        </div>
+                        <p
+                          class="StyledProps--font StyledProps--main Thumbnail--label StyledProps--font-weight-semi-bold StyledProps--color StyledProps--color-grey600 StyledProps--margin-top-small"
+                        >
+                          common.repo_provider.githubLabel
+                        </p>
+                        <input
+                          checked=""
+                          name="store"
+                          type="checkbox"
+                          value="Github"
+                        />
+                      </label>
+                      <button
+                        class="bp3-button bp3-minimal Button--button StyledProps--font StyledProps--main ThumbnailSelect--changeButton StyledProps--intent-primary Button--without-shadow Button--withLeftIcon"
+                        data-testid="thumbnail-select-change"
+                        type="button"
+                      >
+                        <span
+                          class="bp3-icon StyledProps--main StyledProps--padding-right-xsmall"
+                          data-icon="Edit"
+                        >
+                          <svg
+                            height="12"
+                            viewBox="0 0 16 16"
+                            width="12"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              clip-rule="evenodd"
+                              d="M11.207.485a.5.5 0 01.354-.146 3.5 3.5 0 013.5 3.5.5.5 0 01-.146.353l-11 11a.5.5 0 01-.354.147h-3a.5.5 0 01-.5-.5v-3a.5.5 0 01.146-.354l11-11zm.553.862L1.061 12.046v2.293h2.293l10.7-10.7a2.5 2.5 0 00-2.294-2.292z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M11.89 2.646a.5.5 0 010 .708L8.353 6.889a.5.5 0 01-.708-.707l3.536-3.536a.5.5 0 01.707 0z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                              opacity="0.3"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="bp3-button-text"
+                        >
+                          Change
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="Layout--horizontal Layout--layout-spacing-medium StyledProps--main connectorContainer StyledProps--flex StyledProps--flex-alignItems-flex-start StyledProps--flex-justifyContent-flex-start"
+              >
+                <div
+                  class="connectorLabel"
+                >
+                  <div
+                    class="StyledProps--font StyledProps--main"
+                    style="margin-bottom: 5px;"
+                  >
+                    <span
+                      class="Tooltip--acenter bp3-label"
+                      data-tooltip-id="manifestStore_connectorRef"
+                    >
+                      common.repo_provider.githubLabel connector
+                    </span>
+                  </div>
+                  <div
+                    class="bp3-form-group"
+                    data-id="undefined-1"
+                    style="margin-bottom: 0px;"
+                  >
+                    <div
+                      class="bp3-form-content"
+                    >
+                      <div
+                        class="Layout--horizontal StyledProps--main MultiTypeInput--main"
+                        style="width: 400px;"
+                      >
+                        <button
+                          class="bp3-button bp3-minimal Button--button StyledProps--font StyledProps--main container Button--iconOnly Button--without-shadow Button--withRightIcon"
+                          data-testid="cr-field-connectorRef"
+                          style="width: 400px;"
+                          type="button"
+                        >
+                          <span
+                            class="bp3-button-text"
+                          >
+                            <div
+                              class="Layout--horizontal Layout--layout-spacing-small StyledProps--main selectWrapper StyledProps--flex StyledProps--flex-distribution-space-between"
+                            >
+                              <span
+                                class="bp3-popover-wrapper"
+                              >
+                                <span
+                                  class="bp3-popover-target Text--targetClass"
+                                >
+                                  <p
+                                    class="StyledProps--font StyledProps--main label StyledProps--color StyledProps--color-grey800"
+                                    tabindex="0"
+                                  >
+                                    test
+                                  </p>
+                                </span>
+                              </span>
+                              <div
+                                class="rightStatus"
+                              >
+                                <span
+                                  class="bp3-icon bp3-icon-full-circle StyledProps--main status greenStatus"
+                                  data-testid="crf-status"
+                                  icon="full-circle"
+                                >
+                                  <svg
+                                    data-icon="full-circle"
+                                    height="6"
+                                    viewBox="0 0 16 16"
+                                    width="6"
+                                  >
+                                    <desc>
+                                      full-circle
+                                    </desc>
+                                    <path
+                                      d="M8 0a8 8 0 100 16A8 8 0 108 0z"
+                                      fill-rule="evenodd"
+                                    />
+                                  </svg>
+                                </span>
+                                <span
+                                  class="Tag--main"
+                                >
+                                  <span
+                                    class="bp3-tag bp3-minimal"
+                                    id="tag"
+                                  >
+                                    <span
+                                      class="bp3-text-overflow-ellipsis bp3-fill"
+                                    >
+                                      project
+                                    </span>
+                                  </span>
+                                </span>
+                              </div>
+                            </div>
+                          </span>
+                          <span
+                            class="bp3-icon bp3-icon-chevron-down StyledProps--main"
+                            icon="chevron-down"
+                          >
+                            <svg
+                              data-icon="chevron-down"
+                              height="14"
+                              viewBox="0 0 16 16"
+                              width="14"
+                            >
+                              <desc>
+                                chevron-down
+                              </desc>
+                              <path
+                                d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </span>
+                        </button>
+                        <span
+                          class="bp3-popover-wrapper MultiTypeInput--wrapper"
+                        >
+                          <span
+                            class="bp3-popover-target"
+                          >
+                            <button
+                              class="MultiTypeInput--btn MultiTypeInput--FIXED"
+                            >
+                              <span
+                                class="bp3-icon StyledProps--main"
+                                data-icon="fixed-input"
+                              >
+                                <svg
+                                  height="12"
+                                  viewBox="0 0 9 9"
+                                  width="12"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M5.61 7.55c.62-.7.3-1.42.18-2.35a.32.32 0 01.1-.29l1.43-1.42a.76.76 0 01.28-.15c.39-.1 1 0 1.28-.29a.34.34 0 000-.51L6.46.12a.33.33 0 00-.52 0c-.28.29-.2.9-.28 1.3a.53.53 0 01-.13.23L4.09 3.12a.29.29 0 01-.28.09c-.89-.11-1.6-.49-2.27.11-.29.26-.29.43 0 .7l1.31 1.34.15.16-.15.15-2.7 2.69a.36.36 0 000 .54.36.36 0 00.54-.05l2.63-2.68.17-.17.17.16c.45.46.9.91 1.36 1.36.21.21.42.22.59.03z"
+                                    fill="currentColor"
+                                  />
+                                </svg>
+                              </span>
+                            </button>
+                          </span>
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <button
+                  class="bp3-button Button--button StyledProps--font StyledProps--main addNewManifest Button--with-current-color Button--withLeftIcon Button--variation Button--variation-link Button--size Button--small"
+                  id="new-manifest-connector"
+                  type="button"
+                >
+                  <span
+                    class="bp3-icon bp3-icon-plus StyledProps--main StyledProps--padding-right-xsmall"
+                    icon="plus"
+                  >
+                    <svg
+                      data-icon="plus"
+                      height="12"
+                      viewBox="0 0 16 16"
+                      width="12"
+                    >
+                      <desc>
+                        plus
+                      </desc>
+                      <path
+                        d="M13 7H9V3c0-.55-.45-1-1-1s-1 .45-1 1v4H3c-.55 0-1 .45-1 1s.45 1 1 1h4v4c0 .55.45 1 1 1s1-.45 1-1V9h4c.55 0 1-.45 1-1s-.45-1-1-1z"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="bp3-button-text"
+                  >
+                    newLabel common.repo_provider.githubLabel connector
+                  </span>
+                </button>
+              </div>
+            </div>
+            <div
+              class="Layout--horizontal Layout--layout-spacing-medium StyledProps--main saveBtn"
+            >
+              <button
+                class="bp3-button Button--button StyledProps--font StyledProps--main Button--with-current-color Button--withLeftIcon Button--variation Button--variation-secondary"
+                type="button"
+              >
+                <span
+                  class="bp3-icon bp3-icon-chevron-left StyledProps--main StyledProps--padding-right-xsmall"
+                  icon="chevron-left"
+                >
+                  <svg
+                    data-icon="chevron-left"
+                    height="16"
+                    viewBox="0 0 16 16"
+                    width="16"
+                  >
+                    <desc>
+                      chevron-left
+                    </desc>
+                    <path
+                      d="M7.41 8l3.29-3.29c.19-.18.3-.43.3-.71a1.003 1.003 0 00-1.71-.71l-4 4C5.11 7.47 5 7.72 5 8c0 .28.11.53.29.71l4 4a1.003 1.003 0 001.42-1.42L7.41 8z"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="bp3-button-text"
+                >
+                  back
+                </span>
+              </button>
+              <button
+                class="bp3-button Button--button StyledProps--font StyledProps--main Button--with-current-color Button--withRightIcon Button--variation Button--variation-primary"
+                type="submit"
+              >
+                <span
+                  class="bp3-button-text"
+                >
+                  continue
+                </span>
+                <span
+                  class="bp3-icon bp3-icon-chevron-right StyledProps--main"
+                  icon="chevron-right"
+                >
+                  <svg
+                    data-icon="chevron-right"
+                    height="16"
+                    viewBox="0 0 16 16"
+                    width="16"
+                  >
+                    <desc>
+                      chevron-right
+                    </desc>
+                    <path
+                      d="M10.71 7.29l-4-4a1.003 1.003 0 00-1.42 1.42L8.59 8 5.3 11.29c-.19.18-.3.43-.3.71a1.003 1.003 0 001.71.71l4-4c.18-.18.29-.43.29-.71 0-.28-.11-.53-.29-.71z"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ManifestSelection tests renders without crashing 1`] = `
+<div>
+  <div
+    class="Layout--vertical Layout--layout-spacing-medium StyledProps--main optionsViewContainer"
+    style="height: inherit;"
+  >
+    <p
+      class="StyledProps--font StyledProps--main StyledProps--font-variation-h3 StyledProps--margin-bottom-medium"
+    >
+      second step
+    </p>
+    <div
+      class="OverlaySpinner--overlaySpinner"
+    >
+      <form
+        action="#"
+        class="FormikForm--main"
+      >
+        <div>
+          <div
+            class="Layout--vertical StyledProps--main manifestForm StyledProps--flex StyledProps--flex-justifyContent-space-between StyledProps--flex-alignItems-flex-start"
+          >
+            <div
+              class="Layout--vertical StyledProps--main"
+            >
+              <div
+                class="Layout--horizontal Layout--layout-spacing-large StyledProps--main"
+              >
+                <div
+                  class="bp3-form-group ThumbnailSelect--mainContainer thumbnailSelect"
+                  data-id="store-0"
+                >
+                  <div
+                    class="bp3-form-content"
+                  >
+                    <div
+                      class="Layout--horizontal Layout--layout-spacing-medium StyledProps--main"
+                    >
+                      <label
+                        class="Thumbnail--squareCardContainer"
+                      >
+                        <div
+                          class="bp3-card bp3-interactive bp3-elevation-0 Card--card Thumbnail--squareCard Card--interactive"
+                          tabindex="0"
+                        >
+                          <span
+                            class="bp3-icon StyledProps--main"
+                            data-icon="service-github"
+                          >
+                            <svg
+                              height="26"
+                              viewBox="0 0 14 14"
+                              width="26"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M13.6 6.4l-6-6C7.3.1 6.7.1 6.4.4L5.1 1.6l1.6 1.6c.4-.1.8 0 1.1.3s.4.7.2 1.1l1.5 1.5c.4-.1.8 0 1.1.2.4.4.4 1.1 0 1.5s-1.1.4-1.5 0c-.3-.3-.3-.7-.2-1.1L7.5 5.3V9c.1 0 .2.1.3.2.4.4.4 1.1 0 1.5s-1.1.4-1.5 0-.4-1.1 0-1.5c.1-.1.2-.2.3-.2V5.2c-.1-.1-.2-.1-.3-.2-.3-.4-.4-.8-.2-1.2L4.5 2.3.4 6.4c-.3.3-.3.9 0 1.2l6 6c.3.3.9.3 1.2 0l6-6c.3-.3.3-.9 0-1.2z"
+                                fill="#f42534"
+                              />
+                            </svg>
+                          </span>
+                        </div>
+                        <p
+                          class="StyledProps--font StyledProps--main Thumbnail--label StyledProps--font-weight-semi-bold StyledProps--color StyledProps--color-grey600 StyledProps--margin-top-small"
+                        >
+                          pipeline.manifestType.gitConnectorLabel
+                        </p>
+                        <input
+                          name="store"
+                          type="checkbox"
+                          value="Git"
+                        />
+                      </label>
+                      <label
+                        class="Thumbnail--squareCardContainer"
+                      >
+                        <div
+                          class="bp3-card bp3-interactive bp3-elevation-0 Card--card Thumbnail--squareCard Card--interactive"
+                          tabindex="0"
+                        >
+                          <span
+                            class="bp3-icon StyledProps--main"
+                            data-icon="github"
+                          >
+                            <svg
+                              height="26"
+                              viewBox="0 0 24 24"
+                              width="26"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"
+                              />
+                            </svg>
+                          </span>
+                        </div>
+                        <p
+                          class="StyledProps--font StyledProps--main Thumbnail--label StyledProps--font-weight-semi-bold StyledProps--color StyledProps--color-grey600 StyledProps--margin-top-small"
+                        >
+                          common.repo_provider.githubLabel
+                        </p>
+                        <input
+                          name="store"
+                          type="checkbox"
+                          value="Github"
+                        />
+                      </label>
+                      <label
+                        class="Thumbnail--squareCardContainer"
+                      >
+                        <div
+                          class="bp3-card bp3-interactive bp3-elevation-0 Card--card Thumbnail--squareCard Card--interactive"
+                          tabindex="0"
+                        >
+                          <span
+                            class="bp3-icon StyledProps--main"
+                            data-icon="service-gotlab"
+                          >
+                            <svg
+                              height="26"
+                              viewBox="0 0 14 13"
+                              width="26"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M7 12.9L9.6 5H4.4z"
+                                fill="#e24329"
+                              />
+                              <path
+                                d="M7 12.9L4.4 5H.8z"
+                                fill="#fc6d26"
+                              />
+                              <path
+                                d="M.8 5L0 7.4c0 .2 0 .5.2.6L7 12.9z"
+                                fill="#fca326"
+                              />
+                              <path
+                                d="M.8 5h3.6L2.9.2c-.1-.2-.5-.2-.5 0z"
+                                fill="#e24329"
+                              />
+                              <path
+                                d="M7 12.9L9.6 5h3.6z"
+                                fill="#fc6d26"
+                              />
+                              <path
+                                d="M13.2 5l.8 2.4c0 .2 0 .5-.2.6L7 12.9z"
+                                fill="#fca326"
+                              />
+                              <path
+                                d="M13.2 5H9.6L11.2.2c.1-.2.4-.2.5 0z"
+                                fill="#e24329"
+                              />
+                            </svg>
+                          </span>
+                        </div>
+                        <p
+                          class="StyledProps--font StyledProps--main Thumbnail--label StyledProps--font-weight-semi-bold StyledProps--color StyledProps--color-grey600 StyledProps--margin-top-small"
+                        >
+                          common.repo_provider.gitlabLabel
+                        </p>
+                        <input
+                          name="store"
+                          type="checkbox"
+                          value="GitLab"
+                        />
+                      </label>
+                      <label
+                        class="Thumbnail--squareCardContainer"
+                      >
+                        <div
+                          class="bp3-card bp3-interactive bp3-elevation-0 Card--card Thumbnail--squareCard Card--interactive"
+                          tabindex="0"
+                        >
+                          <span
+                            class="bp3-icon StyledProps--main"
+                            data-icon="bitbucket"
+                          >
+                            <svg
+                              height="26"
+                              width="26"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <defs>
+                                <lineargradient
+                                  id="bitbucket_svg__b"
+                                  x1="108.633%"
+                                  x2="46.927%"
+                                  y1="13.408%"
+                                  y2="79.102%"
+                                >
+                                  <stop
+                                    offset="18%"
+                                    stop-color="#0052CC"
+                                  />
+                                  <stop
+                                    offset="100%"
+                                    stop-color="#2684FF"
+                                  />
+                                </lineargradient>
+                                <filter
+                                  id="bitbucket_svg__a"
+                                >
+                                  <fecolormatrix
+                                    in="SourceGraphic"
+                                    values="0 0 0 0 0.157377 0 0 0 0 0.161311 0 0 0 0 0.240000 0 0 0 1.000000 0"
+                                  />
+                                </filter>
+                              </defs>
+                              <g
+                                fill="none"
+                                fill-rule="evenodd"
+                                filter="url(#bitbucket_svg__a)"
+                                transform="translate(2 3)"
+                              >
+                                <path
+                                  d="M8.305 12.59h4.383l1.058-6.211H7.14z"
+                                />
+                                <path
+                                  d="M.681.008a.671.671 0 00-.518.235.68.68 0 00-.154.55l2.855 17.432c.074.44.45.764.895.768h13.698a.674.674 0 00.673-.568L20.985.797a.68.68 0 00-.154-.55.671.671 0 00-.519-.235L.682.008zm12.024 12.6H8.333l-1.184-6.22h6.615l-1.06 6.22z"
+                                  fill="#2684FF"
+                                  fill-rule="nonzero"
+                                />
+                                <path
+                                  d="M20.06 6.379h-6.308l-1.059 6.215H8.325L3.166 18.75a.908.908 0 00.588.223h13.691a.673.673 0 00.672-.568L20.06 6.38z"
+                                  fill="url(#bitbucket_svg__b)"
+                                  fill-rule="nonzero"
+                                />
+                              </g>
+                            </svg>
+                          </span>
+                        </div>
+                        <p
+                          class="StyledProps--font StyledProps--main Thumbnail--label StyledProps--font-weight-semi-bold StyledProps--color StyledProps--color-grey600 StyledProps--margin-top-small"
+                        >
+                          pipeline.manifestType.bitBucketLabel
+                        </p>
+                        <input
+                          name="store"
+                          type="checkbox"
+                          value="Bitbucket"
+                        />
+                      </label>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="Layout--horizontal Layout--layout-spacing-medium StyledProps--main saveBtn"
+            >
+              <button
+                class="bp3-button Button--button StyledProps--font StyledProps--main Button--with-current-color Button--withLeftIcon Button--variation Button--variation-secondary"
+                type="button"
+              >
+                <span
+                  class="bp3-icon bp3-icon-chevron-left StyledProps--main StyledProps--padding-right-xsmall"
+                  icon="chevron-left"
+                >
+                  <svg
+                    data-icon="chevron-left"
+                    height="16"
+                    viewBox="0 0 16 16"
+                    width="16"
+                  >
+                    <desc>
+                      chevron-left
+                    </desc>
+                    <path
+                      d="M7.41 8l3.29-3.29c.19-.18.3-.43.3-.71a1.003 1.003 0 00-1.71-.71l-4 4C5.11 7.47 5 7.72 5 8c0 .28.11.53.29.71l4 4a1.003 1.003 0 001.42-1.42L7.41 8z"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="bp3-button-text"
+                >
+                  back
+                </span>
+              </button>
+              <button
+                class="bp3-button bp3-disabled Button--button StyledProps--font StyledProps--main Button--with-current-color Button--withRightIcon Button--variation Button--variation-primary"
+                disabled=""
+                tabindex="-1"
+                type="submit"
+              >
+                <span
+                  class="bp3-button-text"
+                >
+                  continue
+                </span>
+                <span
+                  class="bp3-icon bp3-icon-chevron-right StyledProps--main"
+                  icon="chevron-right"
+                >
+                  <svg
+                    data-icon="chevron-right"
+                    height="16"
+                    viewBox="0 0 16 16"
+                    width="16"
+                  >
+                    <desc>
+                      chevron-right
+                    </desc>
+                    <path
+                      d="M10.71 7.29l-4-4a1.003 1.003 0 00-1.42 1.42L8.59 8 5.3 11.29c-.19.18-.3.43-.3.71a1.003 1.003 0 001.71.71l4-4c.18-.18.29-.43.29-.71 0-.28-.11-.53-.29-.71z"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
##### Summary:

Disabling the `continue` button in ManifestWizard till the connector is fetched.

##### Jira Links:

[https://harness.atlassian.net/browse/PIE-3816](https://harness.atlassian.net/browse/PIE-3816)

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
