### PR TITLE
feat: [SRM-10723]: add microfrontend components for Error Tracking

### DIFF
--- a/src/modules/10-common/RouteDefinitions.ts
+++ b/src/modules/10-common/RouteDefinitions.ts
@@ -1302,11 +1302,6 @@ const routes = {
       return `/${module}/orgs/${orgIdentifier}/projects/${projectIdentifier}/et`
     }
   ),
-  toErrorTrackingArc: withAccountId(
-    ({ orgIdentifier, projectIdentifier, module = 'cv' }: Partial<ProjectPathProps & { module?: string }>) => {
-      return `/${module}/orgs/${orgIdentifier}/projects/${projectIdentifier}/et/arc`
-    }
-  ),
   toCVCreateSLOs: withAccountId(
     ({ orgIdentifier, projectIdentifier, module = 'cv' }: Partial<ProjectPathProps & { module?: string }>) => {
       return `/${module}/orgs/${orgIdentifier}/projects/${projectIdentifier}/slos/create`

--- a/src/modules/85-cv/ErrorTrackingApp.tsx
+++ b/src/modules/85-cv/ErrorTrackingApp.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import React from 'react'
+
+// eslint-disable-next-line import/no-unresolved
+export const ErrorTracking = React.lazy(() => import('errortracking/App'))
+
+export interface ErrorTrackingLocation {
+  pathname: string
+}
+
+interface ChildAppProps {
+  componentLocation: ErrorTrackingLocation
+}
+
+export interface EventListProps extends ChildAppProps {
+  orgId: string
+  accountId: string
+  projectId: string
+  serviceId: string
+  environmentId: string
+  versionId?: string
+  fromDateTime: number
+  toDateTime: number
+  routeDefinitions: Record<string, unknown>
+}

--- a/src/modules/85-cv/ErrorTrackingApp.tsx
+++ b/src/modules/85-cv/ErrorTrackingApp.tsx
@@ -7,17 +7,21 @@
 
 import React from 'react'
 
+/* istanbul ignore next */
 // eslint-disable-next-line import/no-unresolved
 export const ErrorTracking = React.lazy(() => import('errortracking/App'))
 
+/* istanbul ignore next */
 export interface ErrorTrackingLocation {
   pathname: string
 }
 
+/* istanbul ignore next */
 interface ChildAppProps {
   componentLocation: ErrorTrackingLocation
 }
 
+/* istanbul ignore next */
 export interface EventListProps extends ChildAppProps {
   orgId: string
   accountId: string

--- a/src/modules/85-cv/RouteDestinations.tsx
+++ b/src/modules/85-cv/RouteDestinations.tsx
@@ -42,6 +42,7 @@ import CVSLOsListingPage from './pages/slos/CVSLOsListingPage'
 import CVSLODetailsPage from './pages/slos/CVSLODetailsPage/CVSLODetailsPage'
 import CVCreateSLO from './pages/slos/components/CVCreateSLO/CVCreateSLO'
 import ChildAppMounter from '../../microfrontends/ChildAppMounter'
+import { ErrorTracking } from './ErrorTrackingApp'
 
 PubSubPipelineActions.subscribe(
   PipelineActions.RunPipeline,
@@ -93,9 +94,6 @@ const CVSideNavProps: SidebarContext = {
   icon: 'cv-main'
 }
 
-// eslint-disable-next-line import/no-unresolved
-const ErrorTracking = React.lazy(() => import('errortracking/App'))
-
 export default (
   <>
     <Route
@@ -141,16 +139,8 @@ export default (
     </RouteWithLayout>
 
     <RouteWithLayout
-      exact
       sidebarProps={CVSideNavProps}
       path={routes.toErrorTracking({ ...accountPathProps, ...projectPathProps, ...cvModuleParams })}
-    >
-      <ChildAppMounter ChildApp={ErrorTracking} />
-    </RouteWithLayout>
-
-    <RouteWithLayout
-      sidebarProps={CVSideNavProps}
-      path={routes.toErrorTrackingArc({ ...accountPathProps, ...projectPathProps, ...cvModuleParams })}
     >
       <ChildAppMounter ChildApp={ErrorTracking} />
     </RouteWithLayout>

--- a/src/modules/85-cv/components/LogsAnalysis/components/LogAnalysisRow/LogAnalysisRow.utils.ts
+++ b/src/modules/85-cv/components/LogsAnalysis/components/LogAnalysisRow/LogAnalysisRow.utils.ts
@@ -60,13 +60,13 @@ export const onClickErrorTrackingRow = (
           ,"timestamp":"${timestamp}"
         }`
 
-  const arcUrl = routes.toErrorTrackingArc({
+  const errorTrackingBaseUrl = routes.toErrorTracking({
     orgIdentifier: orgIdentifier,
     projectIdentifier: projectIdentifier,
     accountId: accountId
   })
   const baseUrl = window.location.href.split('#')[0]
-  window.open(`${baseUrl}#${arcUrl}/arc?event=${btoa(arcJson)}`)
+  window.open(`${baseUrl}#${errorTrackingBaseUrl}/arc?event=${btoa(arcJson)}`)
 }
 
 export const isNoLogSelected = (selectedLog?: string | null): boolean =>

--- a/src/modules/85-cv/components/LogsAnalysis/components/LogAnalysisRow/__tests__/LogAnalysisRow.utils.test.ts
+++ b/src/modules/85-cv/components/LogsAnalysis/components/LogAnalysisRow/__tests__/LogAnalysisRow.utils.test.ts
@@ -17,7 +17,7 @@ describe('Unit tests for LogAnalysisRow utils', () => {
     const projectIdentifier = 'def'
     const orgIdentifier = 'ghi'
     onClickErrorTrackingRow(errorRow, accountId, projectIdentifier, orgIdentifier)
-    const url = `http://localhost/#/account/${accountId}/cv/orgs/${orgIdentifier}/projects/${projectIdentifier}/et/arc/arc?event=ewogICAgICAgICAgInNlcnZpY2VfaWQiOiAiUzEiLAogICAgICAgICAgInZpZXdwb3J0X3N0cmluZ3MiOnsKICAgICAgICAgICAgImZyb21fdGltZXN0YW1wIjoiMTY0Njc0NzM5NiIsCiAgICAgICAgICAgICJ0b190aW1lc3RhbXAiOiIxNjQ2NzUwOTk2IiwKICAgICAgICAgICAgInVudGlsX25vdyI6ZmFsc2UsCiAgICAgICAgICAgICJtYWNoaW5lX2hhc2hlcyI6W10sCiAgICAgICAgICAgICJhZ2VudF9oYXNoZXMiOltdLAogICAgICAgICAgICAiZGVwbG95bWVudF9oYXNoZXMiOltdLAogICAgICAgICAgICAicmVxdWVzdF9pZHMiOls2XQogICAgICAgICAgfQogICAgICAgICAgLCJ0aW1lc3RhbXAiOiIxNjQ2NzUwOTk2IgogICAgICAgIH0=`
+    const url = `http://localhost/#/account/${accountId}/cv/orgs/${orgIdentifier}/projects/${projectIdentifier}/et/arc?event=ewogICAgICAgICAgInNlcnZpY2VfaWQiOiAiUzEiLAogICAgICAgICAgInZpZXdwb3J0X3N0cmluZ3MiOnsKICAgICAgICAgICAgImZyb21fdGltZXN0YW1wIjoiMTY0Njc0NzM5NiIsCiAgICAgICAgICAgICJ0b190aW1lc3RhbXAiOiIxNjQ2NzUwOTk2IiwKICAgICAgICAgICAgInVudGlsX25vdyI6ZmFsc2UsCiAgICAgICAgICAgICJtYWNoaW5lX2hhc2hlcyI6W10sCiAgICAgICAgICAgICJhZ2VudF9oYXNoZXMiOltdLAogICAgICAgICAgICAiZGVwbG95bWVudF9oYXNoZXMiOltdLAogICAgICAgICAgICAicmVxdWVzdF9pZHMiOls2XQogICAgICAgICAgfQogICAgICAgICAgLCJ0aW1lc3RhbXAiOiIxNjQ2NzUwOTk2IgogICAgICAgIH0=`
     expect(window.open).toHaveBeenCalled()
     expect(window.open).toHaveBeenCalledWith(url)
   })

--- a/src/modules/85-cv/pages/monitored-service/components/ServiceHealth/components/ErrorTracking/ErrorTracking.module.scss
+++ b/src/modules/85-cv/pages/monitored-service/components/ServiceHealth/components/ErrorTracking/ErrorTracking.module.scss
@@ -5,15 +5,6 @@
  * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
  */
 
-.metricsAndLogsCard {
-  display: flex;
-  flex-direction: column;
-  width: 50%;
-  height: 850px;
-  max-height: 850px;
-  overflow-y: auto;
-}
-
 .noServiceImageCard {
   width: 100%;
 

--- a/src/modules/85-cv/pages/monitored-service/components/ServiceHealth/components/ErrorTracking/ErrorTracking.module.scss.d.ts
+++ b/src/modules/85-cv/pages/monitored-service/components/ServiceHealth/components/ErrorTracking/ErrorTracking.module.scss.d.ts
@@ -7,7 +7,6 @@
  **/
 // this is an auto-generated file, do not update this manually
 declare const styles: {
-  readonly metricsAndLogsCard: string
   readonly noDataCard: string
   readonly noDataCardContainer: string
   readonly noServiceImage: string

--- a/src/modules/85-cv/pages/monitored-service/components/ServiceHealth/components/ErrorTracking/ErrorTracking.tsx
+++ b/src/modules/85-cv/pages/monitored-service/components/ServiceHealth/components/ErrorTracking/ErrorTracking.tsx
@@ -6,31 +6,45 @@
  */
 
 import React from 'react'
-import { Container, Layout, Heading, Card, NoDataCard } from '@wings-software/uicore'
+import { Container, Heading, Card, NoDataCard } from '@wings-software/uicore'
 import { FontVariation } from '@harness/design-system'
+import { useParams } from 'react-router-dom'
 import noServiceAvailableImage from '@cv/assets/noServiceAvailable.png'
 import { useStrings } from 'framework/strings'
-import ErrorTrackingAnalysis from '@cv/components/ErrorTrackingAnalysis/ErrorTrackingAnalysis'
+import type { ProjectPathProps } from '@common/interfaces/RouteInterfaces'
+import { ErrorTracking as EventList, EventListProps } from '@cv/ErrorTrackingApp'
+import ChildAppMounter from 'microfrontends/ChildAppMounter'
+import routes from '@common/RouteDefinitions'
 import type { MetricsAndLogsProps } from '../MetricsAndLogs/MetricsAndLogs.types'
 import css from './ErrorTracking.module.scss'
 
 const ErrorTracking: React.FC<MetricsAndLogsProps> = props => {
   const { getString } = useStrings()
-
+  const { accountId, projectIdentifier, orgIdentifier } = useParams<ProjectPathProps>()
   const { startTime, endTime } = props
+
+  const componentLocation = {
+    pathname: '/events'
+  }
 
   return (
     <Container margin={{ bottom: 'medium' }}>
       <Heading level={2} font={{ variation: FontVariation.H6 }} padding={{ bottom: 'small' }}>
         {getString('errors')}
       </Heading>
-
       {startTime && endTime ? (
-        <Layout.Horizontal data-testid="error-tracking-analysis-view" spacing="medium">
-          <Card className={css.metricsAndLogsCard}>
-            <ErrorTrackingAnalysis {...props} startTime={startTime} endTime={endTime} />
-          </Card>
-        </Layout.Horizontal>
+        <ChildAppMounter<EventListProps>
+          ChildApp={EventList}
+          componentLocation={componentLocation}
+          orgId={orgIdentifier}
+          accountId={accountId}
+          projectId={projectIdentifier}
+          serviceId={props.serviceIdentifier}
+          environmentId={props.environmentIdentifier}
+          fromDateTime={Math.floor(startTime / 1000)}
+          toDateTime={Math.floor(endTime / 1000)}
+          routeDefinitions={routes}
+        />
       ) : (
         <Card className={css.noServiceImageCard} data-testid="error-tracking-analysis-image-view">
           <NoDataCard

--- a/src/modules/85-cv/pages/monitored-service/components/ServiceHealth/components/ErrorTracking/__tests__/ErrorTracking.test.tsx
+++ b/src/modules/85-cv/pages/monitored-service/components/ServiceHealth/components/ErrorTracking/__tests__/ErrorTracking.test.tsx
@@ -40,19 +40,24 @@ jest.mock('services/cv', () => ({
   })
 }))
 
-describe('Unit tests for ErrorTracking', () => {
-  test('Verify if Error Tracking View is rendered when required params are defined', async () => {
-    const props = {
-      monitoredServiceIdentifier: 'monitored_service_identifier',
-      serviceIdentifier: 'service-identifier',
-      environmentIdentifier: 'env-identifier',
-      startTime: 1630594988077,
-      endTime: 1630595011443
-    }
-    const { getByTestId } = render(<WrapperComponent {...props} />)
-    expect(getByTestId('error-tracking-analysis-view')).toBeTruthy()
-  })
+// eslint-disable-next-line react/display-name
+jest.mock('microfrontends/ChildAppMounter', () => () => {
+  return <div data-testid="error-tracking-child-mounter">mounted</div>
+})
 
+test('Verify if Error Tracking View is rendered when required params are defined', async () => {
+  const props = {
+    monitoredServiceIdentifier: 'monitored_service_identifier',
+    serviceIdentifier: 'service-identifier',
+    environmentIdentifier: 'env-identifier',
+    startTime: 1630594988077,
+    endTime: 1630595011443
+  }
+  const { getByTestId } = render(<WrapperComponent {...props} />)
+  expect(getByTestId('error-tracking-child-mounter')).toBeTruthy()
+})
+
+describe('Unit tests for ErrorTracking', () => {
   test('Verify if appropriate image is rendered when start or endtime is not present', async () => {
     const props = {
       monitoredServiceIdentifier: 'monitored_service_identifier',


### PR DESCRIPTION
##### Summary:

Use Error Tracking microfrontend component the ET Event List

##### Jira Links:

https://harness.atlassian.net/browse/SRM-10723

##### Screenshots:

The full Error List in Monitored Services has been replaced with the ET microfrontend component
![Screen Shot 2022-06-08 at 8 39 31 PM](https://user-images.githubusercontent.com/2991478/172740322-d3118c41-cb01-4ef4-8be6-e17b3f202103.png)

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
