### PR TITLE
feat: [CCM-7436]: Perspective Preferences

### DIFF
--- a/cypress/integration/75-ce/CreatePerspective.spec.ts
+++ b/cypress/integration/75-ce/CreatePerspective.spec.ts
@@ -110,6 +110,11 @@ describe('CCM Perspective Creation flow', () => {
     cy.contains('span', '+ create new Report schedule').should('exist')
     cy.contains('span', '+ create new Budget').should('exist')
 
+    cy.contains('span', 'Next').click()
+
+    cy.contains('p', 'Preferences').should('exist')
+    cy.get('input[type=checkbox]').should('not.be.checked')
+
     cy.contains('span', 'Save Perspective').click()
   })
 })

--- a/src/modules/75-ce/components/CloudCostInsightChart/Chart.tsx
+++ b/src/modules/75-ce/components/CloudCostInsightChart/Chart.tsx
@@ -5,7 +5,7 @@
  * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
  */
 
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import type { OptionsStackingValue } from 'highcharts'
 import moment from 'moment'
 import { Icon } from '@wings-software/uicore'
@@ -224,11 +224,26 @@ const GetChart: React.FC<GetChartProps> = ({
     return labels || []
   }
 
+  const chartData = useMemo(
+    () =>
+      chart.map(chartItem => {
+        switch (chartItem.name) {
+          case 'Others':
+            return { ...chartItem, color: 'var(--primary-2)' }
+          case 'Unallocated':
+            return { ...chartItem, color: 'var(--blue-100)' }
+          default:
+            return chartItem
+        }
+      }),
+    [chart]
+  )
+
   return (
     <article key={idx} onClick={redirection}>
       <CEChart
         options={{
-          series: chart as any,
+          series: chartData as any,
           chart: {
             zoomType: 'x',
             height: 300,

--- a/src/modules/75-ce/components/CloudCostInsightChart/ChartLegend.module.scss
+++ b/src/modules/75-ce/components/CloudCostInsightChart/ChartLegend.module.scss
@@ -11,6 +11,10 @@
   grid-column-gap: var(--spacing-large);
   grid-row-gap: var(--spacing-small);
 
+  &.preferences {
+    grid-template-columns: repeat(7, 1fr);
+  }
+
   .legendText {
     cursor: pointer;
   }

--- a/src/modules/75-ce/components/CloudCostInsightChart/ChartLegend.module.scss.d.ts
+++ b/src/modules/75-ce/components/CloudCostInsightChart/ChartLegend.module.scss.d.ts
@@ -11,5 +11,6 @@ declare const styles: {
   readonly colorBoxContainer: string
   readonly legendContainer: string
   readonly legendText: string
+  readonly preferences: string
 }
 export default styles

--- a/src/modules/75-ce/components/CloudCostInsightChart/ChartLegend.tsx
+++ b/src/modules/75-ce/components/CloudCostInsightChart/ChartLegend.tsx
@@ -8,6 +8,7 @@
 import React, { useEffect, useState } from 'react'
 import { Container, Layout, Text } from '@wings-software/uicore'
 import type Highcharts from 'highcharts'
+import cx from 'classnames'
 
 import css from './ChartLegend.module.scss'
 
@@ -66,7 +67,7 @@ const ChartLegend: React.FC<ChartLegendProps> = ({ chartRefObj }) => {
 
   return (
     <Container
-      className={css.legendContainer}
+      className={cx(css.legendContainer, { [css.preferences]: chartRefObj.series.length > 12 })}
       padding={{
         left: 'medium',
         top: 'small',

--- a/src/modules/75-ce/components/PerspectiveBuilder/PerspectiveBuilder.tsx
+++ b/src/modules/75-ce/components/PerspectiveBuilder/PerspectiveBuilder.tsx
@@ -179,6 +179,7 @@ const PerspectiveBuilder: React.FC<PerspectiveBuilderProps> = props => {
       ...values,
       viewState: 'DRAFT',
       viewType: 'CUSTOMER',
+      viewPreferences: perspectiveData?.viewPreferences,
       uuid: perspectiveId,
       folderId: selectedFolder?.uuid || ''
     }

--- a/src/modules/75-ce/components/PerspectiveBuilder/PerspectiveBuilder.tsx
+++ b/src/modules/75-ce/components/PerspectiveBuilder/PerspectiveBuilder.tsx
@@ -135,7 +135,12 @@ const FolderSelection: React.FC<FolderSelectionProps> = ({ selectedFolder, setSe
   )
 }
 
-const PerspectiveBuilder: React.FC<{ perspectiveData?: CEView; onNext: (resource: CEView) => void }> = props => {
+interface PerspectiveBuilderProps {
+  perspectiveData?: CEView
+  onNext: (resource: CEView, payload: CEView) => void
+}
+
+const PerspectiveBuilder: React.FC<PerspectiveBuilderProps> = props => {
   const { getString } = useStrings()
   const { perspectiveId, accountId } = useParams<{ perspectiveId: string; accountId: string }>()
   const history = useHistory()
@@ -199,7 +204,7 @@ const PerspectiveBuilder: React.FC<{ perspectiveData?: CEView; onNext: (resource
     try {
       const { data } = await createView(apiObject as CEView)
       if (data) {
-        props.onNext(data)
+        props.onNext(data, apiObject as CEView)
       }
     } catch (err: any) {
       const errMessage = err.data.message

--- a/src/modules/75-ce/components/PerspectiveBuilderPreview/PerspectiveBuilderPreview.tsx
+++ b/src/modules/75-ce/components/PerspectiveBuilderPreview/PerspectiveBuilderPreview.tsx
@@ -82,7 +82,11 @@ const PerspectiveBuilderPreview: React.FC<PerspectiveBuilderPreviewProps> = ({
           (formValues.viewVisualization?.granularity as QlceViewTimeGroupType) || QlceViewTimeGroupType.Day
         ),
         getGroupByFilter(groupBy)
-      ]
+      ],
+      preferences: {
+        includeOthers: false,
+        includeUnallocatedCost: false
+      }
     }
   })
 

--- a/src/modules/75-ce/components/PerspectiveExplorerGroupBy/PersepectiveExplorerGroupBy.module.scss
+++ b/src/modules/75-ce/components/PerspectiveExplorerGroupBy/PersepectiveExplorerGroupBy.module.scss
@@ -7,5 +7,9 @@
 
 .groupByContainer {
   display: grid;
-  grid-template-columns: 1fr 50px;
+  grid-template-columns: 1fr 180px 50px;
+
+  span[class*='bp3-popover-wrapper'] {
+    align-self: center;
+  }
 }

--- a/src/modules/75-ce/components/PerspectiveExplorerGroupBy/PerspectiveExplorerGroupBy.tsx
+++ b/src/modules/75-ce/components/PerspectiveExplorerGroupBy/PerspectiveExplorerGroupBy.tsx
@@ -61,6 +61,7 @@ interface PerspectiveExplorerGroupByProps {
   groupBy: QlceViewFieldInputInput
   setGroupBy: setGroupByFn
   timeFilter: QlceViewFilterWrapperInput[]
+  preferencesDropDown?: React.ReactNode
 }
 
 const PerspectiveExplorerGroupBy: React.FC<PerspectiveExplorerGroupByProps> = ({
@@ -68,7 +69,8 @@ const PerspectiveExplorerGroupBy: React.FC<PerspectiveExplorerGroupByProps> = ({
   setChartType,
   groupBy,
   setGroupBy,
-  timeFilter
+  timeFilter,
+  preferencesDropDown
 }) => {
   const { perspectiveId } = useParams<{ perspectiveId: string }>()
   const [drawerOpen, setDrawerOpen] = useState<boolean>(false)
@@ -119,6 +121,7 @@ const PerspectiveExplorerGroupBy: React.FC<PerspectiveExplorerGroupByProps> = ({
           setDrawerOpen(true)
         }}
       />
+      {preferencesDropDown}
       <ChartTypeSwitcher chartType={chartType} setChartType={setChartType} />
       <Drawer
         autoFocus

--- a/src/modules/75-ce/components/PerspectivePreferences/PerspectivePreferences.module.scss
+++ b/src/modules/75-ce/components/PerspectivePreferences/PerspectivePreferences.module.scss
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+.container {
+  height: calc(100vh - 124px);
+  display: flex;
+
+  .prefLabel {
+    font-weight: 500;
+    font-size: 12px;
+    color: var(--grey-1000) !important;
+    letter-spacing: 0.2px;
+    padding-top: var(--spacing-small);
+  }
+}

--- a/src/modules/75-ce/components/PerspectivePreferences/PerspectivePreferences.module.scss
+++ b/src/modules/75-ce/components/PerspectivePreferences/PerspectivePreferences.module.scss
@@ -9,11 +9,17 @@
   height: calc(100vh - 124px);
   display: flex;
 
-  .prefLabel {
-    font-weight: 500;
-    font-size: 12px;
-    color: var(--grey-1000) !important;
-    letter-spacing: 0.2px;
-    padding-top: var(--spacing-small);
+  .labelContainer {
+    display: flex;
+    align-items: center;
+    margin-bottom: var(--spacing-medium);
+
+    .prefLabel {
+      font-weight: 500;
+      font-size: 12px;
+      color: var(--grey-1000) !important;
+      letter-spacing: 0.2px;
+      width: fit-content;
+    }
   }
 }

--- a/src/modules/75-ce/components/PerspectivePreferences/PerspectivePreferences.module.scss.d.ts
+++ b/src/modules/75-ce/components/PerspectivePreferences/PerspectivePreferences.module.scss.d.ts
@@ -7,16 +7,7 @@
  **/
 // this is an auto-generated file, do not update this manually
 declare const styles: {
-  readonly chartGridContainer: string
-  readonly chartLoadingContainer: string
-  readonly emptyContainer: string
-  readonly emptyIllustrationContainer: string
-  readonly headerContent: string
-  readonly headerContentSection: string
+  readonly container: string
   readonly prefLabel: string
-  readonly preferenceMenu: string
-  readonly preferencesContainer: string
-  readonly preferencesPopover: string
-  readonly subscriptionLimitCtn: string
 }
 export default styles

--- a/src/modules/75-ce/components/PerspectivePreferences/PerspectivePreferences.module.scss.d.ts
+++ b/src/modules/75-ce/components/PerspectivePreferences/PerspectivePreferences.module.scss.d.ts
@@ -8,6 +8,7 @@
 // this is an auto-generated file, do not update this manually
 declare const styles: {
   readonly container: string
+  readonly labelContainer: string
   readonly prefLabel: string
 }
 export default styles

--- a/src/modules/75-ce/components/PerspectivePreferences/PerspectivePreferences.tsx
+++ b/src/modules/75-ce/components/PerspectivePreferences/PerspectivePreferences.tsx
@@ -10,6 +10,7 @@ import { Button, Container, Layout, Text } from '@harness/uicore'
 import { Switch } from '@blueprintjs/core'
 import { Color, FontVariation } from '@harness/design-system'
 import { useHistory, useParams } from 'react-router-dom'
+import { isEqual } from 'lodash-es'
 
 import { useStrings } from 'framework/strings'
 import { CEView, useUpdatePerspective, ViewPreferences } from 'services/ce'
@@ -47,10 +48,12 @@ const PerspectivePreferences: React.FC<PerspectivePreferencesProps> = ({
   })
 
   const savePerspective = async (): Promise<void> => {
-    await updatePerspective({
-      ...updatePayload,
-      viewPreferences: preferences
-    })
+    if (!isEqual(preferences, perspectiveData.viewPreferences)) {
+      await updatePerspective({
+        ...updatePayload,
+        viewPreferences: preferences
+      })
+    }
 
     trackEvent(USER_JOURNEY_EVENTS.SAVE_PERSPECTIVE, {
       include_others: preferences?.includeOthers,

--- a/src/modules/75-ce/components/PerspectivePreferences/PerspectivePreferences.tsx
+++ b/src/modules/75-ce/components/PerspectivePreferences/PerspectivePreferences.tsx
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import React, { useState } from 'react'
+import { Button, Container, Layout, Text } from '@harness/uicore'
+import { Switch } from '@blueprintjs/core'
+import { Color, FontVariation } from '@harness/design-system'
+import { useHistory, useParams } from 'react-router-dom'
+
+import { useStrings } from 'framework/strings'
+import { CEView, useUpdatePerspective, ViewPreferences } from 'services/ce'
+import routes from '@common/RouteDefinitions'
+import { useTelemetry } from '@common/hooks/useTelemetry'
+import { USER_JOURNEY_EVENTS } from '@ce/TrackingEventsConstants'
+
+import css from './PerspectivePreferences.module.scss'
+
+interface PerspectivePreferencesProps {
+  perspectiveData: CEView
+  onPrevButtonClick: () => void
+  updatePayload: CEView | null
+}
+
+const PerspectivePreferences: React.FC<PerspectivePreferencesProps> = ({
+  perspectiveData,
+  onPrevButtonClick,
+  updatePayload
+}) => {
+  const { getString } = useStrings()
+  const { trackEvent } = useTelemetry()
+  const history = useHistory()
+  const { perspectiveId, accountId } = useParams<{ perspectiveId: string; accountId: string }>()
+
+  const [preferences, setPreferences] = useState<ViewPreferences | undefined>(perspectiveData.viewPreferences)
+
+  const { mutate: updatePerspective } = useUpdatePerspective({
+    queryParams: {
+      accountIdentifier: accountId
+    }
+  })
+
+  const savePerspective = async (): Promise<void> => {
+    await updatePerspective({
+      ...updatePayload,
+      viewPreferences: preferences
+    })
+
+    trackEvent(USER_JOURNEY_EVENTS.SAVE_PERSPECTIVE, {})
+
+    history.push(
+      routes.toPerspectiveDetails({
+        accountId,
+        perspectiveId,
+        perspectiveName: perspectiveId
+      })
+    )
+  }
+
+  return (
+    <Container className={css.container}>
+      <Layout.Vertical
+        spacing="medium"
+        height="100%"
+        padding={{ left: 'large', right: 'xxlarge', bottom: 'xxlarge', top: 'xxlarge' }}
+      >
+        <Text font={{ variation: FontVariation.H4 }}>{getString('preferences')}</Text>
+        <Text
+          font={{ variation: FontVariation.H6 }}
+          padding={{ bottom: 'small' }}
+          border={{ bottom: true, color: Color.GREY_200 }}
+        >
+          {getString('preferences')}
+        </Text>
+        <Container height={'100%'} width={500}>
+          <Text color={Color.GREY_500} font={{ variation: FontVariation.SMALL }} margin={{ bottom: 'medium' }}>
+            You can change them later when vieweing perspectives
+          </Text>
+          <Switch
+            large
+            checked={preferences?.includeOthers}
+            label={'Include Others'}
+            className={css.prefLabel}
+            onChange={() => setPreferences(prevPref => ({ ...prevPref, includeOthers: !prevPref?.includeOthers }))}
+          />
+          <Switch
+            large
+            checked={preferences?.includeUnallocatedCost}
+            label={'Include Unallocated'}
+            className={css.prefLabel}
+            onChange={() =>
+              setPreferences(prevPref => ({ ...prevPref, includeUnallocatedCost: !prevPref?.includeUnallocatedCost }))
+            }
+          />
+        </Container>
+        <Layout.Horizontal padding={{ top: 'medium' }} spacing="large">
+          <Button
+            icon="chevron-left"
+            text={getString('ce.perspectives.createPerspective.prevButton')}
+            onClick={onPrevButtonClick}
+          />
+          <Button intent="primary" text={getString('ce.perspectives.save')} onClick={savePerspective} />
+        </Layout.Horizontal>
+      </Layout.Vertical>
+    </Container>
+  )
+}
+
+export default PerspectivePreferences

--- a/src/modules/75-ce/components/PerspectivePreferences/PerspectivePreferences.tsx
+++ b/src/modules/75-ce/components/PerspectivePreferences/PerspectivePreferences.tsx
@@ -37,6 +37,9 @@ const PerspectivePreferences: React.FC<PerspectivePreferencesProps> = ({
 
   const [preferences, setPreferences] = useState<ViewPreferences | undefined>(perspectiveData.viewPreferences)
 
+  const isClusterDatasource =
+    perspectiveData.dataSources?.length === 1 && perspectiveData.dataSources.includes('CLUSTER')
+
   const { mutate: updatePerspective } = useUpdatePerspective({
     queryParams: {
       accountIdentifier: accountId
@@ -77,19 +80,20 @@ const PerspectivePreferences: React.FC<PerspectivePreferencesProps> = ({
         </Text>
         <Container height={'100%'} width={500}>
           <Text color={Color.GREY_500} font={{ variation: FontVariation.SMALL }} margin={{ bottom: 'medium' }}>
-            You can change them later when vieweing perspectives
+            {getString('ce.perspectives.createPerspective.preferences.changeLater')}
           </Text>
           <Switch
             large
             checked={preferences?.includeOthers}
-            label={'Include Others'}
+            label={getString('ce.perspectives.createPerspective.preferences.includeOthers')}
             className={css.prefLabel}
             onChange={() => setPreferences(prevPref => ({ ...prevPref, includeOthers: !prevPref?.includeOthers }))}
           />
           <Switch
             large
             checked={preferences?.includeUnallocatedCost}
-            label={'Include Unallocated'}
+            label={getString('ce.perspectives.createPerspective.preferences.includeUnallocated')}
+            disabled={!isClusterDatasource}
             className={css.prefLabel}
             onChange={() =>
               setPreferences(prevPref => ({ ...prevPref, includeUnallocatedCost: !prevPref?.includeUnallocatedCost }))

--- a/src/modules/75-ce/components/PerspectivePreferences/PerspectivePreferences.tsx
+++ b/src/modules/75-ce/components/PerspectivePreferences/PerspectivePreferences.tsx
@@ -52,7 +52,10 @@ const PerspectivePreferences: React.FC<PerspectivePreferencesProps> = ({
       viewPreferences: preferences
     })
 
-    trackEvent(USER_JOURNEY_EVENTS.SAVE_PERSPECTIVE, {})
+    trackEvent(USER_JOURNEY_EVENTS.SAVE_PERSPECTIVE, {
+      include_others: preferences?.includeOthers,
+      include_unallocated: preferences?.includeUnallocatedCost
+    })
 
     history.push(
       routes.toPerspectiveDetails({
@@ -76,7 +79,7 @@ const PerspectivePreferences: React.FC<PerspectivePreferencesProps> = ({
           padding={{ bottom: 'small' }}
           border={{ bottom: true, color: Color.GREY_200 }}
         >
-          {getString('preferences')}
+          {getString('ce.perspectives.sideNavText')}
         </Text>
         <Container height={'100%'} width={500}>
           <Text color={Color.GREY_500} font={{ variation: FontVariation.SMALL }} margin={{ bottom: 'medium' }}>
@@ -89,16 +92,17 @@ const PerspectivePreferences: React.FC<PerspectivePreferencesProps> = ({
             className={css.prefLabel}
             onChange={() => setPreferences(prevPref => ({ ...prevPref, includeOthers: !prevPref?.includeOthers }))}
           />
-          <Switch
-            large
-            checked={preferences?.includeUnallocatedCost}
-            label={getString('ce.perspectives.createPerspective.preferences.includeUnallocated')}
-            disabled={!isClusterDatasource}
-            className={css.prefLabel}
-            onChange={() =>
-              setPreferences(prevPref => ({ ...prevPref, includeUnallocatedCost: !prevPref?.includeUnallocatedCost }))
-            }
-          />
+          {isClusterDatasource ? (
+            <Switch
+              large
+              checked={preferences?.includeUnallocatedCost}
+              label={getString('ce.perspectives.createPerspective.preferences.includeUnallocated')}
+              className={css.prefLabel}
+              onChange={() =>
+                setPreferences(prevPref => ({ ...prevPref, includeUnallocatedCost: !prevPref?.includeUnallocatedCost }))
+              }
+            />
+          ) : null}
         </Container>
         <Layout.Horizontal padding={{ top: 'medium' }} spacing="large">
           <Button

--- a/src/modules/75-ce/components/PerspectivePreferences/PerspectivePreferences.tsx
+++ b/src/modules/75-ce/components/PerspectivePreferences/PerspectivePreferences.tsx
@@ -91,20 +91,33 @@ const PerspectivePreferences: React.FC<PerspectivePreferencesProps> = ({
           <Switch
             large
             checked={preferences?.includeOthers}
-            label={getString('ce.perspectives.createPerspective.preferences.includeOthers')}
-            className={css.prefLabel}
+            labelElement={
+              <Text className={css.prefLabel} tooltipProps={{ dataTooltipId: 'includeOthers' }}>
+                {getString('ce.perspectives.createPerspective.preferences.includeOthers')}
+              </Text>
+            }
+            className={css.labelContainer}
             onChange={() => setPreferences(prevPref => ({ ...prevPref, includeOthers: !prevPref?.includeOthers }))}
           />
           {isClusterDatasource ? (
-            <Switch
-              large
-              checked={preferences?.includeUnallocatedCost}
-              label={getString('ce.perspectives.createPerspective.preferences.includeUnallocated')}
-              className={css.prefLabel}
-              onChange={() =>
-                setPreferences(prevPref => ({ ...prevPref, includeUnallocatedCost: !prevPref?.includeUnallocatedCost }))
-              }
-            />
+            <>
+              <Switch
+                large
+                checked={preferences?.includeUnallocatedCost}
+                labelElement={
+                  <Text className={css.prefLabel} tooltipProps={{ dataTooltipId: 'includeUnallocated' }}>
+                    {getString('ce.perspectives.createPerspective.preferences.includeUnallocated')}
+                  </Text>
+                }
+                className={css.labelContainer}
+                onChange={() =>
+                  setPreferences(prevPref => ({
+                    ...prevPref,
+                    includeUnallocatedCost: !prevPref?.includeUnallocatedCost
+                  }))
+                }
+              />
+            </>
           ) : null}
         </Container>
         <Layout.Horizontal padding={{ top: 'medium' }} spacing="large">

--- a/src/modules/75-ce/components/PerspectivePreferences/__test__/PerspectivePreferences.test.tsx
+++ b/src/modules/75-ce/components/PerspectivePreferences/__test__/PerspectivePreferences.test.tsx
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import React from 'react'
+import { fireEvent, getAllByText, getByLabelText, render } from '@testing-library/react'
+import { omit } from 'lodash-es'
+
+import { TestWrapper } from '@common/utils/testUtils'
+import type { CEView } from 'services/ce'
+
+import PerspectivePreferences from '../PerspectivePreferences'
+
+const perspectiveData = {
+  uuid: 'uuid_1',
+  name: 'viewPreferencesTest',
+  accountId: 'account_id',
+  folderId: 'folder_id',
+  viewVersion: 'v1',
+  viewTimeRange: {
+    viewTimeRangeType: 'LAST_7',
+    startTime: 0,
+    endTime: 0
+  },
+  viewRules: [
+    {
+      viewConditions: [
+        {
+          type: 'VIEW_ID_CONDITION',
+          viewField: {
+            fieldId: 'clusterType',
+            fieldName: 'Cluster Type',
+            identifier: 'CLUSTER',
+            identifierName: null
+          },
+          viewOperator: 'IN',
+          values: ['Mock Value']
+        }
+      ]
+    }
+  ],
+  dataSources: ['CLUSTER'],
+  viewPreferences: {
+    includeOthers: true,
+    includeUnallocatedCost: true
+  },
+  viewType: 'CUSTOMER',
+  viewState: 'COMPLETED',
+  totalCost: 0,
+  createdAt: 1654425970314,
+  lastUpdatedAt: 1654679887173
+}
+
+const payload = {
+  viewVersion: 'v1',
+  viewTimeRange: {
+    viewTimeRangeType: 'LAST_7'
+  },
+  viewType: 'CUSTOMER',
+  viewVisualization: {
+    groupBy: {
+      fieldId: 'product',
+      fieldName: 'Product',
+      identifier: 'COMMON',
+      identifierName: 'COMMON'
+    },
+    chartType: 'STACKED_LINE_CHART'
+  },
+  name: 'viewPreferencesTest',
+  viewRules: [
+    {
+      viewConditions: [
+        {
+          type: 'VIEW_ID_CONDITION',
+          viewField: {
+            fieldId: 'clusterType',
+            fieldName: 'Cluster Type',
+            identifier: 'CLUSTER',
+            identifierName: null
+          },
+          viewOperator: 'IN',
+          values: ['Mock Value']
+        }
+      ]
+    }
+  ],
+  viewState: 'DRAFT',
+  uuid: 'uuid_1',
+  folderId: 'folder_id'
+}
+
+jest.mock('services/ce', () => {
+  return {
+    useUpdatePerspective: jest.fn().mockImplementation(() => ({
+      mutate: async () => {
+        return {
+          status: 'SUCCESS',
+          data: {}
+        }
+      }
+    }))
+  }
+})
+
+const params = {
+  accountId: 'TEST_ACC',
+  perspetiveId: 'perspectiveId',
+  perspectiveName: 'sample perspective'
+}
+
+describe('Tests for PerspectivePreferences Component', () => {
+  test('Should be able to render PerspectivePreferences / Datasource - CLUSTER', () => {
+    const { container } = render(
+      <TestWrapper pathParams={params}>
+        <PerspectivePreferences
+          onPrevButtonClick={jest.fn()}
+          perspectiveData={perspectiveData as CEView}
+          updatePayload={payload as CEView}
+        />
+      </TestWrapper>
+    )
+
+    expect(getAllByText(container, 'preferences')).toBeDefined()
+    expect(getByLabelText(container, 'ce.perspectives.createPerspective.preferences.includeOthers')).toBeDefined()
+    expect(getByLabelText(container, 'ce.perspectives.createPerspective.preferences.includeUnallocated')).toBeDefined()
+  })
+
+  test('Should be able to render PerspectivePreferences / Datasource - [CLUSTER, AWS]', () => {
+    const { container } = render(
+      <TestWrapper pathParams={params}>
+        <PerspectivePreferences
+          onPrevButtonClick={jest.fn()}
+          perspectiveData={{ ...perspectiveData, dataSources: ['CLUSTER', 'AWS'] } as CEView}
+          updatePayload={payload as CEView}
+        />
+      </TestWrapper>
+    )
+
+    const includeUnallocatedCheckbox = container.querySelectorAll('input[type="checkbox"]')[1]
+    expect(includeUnallocatedCheckbox).toBeDisabled()
+  })
+
+  test('Should be able to set preferences', () => {
+    const { container } = render(
+      <TestWrapper pathParams={params}>
+        <PerspectivePreferences
+          onPrevButtonClick={jest.fn()}
+          perspectiveData={perspectiveData as CEView}
+          updatePayload={payload as CEView}
+        />
+      </TestWrapper>
+    )
+
+    const includeOthersCheckbox = container.querySelectorAll('input[type="checkbox"]')[0]
+    const includeUnallocatedCheckbox = container.querySelectorAll('input[type="checkbox"]')[1]
+
+    fireEvent.click(includeOthersCheckbox)
+    expect(includeOthersCheckbox).not.toBeChecked()
+
+    fireEvent.click(includeUnallocatedCheckbox)
+    expect(includeUnallocatedCheckbox).not.toBeChecked()
+  })
+
+  test('Should be able to render No Preferences / No Datasources', () => {
+    const noPreferenceData = omit(perspectiveData, 'viewPreferences')
+
+    const { container } = render(
+      <TestWrapper pathParams={params}>
+        <PerspectivePreferences
+          onPrevButtonClick={jest.fn()}
+          perspectiveData={{ ...noPreferenceData, dataSources: [] } as CEView}
+          updatePayload={payload as CEView}
+        />
+      </TestWrapper>
+    )
+
+    const includeOthersCheckbox = container.querySelectorAll('input[type="checkbox"]')[0]
+    const includeUnallocatedCheckbox = container.querySelectorAll('input[type="checkbox"]')[1]
+
+    expect(includeOthersCheckbox).not.toBeChecked()
+    expect(includeUnallocatedCheckbox).not.toBeChecked()
+  })
+})

--- a/src/modules/75-ce/components/PerspectivePreferences/__test__/PerspectivePreferences.test.tsx
+++ b/src/modules/75-ce/components/PerspectivePreferences/__test__/PerspectivePreferences.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react'
-import { fireEvent, getAllByText, getByLabelText, render } from '@testing-library/react'
+import { fireEvent, getByLabelText, getByText, render } from '@testing-library/react'
 import { omit } from 'lodash-es'
 
 import { TestWrapper } from '@common/utils/testUtils'
@@ -123,7 +123,7 @@ describe('Tests for PerspectivePreferences Component', () => {
       </TestWrapper>
     )
 
-    expect(getAllByText(container, 'preferences')).toBeDefined()
+    expect(getByText(container, 'preferences')).toBeDefined()
     expect(getByLabelText(container, 'ce.perspectives.createPerspective.preferences.includeOthers')).toBeDefined()
     expect(getByLabelText(container, 'ce.perspectives.createPerspective.preferences.includeUnallocated')).toBeDefined()
   })
@@ -139,8 +139,7 @@ describe('Tests for PerspectivePreferences Component', () => {
       </TestWrapper>
     )
 
-    const includeUnallocatedCheckbox = container.querySelectorAll('input[type="checkbox"]')[1]
-    expect(includeUnallocatedCheckbox).toBeDisabled()
+    expect(container.querySelectorAll('input[type="checkbox"]').length).toBe(1)
   })
 
   test('Should be able to set preferences', () => {
@@ -181,6 +180,6 @@ describe('Tests for PerspectivePreferences Component', () => {
     const includeUnallocatedCheckbox = container.querySelectorAll('input[type="checkbox"]')[1]
 
     expect(includeOthersCheckbox).not.toBeChecked()
-    expect(includeUnallocatedCheckbox).not.toBeChecked()
+    expect(includeUnallocatedCheckbox).toBeUndefined()
   })
 })

--- a/src/modules/75-ce/components/PerspectiveReportsAndBudget/PerspectiveReportsAndBudgets.tsx
+++ b/src/modules/75-ce/components/PerspectiveReportsAndBudget/PerspectiveReportsAndBudgets.tsx
@@ -8,7 +8,7 @@
 import React, { useState, useMemo, ReactNode, useEffect } from 'react'
 import cronstrue from 'cronstrue'
 import { isEmpty } from 'lodash-es'
-import { useHistory, useParams } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 import type { Column, CellProps, Renderer } from 'react-table'
 import {
   Button,
@@ -26,7 +26,6 @@ import {
 import { FontVariation, Color } from '@harness/design-system'
 import { Popover, Position, Classes, PopoverInteractionKind } from '@blueprintjs/core'
 import { DEFAULT_GROUP_BY } from '@ce/utils/perspectiveUtils'
-import routes from '@common/RouteDefinitions'
 import { QlceViewFieldInputInput, ViewChartType, AlertThreshold } from 'services/ce/services'
 import {
   CEView,
@@ -71,6 +70,7 @@ interface TableActionsProps {
 interface ReportsAndBudgetsProps {
   values?: CEView
   onPrevButtonClick: () => void
+  onNext: () => void
 }
 
 interface SelectedAlertType {
@@ -83,7 +83,7 @@ export interface UrlParams {
   accountId: string
 }
 
-const ReportsAndBudgets: React.FC<ReportsAndBudgetsProps> = ({ values, onPrevButtonClick }) => {
+const ReportsAndBudgets: React.FC<ReportsAndBudgetsProps> = ({ values, onPrevButtonClick, onNext }) => {
   const [groupBy, setGroupBy] = useState<QlceViewFieldInputInput>(() => {
     return (values?.viewVisualization?.groupBy as QlceViewFieldInputInput) || DEFAULT_GROUP_BY
   })
@@ -96,20 +96,7 @@ const ReportsAndBudgets: React.FC<ReportsAndBudgetsProps> = ({ values, onPrevBut
     return (values?.viewVisualization?.chartType as ViewChartType) || ViewChartType.StackedLineChart
   })
 
-  const history = useHistory()
-  const { trackEvent } = useTelemetry()
   const { getString } = useStrings()
-  const { perspectiveId, accountId } = useParams<UrlParams>()
-
-  const savePerspective = (): void => {
-    history.push(
-      routes.toPerspectiveDetails({
-        accountId,
-        perspectiveId,
-        perspectiveName: perspectiveId
-      })
-    )
-  }
 
   return (
     <Container className={css.mainContainer}>
@@ -131,14 +118,7 @@ const ReportsAndBudgets: React.FC<ReportsAndBudgetsProps> = ({ values, onPrevBut
           <FlexExpander />
           <Layout.Horizontal padding={{ top: 'medium' }} spacing="large">
             <Button icon="chevron-left" text={getString('previous')} onClick={onPrevButtonClick} />
-            <Button
-              intent="primary"
-              text={getString('ce.perspectives.save')}
-              onClick={() => {
-                trackEvent(USER_JOURNEY_EVENTS.SAVE_PERSPECTIVE, {})
-                savePerspective()
-              }}
-            />
+            <Button intent="primary" icon="chevron-right" text={getString('next')} onClick={onNext} />
           </Layout.Horizontal>
         </Layout.Vertical>
         {values && (

--- a/src/modules/75-ce/components/PerspectiveReportsAndBudget/__test__/PerspectiveReportsAndBudget.test.tsx
+++ b/src/modules/75-ce/components/PerspectiveReportsAndBudget/__test__/PerspectiveReportsAndBudget.test.tsx
@@ -164,7 +164,7 @@ describe('test cases for Perspective Reports and Budget page', () => {
     const handlePrevButtonClick = jest.fn().mockImplementationOnce(() => ({}))
     const { container } = render(
       <TestWrapper pathParams={params}>
-        <PerspectiveReportsAndBudgets onPrevButtonClick={handlePrevButtonClick} />
+        <PerspectiveReportsAndBudgets onPrevButtonClick={handlePrevButtonClick} onNext={jest.fn()} />
       </TestWrapper>
     )
     expect(container).toMatchSnapshot()

--- a/src/modules/75-ce/components/PerspectiveReportsAndBudget/__test__/__snapshots__/PerspectiveReportsAndBudget.test.tsx.snap
+++ b/src/modules/75-ce/components/PerspectiveReportsAndBudget/__test__/__snapshots__/PerspectiveReportsAndBudget.test.tsx.snap
@@ -2568,13 +2568,32 @@ exports[`test cases for Perspective Reports and Budget page should be able to re
             </span>
           </button>
           <button
-            class="bp3-button Button--button StyledProps--font StyledProps--main StyledProps--intent-primary Button--with-current-color"
+            class="bp3-button Button--button StyledProps--font StyledProps--main StyledProps--intent-primary Button--with-current-color Button--withLeftIcon"
             type="button"
           >
             <span
+              class="bp3-icon bp3-icon-chevron-right StyledProps--main StyledProps--padding-right-xsmall"
+              icon="chevron-right"
+            >
+              <svg
+                data-icon="chevron-right"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+              >
+                <desc>
+                  chevron-right
+                </desc>
+                <path
+                  d="M10.71 7.29l-4-4a1.003 1.003 0 00-1.42 1.42L8.59 8 5.3 11.29c-.19.18-.3.43-.3.71a1.003 1.003 0 001.71.71l4-4c.18-.18.29-.43.29-.71 0-.28-.11-.53-.29-.71z"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </span>
+            <span
               class="bp3-button-text"
             >
-              ce.perspectives.save
+              next
             </span>
           </button>
         </div>

--- a/src/modules/75-ce/pages/perspective-builder/CreatePerspectivePage.tsx
+++ b/src/modules/75-ce/pages/perspective-builder/CreatePerspectivePage.tsx
@@ -21,6 +21,7 @@ import {
 } from '@wings-software/uicore'
 import { Color } from '@harness/design-system'
 import { Breadcrumbs } from '@common/components/Breadcrumbs/Breadcrumbs'
+import { useStrings } from 'framework/strings'
 import routes from '@common/RouteDefinitions'
 import { useGetPerspective, CEView } from 'services/ce/'
 
@@ -56,7 +57,13 @@ const PerspectiveHeader: React.FC<{ title: string }> = ({ title }) => {
 }
 
 const CreatePerspectivePage: React.FC = () => {
-  const tabHeadings = ['1. Perspective Builder', '2. Reports and Budget', '3. Preferences']
+  const { getString } = useStrings()
+
+  const tabHeadings = [
+    getString('ce.perspectives.createPerspective.tabHeaders.perspectiveBuilder'),
+    getString('ce.perspectives.createPerspective.tabHeaders.reportsAndBudget'),
+    getString('ce.perspectives.createPerspective.tabHeaders.preferences')
+  ]
   const [selectedTabId, setSelectedTabId] = useState(tabHeadings[0])
 
   const [perspectiveData, setPerspectiveData] = useState<CEView | null>(null)

--- a/src/modules/75-ce/pages/perspective-builder/CreatePerspectivePage.tsx
+++ b/src/modules/75-ce/pages/perspective-builder/CreatePerspectivePage.tsx
@@ -19,10 +19,12 @@ import {
   PageBody,
   PageSpinner
 } from '@wings-software/uicore'
+import { Color } from '@harness/design-system'
 import { Breadcrumbs } from '@common/components/Breadcrumbs/Breadcrumbs'
 import routes from '@common/RouteDefinitions'
 import { useGetPerspective, CEView } from 'services/ce/'
 
+import PerspectivePreferences from '@ce/components/PerspectivePreferences/PerspectivePreferences'
 import PerspectiveBuilder from '../../components/PerspectiveBuilder'
 import ReportsAndBudgets from '../../components/PerspectiveReportsAndBudget/PerspectiveReportsAndBudgets'
 import css from './CreatePerspectivePage.module.scss'
@@ -54,10 +56,11 @@ const PerspectiveHeader: React.FC<{ title: string }> = ({ title }) => {
 }
 
 const CreatePerspectivePage: React.FC = () => {
-  const tabHeadings = ['1. Perspective Builder', '2. Reports and Budget']
+  const tabHeadings = ['1. Perspective Builder', '2. Reports and Budget', '3. Preferences']
   const [selectedTabId, setSelectedTabId] = useState(tabHeadings[0])
 
   const [perspectiveData, setPerspectiveData] = useState<CEView | null>(null)
+  const [updatePayload, setUpdatePayload] = useState<CEView | null>(null)
 
   const { perspectiveId, accountId } = useParams<{
     perspectiveId: string
@@ -124,9 +127,10 @@ const CreatePerspectivePage: React.FC = () => {
                 panel={
                   <PerspectiveBuilder
                     perspectiveData={perspectiveData}
-                    onNext={resource => {
+                    onNext={(resource, payload) => {
                       setSelectedTabId(tabHeadings[1])
                       setPerspectiveData(resource)
+                      setUpdatePayload(payload)
                     }}
                   />
                 }
@@ -167,9 +171,43 @@ const CreatePerspectivePage: React.FC = () => {
                       setSelectedTabId(tabHeadings[0])
                     }}
                     values={perspectiveData}
+                    onNext={() => {
+                      setSelectedTabId(tabHeadings[2])
+                    }}
                   />
                 }
                 data-testid={tabHeadings[1]}
+              />
+              <Icon
+                name="chevron-right"
+                height={20}
+                size={20}
+                margin={{ right: 'small', left: 'small' }}
+                color={Color.GREY_400}
+                style={{ alignSelf: 'center' }}
+              />
+              <Tab
+                disabled={selectedTabId !== tabHeadings[2]}
+                id={tabHeadings[2]}
+                panelClassName={css.panelClass}
+                title={
+                  <>
+                    <span data-tooltip-id="perspectivePreferences" className={css.tab}>
+                      {tabHeadings[2]}
+                    </span>
+                    <HarnessDocTooltip tooltipId="perspectivePreferences" useStandAlone={true} />
+                  </>
+                }
+                panel={
+                  <PerspectivePreferences
+                    perspectiveData={perspectiveData}
+                    onPrevButtonClick={() => {
+                      setSelectedTabId(tabHeadings[1])
+                    }}
+                    updatePayload={updatePayload}
+                  />
+                }
+                data-testid={tabHeadings[2]}
               />
             </Tabs>
           </div>

--- a/src/modules/75-ce/pages/perspective-details/PerspectiveDetailsPage.module.scss
+++ b/src/modules/75-ce/pages/perspective-details/PerspectiveDetailsPage.module.scss
@@ -44,3 +44,32 @@
   box-shadow: 0px 0px 1px rgba(40, 41, 61, 0.04), 0px 2px 4px rgba(96, 97, 112, 0.16);
   border-top: 1px solid var(--grey-100);
 }
+
+.preferencesPopover {
+  width: 100%;
+
+  .preferencesContainer {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    background: var(--primary-bg) !important;
+    border: 1px solid rgb(217, 218, 230);
+    border-radius: 4px;
+    height: 32px;
+    margin-right: var(--spacing-medium) !important ;
+    padding: 0 var(--spacing-small) 0 12px !important;
+  }
+}
+
+.preferenceMenu {
+  padding: var(--spacing-medium) !important;
+
+  .prefLabel {
+    font-weight: 500;
+    font-size: 12px;
+    color: var(--grey-1000) !important;
+    letter-spacing: 0.2px;
+    padding-top: var(--spacing-small);
+  }
+}

--- a/src/modules/75-ce/pages/perspective-details/PerspectiveDetailsPage.tsx
+++ b/src/modules/75-ce/pages/perspective-details/PerspectiveDetailsPage.tsx
@@ -52,7 +52,8 @@ import {
   highlightNode,
   resetNodeState,
   clusterInfoUtil,
-  getQueryFiltersFromPerspectiveResponse
+  getQueryFiltersFromPerspectiveResponse,
+  UnallocatedCostClusterFields
 } from '@ce/utils/perspectiveUtils'
 import { AGGREGATE_FUNCTION, getGridColumnsByGroupBy } from '@ce/components/PerspectiveGrid/Columns'
 import { getGMTStartDateTime, getGMTEndDateTime, DEFAULT_TIME_RANGE } from '@ce/utils/momentUtils'
@@ -470,7 +471,10 @@ const PerspectiveDetailsPage: React.FC = () => {
                 <PreferencesDropDown
                   preferences={preferences}
                   setPreferences={setPreferences}
-                  isClusterDatasource={isClusterDatasource}
+                  showIncludeUnallocatedCost={
+                    isClusterDatasource &&
+                    (Object.values(UnallocatedCostClusterFields) as string[]).includes(groupBy.fieldId)
+                  }
                 />
               }
             />
@@ -552,8 +556,8 @@ export default PerspectiveDetailsPage
 const PreferencesDropDown: React.FC<{
   preferences: QlceViewPreferencesInput
   setPreferences: React.Dispatch<React.SetStateAction<QlceViewPreferencesInput>>
-  isClusterDatasource: boolean
-}> = ({ preferences, setPreferences, isClusterDatasource }) => {
+  showIncludeUnallocatedCost: boolean
+}> = ({ preferences, setPreferences, showIncludeUnallocatedCost }) => {
   const { getString } = useStrings()
 
   return (
@@ -571,7 +575,7 @@ const PreferencesDropDown: React.FC<{
               setPreferences(prevPref => ({ ...prevPref, includeOthers: event.currentTarget.checked }))
             }}
           />
-          {isClusterDatasource ? (
+          {showIncludeUnallocatedCost ? (
             <Switch
               large
               checked={Boolean(preferences.includeUnallocatedCost)}

--- a/src/modules/75-ce/pages/perspective-details/PerspectiveDetailsPage.tsx
+++ b/src/modules/75-ce/pages/perspective-details/PerspectiveDetailsPage.tsx
@@ -571,16 +571,17 @@ const PreferencesDropDown: React.FC<{
               setPreferences(prevPref => ({ ...prevPref, includeOthers: event.currentTarget.checked }))
             }}
           />
-          <Switch
-            large
-            checked={Boolean(preferences.includeUnallocatedCost)}
-            label={getString('ce.perspectives.createPerspective.preferences.includeUnallocated')}
-            disabled={!isClusterDatasource}
-            className={css.prefLabel}
-            onChange={event => {
-              setPreferences(prevPref => ({ ...prevPref, includeUnallocatedCost: event.currentTarget.checked }))
-            }}
-          />
+          {isClusterDatasource ? (
+            <Switch
+              large
+              checked={Boolean(preferences.includeUnallocatedCost)}
+              label={getString('ce.perspectives.createPerspective.preferences.includeUnallocated')}
+              className={css.prefLabel}
+              onChange={event => {
+                setPreferences(prevPref => ({ ...prevPref, includeUnallocatedCost: event.currentTarget.checked }))
+              }}
+            />
+          ) : null}
         </Container>
       }
       minimal

--- a/src/modules/75-ce/pages/perspective-details/PerspectiveDetailsPage.tsx
+++ b/src/modules/75-ce/pages/perspective-details/PerspectiveDetailsPage.tsx
@@ -12,6 +12,7 @@ import qs from 'qs'
 import cx from 'classnames'
 import { Button, Container, Text, PageHeader, PageBody, Icon, useToaster } from '@wings-software/uicore'
 import { FontVariation, Color } from '@harness/design-system'
+import { Popover, Position, Switch } from '@blueprintjs/core'
 import routes from '@common/RouteDefinitions'
 import {
   PerspectiveAnomalyData,
@@ -32,7 +33,8 @@ import {
   ViewChartType,
   ViewType,
   QlceViewAggregateOperation,
-  useFetchPerspectiveTotalCountQuery
+  useFetchPerspectiveTotalCountQuery,
+  QlceViewPreferencesInput
 } from 'services/ce/services'
 import { useStrings } from 'framework/strings'
 import PerspectiveGrid from '@ce/components/PerspectiveGrid/PerspectiveGrid'
@@ -300,12 +302,26 @@ const PerspectiveDetailsPage: React.FC = () => {
     ],
     [perspectiveId, timeRange, filters]
   )
+  const [preferences, setPreferences] = useState<QlceViewPreferencesInput>({
+    includeOthers: false,
+    includeUnallocatedCost: false
+  })
+
+  useEffect(() => {
+    if (perspectiveData?.viewPreferences) {
+      setPreferences({
+        includeOthers: Boolean(perspectiveData?.viewPreferences?.includeOthers),
+        includeUnallocatedCost: Boolean(perspectiveData?.viewPreferences?.includeUnallocatedCost)
+      })
+    }
+  }, [perspectiveData])
 
   const [chartResult, executePerspectiveChartQuery] = useFetchPerspectiveTimeSeriesQuery({
     variables: {
       filters: queryFilters,
       limit: 12,
-      groupBy: [getTimeRangeFilter(aggregation), getGroupByFilter(groupBy)]
+      groupBy: [getTimeRangeFilter(aggregation), getGroupByFilter(groupBy)],
+      preferences
     }
   })
 
@@ -447,6 +463,7 @@ const PerspectiveDetailsPage: React.FC = () => {
               groupBy={groupBy}
               setGroupBy={setGroupBy}
               timeFilter={getTimeFilters(getGMTStartDateTime(timeRange.from), getGMTEndDateTime(timeRange.to))}
+              preferencesDropDown={<PreferencesDropDown preferences={preferences} setPreferences={setPreferences} />}
             />
             {!isChartGridEmpty && (
               <CloudCostInsightChart
@@ -522,3 +539,48 @@ const PerspectiveDetailsPage: React.FC = () => {
 }
 
 export default PerspectiveDetailsPage
+
+const PreferencesDropDown: React.FC<{
+  preferences: QlceViewPreferencesInput
+  setPreferences: React.Dispatch<React.SetStateAction<QlceViewPreferencesInput>>
+}> = ({ preferences, setPreferences }) => {
+  const { getString } = useStrings()
+
+  return (
+    <Popover
+      interactionKind="click"
+      targetClassName={css.preferencesPopover}
+      content={
+        <Container className={css.preferenceMenu}>
+          <Switch
+            large
+            checked={Boolean(preferences.includeOthers)}
+            label={'Include Others'}
+            className={css.prefLabel}
+            onChange={event => {
+              setPreferences(prevPref => ({ ...prevPref, includeOthers: event.currentTarget.checked }))
+            }}
+          />
+          <Switch
+            large
+            checked={Boolean(preferences.includeUnallocatedCost)}
+            label={'Include Unallocated'}
+            className={css.prefLabel}
+            onChange={event => {
+              setPreferences(prevPref => ({ ...prevPref, includeUnallocatedCost: event.currentTarget.checked }))
+            }}
+          />
+        </Container>
+      }
+      minimal
+      position={Position.BOTTOM}
+    >
+      <Container className={css.preferencesContainer}>
+        <Text color={Color.GREY_800} font={{ variation: FontVariation.SMALL_SEMI }}>
+          {getString('preferences')}
+        </Text>
+        <Icon name="chevron-down" />
+      </Container>
+    </Popover>
+  )
+}

--- a/src/modules/75-ce/pages/perspective-details/PerspectiveDetailsPage.tsx
+++ b/src/modules/75-ce/pages/perspective-details/PerspectiveDetailsPage.tsx
@@ -429,6 +429,9 @@ const PerspectiveDetailsPage: React.FC = () => {
   const { licenseInformation } = useLicenseStore()
   const isFreeEdition = licenseInformation['CE']?.edition === ModuleLicenseType.FREE
 
+  const isClusterDatasource =
+    perspectiveData?.dataSources?.length === 1 && perspectiveData?.dataSources.includes('CLUSTER')
+
   return (
     <>
       <PerspectiveHeader title={persName} viewType={perspectiveData?.viewType || ViewType.Default} />
@@ -463,7 +466,13 @@ const PerspectiveDetailsPage: React.FC = () => {
               groupBy={groupBy}
               setGroupBy={setGroupBy}
               timeFilter={getTimeFilters(getGMTStartDateTime(timeRange.from), getGMTEndDateTime(timeRange.to))}
-              preferencesDropDown={<PreferencesDropDown preferences={preferences} setPreferences={setPreferences} />}
+              preferencesDropDown={
+                <PreferencesDropDown
+                  preferences={preferences}
+                  setPreferences={setPreferences}
+                  isClusterDatasource={isClusterDatasource}
+                />
+              }
             />
             {!isChartGridEmpty && (
               <CloudCostInsightChart
@@ -543,7 +552,8 @@ export default PerspectiveDetailsPage
 const PreferencesDropDown: React.FC<{
   preferences: QlceViewPreferencesInput
   setPreferences: React.Dispatch<React.SetStateAction<QlceViewPreferencesInput>>
-}> = ({ preferences, setPreferences }) => {
+  isClusterDatasource: boolean
+}> = ({ preferences, setPreferences, isClusterDatasource }) => {
   const { getString } = useStrings()
 
   return (
@@ -555,7 +565,7 @@ const PreferencesDropDown: React.FC<{
           <Switch
             large
             checked={Boolean(preferences.includeOthers)}
-            label={'Include Others'}
+            label={getString('ce.perspectives.createPerspective.preferences.includeOthers')}
             className={css.prefLabel}
             onChange={event => {
               setPreferences(prevPref => ({ ...prevPref, includeOthers: event.currentTarget.checked }))
@@ -564,7 +574,8 @@ const PreferencesDropDown: React.FC<{
           <Switch
             large
             checked={Boolean(preferences.includeUnallocatedCost)}
-            label={'Include Unallocated'}
+            label={getString('ce.perspectives.createPerspective.preferences.includeUnallocated')}
+            disabled={!isClusterDatasource}
             className={css.prefLabel}
             onChange={event => {
               setPreferences(prevPref => ({ ...prevPref, includeUnallocatedCost: event.currentTarget.checked }))

--- a/src/modules/75-ce/pages/perspective-details/__test__/__snapshots__/PerspectiveDetailsPage.test.tsx.snap
+++ b/src/modules/75-ce/pages/perspective-details/__test__/__snapshots__/PerspectiveDetailsPage.test.tsx.snap
@@ -637,6 +637,42 @@ exports[`test cases for Perspective details Page should be able to render no dat
               </span>
             </div>
           </section>
+          <span
+            class="bp3-popover-wrapper"
+          >
+            <span
+              class="bp3-popover-target preferencesPopover"
+            >
+              <div
+                class="StyledProps--font StyledProps--main preferencesContainer"
+              >
+                <p
+                  class="StyledProps--font StyledProps--main StyledProps--color StyledProps--color-grey800 StyledProps--font-variation-small-semi"
+                >
+                  preferences
+                </p>
+                <span
+                  class="bp3-icon bp3-icon-chevron-down StyledProps--main"
+                  icon="chevron-down"
+                >
+                  <svg
+                    data-icon="chevron-down"
+                    height="16"
+                    viewBox="0 0 16 16"
+                    width="16"
+                  >
+                    <desc>
+                      chevron-down
+                    </desc>
+                    <path
+                      d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+              </div>
+            </span>
+          </span>
           <div
             class="Layout--horizontal Layout--layout-spacing-small StyledProps--main"
             style="align-items: center; justify-content: flex-end;"
@@ -1480,6 +1516,42 @@ exports[`test cases for Perspective details Page should be able to render the de
               </span>
             </div>
           </section>
+          <span
+            class="bp3-popover-wrapper"
+          >
+            <span
+              class="bp3-popover-target preferencesPopover"
+            >
+              <div
+                class="StyledProps--font StyledProps--main preferencesContainer"
+              >
+                <p
+                  class="StyledProps--font StyledProps--main StyledProps--color StyledProps--color-grey800 StyledProps--font-variation-small-semi"
+                >
+                  preferences
+                </p>
+                <span
+                  class="bp3-icon bp3-icon-chevron-down StyledProps--main"
+                  icon="chevron-down"
+                >
+                  <svg
+                    data-icon="chevron-down"
+                    height="16"
+                    viewBox="0 0 16 16"
+                    width="16"
+                  >
+                    <desc>
+                      chevron-down
+                    </desc>
+                    <path
+                      d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+              </div>
+            </span>
+          </span>
           <div
             class="Layout--horizontal Layout--layout-spacing-small StyledProps--main"
             style="align-items: center; justify-content: flex-end;"

--- a/src/modules/75-ce/strings/strings.en.yaml
+++ b/src/modules/75-ce/strings/strings.en.yaml
@@ -764,6 +764,10 @@ perspectives:
       opNull: 'NULL'
       opNotNull: 'NOT NULL'
       opLike: 'LIKE'
+    preferences:
+      changeLater: You can change them later when vieweing perspectives
+      includeOthers: Include Others
+      includeUnallocated: Include Unallocated
   reports:
     title: 'Report Schedules({{ count }})'
     desc: Reports can send a cost report to specified users at the specified frequency.

--- a/src/modules/75-ce/strings/strings.en.yaml
+++ b/src/modules/75-ce/strings/strings.en.yaml
@@ -730,6 +730,10 @@ perspectives:
     upgradeOffer: now for data retention upto 5 years.
   createPerspective:
     title: 'Perspective Builder'
+    tabHeaders:
+      perspectiveBuilder: '1. Perspective Builder'
+      reportsAndBudget: '2. Reports and Budget'
+      preferences: '3. Preferences'
     nameLabel: 'Enter a name for the view*'
     name: 'Perspective name'
     proTipText: 'Pro tip: Create custom fields for advanced filtering. Apart from the given fields, you can

--- a/src/modules/75-ce/utils/perspectiveUtils.ts
+++ b/src/modules/75-ce/utils/perspectiveUtils.ts
@@ -296,3 +296,11 @@ export const searchList = (searchVal: string, perspectiveList: any) => {
 
   return perspectiveList
 }
+
+export enum UnallocatedCostClusterFields {
+  NAMESPACE_FIELD_ID = 'namespace',
+  WORKLOAD_NAME_FIELD_ID = 'workloadName',
+  CLOUD_SERVICE_NAME_FIELD_ID = 'cloudServiceName',
+  TASK_FIELD_ID = 'taskId',
+  LAUNCH_TYPE_FIELD_ID = 'launchType'
+}

--- a/src/queries/ce/fetch_perspective_time_series.gql
+++ b/src/queries/ce/fetch_perspective_time_series.gql
@@ -7,12 +7,13 @@ query FetchPerspectiveTimeSeries(
   $filters: [QLCEViewFilterWrapperInput]
   $groupBy: [QLCEViewGroupByInput]
   $limit: Int
+  $preferences: QLCEViewPreferencesInput
 ) {
   perspectiveTimeSeriesStats(
     filters: $filters
     groupBy: $groupBy
     limit: $limit
-    preferences: { includeOthers: false, includeUnallocatedCost: false }
+    preferences: $preferences
     aggregateFunction: [{ operationType: SUM, columnName: "cost" }]
     sortCriteria: [{ sortType: COST, sortOrder: DESCENDING }]
   ) {

--- a/src/services/ce/services.ts
+++ b/src/services/ce/services.ts
@@ -722,12 +722,13 @@ export const FetchPerspectiveTimeSeriesDocument = gql`
     $filters: [QLCEViewFilterWrapperInput]
     $groupBy: [QLCEViewGroupByInput]
     $limit: Int
+    $preferences: QLCEViewPreferencesInput
   ) {
     perspectiveTimeSeriesStats(
       filters: $filters
       groupBy: $groupBy
       limit: $limit
-      preferences: { includeOthers: false, includeUnallocatedCost: false }
+      preferences: $preferences
       aggregateFunction: [{ operationType: SUM, columnName: "cost" }]
       sortCriteria: [{ sortType: COST, sortOrder: DESCENDING }]
     ) {
@@ -1814,6 +1815,7 @@ export type FetchPerspectiveTimeSeriesQueryVariables = Exact<{
   filters: InputMaybe<Array<InputMaybe<QlceViewFilterWrapperInput>> | InputMaybe<QlceViewFilterWrapperInput>>
   groupBy: InputMaybe<Array<InputMaybe<QlceViewGroupByInput>> | InputMaybe<QlceViewGroupByInput>>
   limit: InputMaybe<Scalars['Int']>
+  preferences: InputMaybe<QlceViewPreferencesInput>
 }>
 
 export type FetchPerspectiveTimeSeriesQuery = {

--- a/src/stringTypes.ts
+++ b/src/stringTypes.ts
@@ -4819,6 +4819,9 @@ export interface StringsMap {
   'ce.perspectives.createPerspective.preview.groupBy': string
   'ce.perspectives.createPerspective.preview.title': string
   'ce.perspectives.createPerspective.proTipText': string
+  'ce.perspectives.createPerspective.tabHeaders.perspectiveBuilder': string
+  'ce.perspectives.createPerspective.tabHeaders.preferences': string
+  'ce.perspectives.createPerspective.tabHeaders.reportsAndBudget': string
   'ce.perspectives.createPerspective.title': string
   'ce.perspectives.createPerspective.validationErrors.nameError': string
   'ce.perspectives.createPerspective.validationErrors.nameLengthError': string

--- a/src/stringTypes.ts
+++ b/src/stringTypes.ts
@@ -4812,6 +4812,9 @@ export interface StringsMap {
   'ce.perspectives.createPerspective.operatorLabels.opLike': string
   'ce.perspectives.createPerspective.operatorLabels.opNotNull': string
   'ce.perspectives.createPerspective.operatorLabels.opNull': string
+  'ce.perspectives.createPerspective.preferences.changeLater': string
+  'ce.perspectives.createPerspective.preferences.includeOthers': string
+  'ce.perspectives.createPerspective.preferences.includeUnallocated': string
   'ce.perspectives.createPerspective.prevButton': string
   'ce.perspectives.createPerspective.preview.groupBy': string
   'ce.perspectives.createPerspective.preview.title': string


### PR DESCRIPTION
##### Summary:

Allow users to set perspective preferences in create perspective flow and perspective time series chart.

##### Jira Links:

https://harness.atlassian.net/browse/CCM-7436

##### Screenshots:

<img width="1396" alt="Screenshot 2022-06-22 at 11 59 24 AM" src="https://user-images.githubusercontent.com/97532027/174958982-7f2406be-8552-42a0-aac7-f6722d6e5a7c.png">

<img width="1680" alt="Screenshot 2022-06-22 at 12 00 05 PM" src="https://user-images.githubusercontent.com/97532027/174958962-b001714e-fede-490e-8644-264fd2a9b2ac.png">

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
