### PR TITLE
feat: [SRM-10735]: making slack webhook url as optional

### DIFF
--- a/src/modules/15-notifications/modals/ConfigureNotificationsModal/views/ConfigureSlackNotifications/ConfigureSlackNotifications.tsx
+++ b/src/modules/15-notifications/modals/ConfigureNotificationsModal/views/ConfigureSlackNotifications/ConfigureSlackNotifications.tsx
@@ -131,11 +131,15 @@ const ConfigureSlackNotifications: React.FC<ConfigureSlackNotificationsProps> = 
           validationSchema={Yup.object().shape({
             webhookUrl: Yup.string().test('isValidUrl', getString('validation.urlIsNotValid'), _webhookUrl => {
               // TODO: Create global validation function for url validation
-              try {
-                const url = new URL(_webhookUrl)
-                return url.protocol === 'http:' || url.protocol === 'https:'
-              } catch (_) {
-                return false
+              if (_webhookUrl) {
+                try {
+                  const url = new URL(_webhookUrl)
+                  return url.protocol === 'http:' || url.protocol === 'https:'
+                } catch (_) {
+                  return false
+                }
+              } else {
+                return true
               }
             })
           })}


### PR DESCRIPTION
##### Summary:

<!--- Add summary of your changes here -->
1. Making slack webhook url as optional as mentioned in the Design.
##### Jira Links:

<!--- Add jira links for your changes here -->

##### Screenshots:

<!--- Add screenshots for your changes here -->

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
