### PR TITLE
feat: [PL-23301]: use BrowserRouter instead of HashRouter

### DIFF
--- a/configs/webpack.dev.js
+++ b/configs/webpack.dev.js
@@ -46,6 +46,7 @@ const config = {
     filename: '[name].js',
     chunkFilename: '[name].[id].js',
     pathinfo: false,
+    publicPath: '/',
     assetModuleFilename: 'images/[hash:7][ext][query]'
   },
   devServer: isCI

--- a/src/framework/app/App.tsx
+++ b/src/framework/app/App.tsx
@@ -255,6 +255,14 @@ export function AppWithAuthentication(props: AppProps): React.ReactElement {
 }
 
 export function AppWithoutAuthentication(props: AppProps): React.ReactElement {
+  const { pathname, hash } = window.location
+
+  // Redirect from `/#/account/...` to `/account/...`
+  if (hash && (pathname === '/' || pathname === '/ng')) {
+    const targetUrl = window.location.href.replace('/#/', '/')
+    window.location.href = targetUrl
+  }
+
   return (
     <RestfulProvider base="/">
       <StringsContextProvider initialStrings={props.strings}>

--- a/src/framework/app/bootstrap.tsx
+++ b/src/framework/app/bootstrap.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { HashRouter, Route, Switch } from 'react-router-dom'
+import { Route, Switch, BrowserRouter } from 'react-router-dom'
 
 import languageLoader from 'strings/languageLoader'
 import type { LangLocale } from 'strings/languageLoader'
@@ -36,7 +36,7 @@ export default async function render(): Promise<void> {
   }
 
   ReactDOM.render(
-    <HashRouter>
+    <BrowserRouter>
       <Switch>
         <Route
           path={[
@@ -53,7 +53,7 @@ export default async function render(): Promise<void> {
           <AppWithoutAuthentication strings={strings} />
         </Route>
       </Switch>
-    </HashRouter>,
+    </BrowserRouter>,
     document.getElementById('react-root')
   )
 }

--- a/src/index.html
+++ b/src/index.html
@@ -31,7 +31,7 @@
     <!-- apiurl -->
     <script type="text/javascript">
       window.getApiBaseUrl = str => {
-        return window.apiUrl ? `${window.apiUrl}/${str}` : window.location.pathname.replace('ng/', '') + str
+        return `${window.apiUrl || ''}/${str}`
       }
     </script>
     <!-- segmentToken -->

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -10,7 +10,7 @@ import { mapKeys } from 'lodash-es'
 import qs from 'qs'
 
 export const getConfig = (str: string): string => {
-  return window.apiUrl ? `${window.apiUrl}/${str}` : window.location.pathname.replace('ng/', '') + str
+  return `${window.apiUrl || ''}/${str}`
 }
 export interface GetUsingFetchProps<
   _TData = any,


### PR DESCRIPTION
##### Summary:

Changes URLs from `/#/account/...` to `/account/...`

##### Jira Links:

https://harness.atlassian.net/browse/PL-23301

##### Screenshots:

<img width="556" alt="Screenshot 2022-06-08 at 3 09 23 PM" src="https://user-images.githubusercontent.com/47316575/172725968-302bcf61-65d9-4f0e-9887-f7368747a044.png">

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
