### PR TITLE
fix: [PL-25457]: MFE chunks fail to load: redirect to login via index.html if token is missing

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -27,6 +27,7 @@ sed -i "s|<\!-- saberToken -->|<script>window.saberToken = '$SABER_TOKEN'</scrip
 sed -i "s|<\!-- helpPanelAccessToken -->|<script>window.helpPanelAccessToken = '$HELP_PANEL_ACCESS_TOKEN'</script>|" index.html
 sed -i "s|<\!-- helpPanelSpace -->|<script>window.helpPanelSpace = '$HELP_PANEL_SPACE'</script>|" index.html
 sed -i "s|<\!-- helpPanelEnvironment -->|<script>window.helpPanelEnvironment = '$HELP_PANEL_ENVIRONMENT'</script>|" index.html
+sed -i "s|HARNESS_REDIRECT_FROM_INDEX_PLACEHOLDER|$HARNESS_REDIRECT_FROM_INDEX_PLACEHOLDER|" index.html
 if [ "$HARNESS_ENABLE_CDN_PLACEHOLDER" = "true" ]
 then
   sed -i "s|\"static\/main\.\(.*\)\.js\"|\"//static.harness.io/ng-static/main.\1.js\"|" index.html

--- a/src/index.html
+++ b/src/index.html
@@ -80,6 +80,21 @@
       window.HARNESS_ENABLE_NG_AUTH_UI = true
     </script>
     <% } %>
+    <script>
+      function getLoginPageURL({ returnUrl }) {
+        var basePath = window.HARNESS_ENABLE_NG_AUTH_UI
+          ? '/auth/#/signin'
+          : `${window.location.pathname.replace(/\/ng\//, '/')}#/login` // pick current path, but remove `/ng/`
+
+        return returnUrl
+          ? `${basePath}?action=signout&returnUrl=${encodeURIComponent(returnUrl)}`
+          : `${basePath}?action=signout`
+      }
+      var token = localStorage.getItem('token')
+      if (!token) {
+        window.location = getLoginPageURL({ returnUrl: window.location.href })
+      }
+    </script>
 
     <!-- AppDynamic EUM -->
     <script>

--- a/src/index.html
+++ b/src/index.html
@@ -64,6 +64,7 @@
       window.HARNESS_ENABLE_APPDY_EUM = 'HARNESS_ENABLE_APPDY_EUM_PLACEHOLDER' === 'true'
       window.HARNESS_ENABLE_CDN = 'HARNESS_ENABLE_CDN_PLACEHOLDER' === 'true'
       window.HARNESS_ENABLE_SABER = 'HARNESS_ENABLE_SABER_PLACEHOLDER' === 'true'
+      window.HARNESS_REDIRECT_FROM_INDEX = 'HARNESS_REDIRECT_FROM_INDEX_PLACEHOLDER' === 'true'
     </script>
     <% if (__DEV__) { %>
     <script>
@@ -90,9 +91,11 @@
           ? `${basePath}?action=signout&returnUrl=${encodeURIComponent(returnUrl)}`
           : `${basePath}?action=signout`
       }
-      var token = localStorage.getItem('token')
-      if (!token) {
-        window.location = getLoginPageURL({ returnUrl: window.location.href })
+      if (window.HARNESS_REDIRECT_FROM_INDEX) {
+        var token = localStorage.getItem('token')
+        if (!token) {
+          window.location = getLoginPageURL({ returnUrl: window.location.href })
+        }
       }
     </script>
 


### PR DESCRIPTION
##### Summary:

Some MFE chunks fail to load. In case user is logged-out (token doesn't exist), redirect to login via index.html to short-circuit before Chunk-load-error comes up.

##### Jira Links:

https://harness.atlassian.net/browse/PL-25457

##### Screenshots:

<!--- Add screenshots for your changes here -->

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
