### PR TITLE
fix: [PL-25539]: Hotfix: update hashes of files in 'images' directory

### DIFF
--- a/configs/webpack.dev.js
+++ b/configs/webpack.dev.js
@@ -46,7 +46,7 @@ const config = {
     filename: '[name].js',
     chunkFilename: '[name].[id].js',
     pathinfo: false,
-    assetModuleFilename: 'images/[hash:6][ext][query]'
+    assetModuleFilename: 'images/[hash:7][ext][query]'
   },
   devServer: isCI
     ? undefined

--- a/configs/webpack.prod.js
+++ b/configs/webpack.prod.js
@@ -52,7 +52,7 @@ const config = {
     filename: '[name].[contenthash:6].js',
     chunkFilename: '[name].[id].[contenthash:6].js',
     pathinfo: false,
-    assetModuleFilename: 'images/[hash:6][ext][query]'
+    assetModuleFilename: 'images/[hash:7][ext][query]'
   },
   plugins: [
     new webpack.DefinePlugin({

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nextgenui",
   "description": "Harness Inc",
-  "version": "0.302.8",
+  "version": "0.302.9",
   "author": "Harness Inc",
   "license": "Harness Inc",
   "homepage": "http://app.harness.io/",


### PR DESCRIPTION
##### Summary:

Update: Since we didn't get reviews in time and had to provide sign-off to QA—this hotfix is deferred. It will go-live in the next release.

Hotfix for: https://github.com/harness/harness-core-ui/pull/9298

Update hashes of files in 'images' directory. Needed as a last resort for CDN-Cache invalidation. Further details on JIRA: https://harness.atlassian.net/browse/PL-25539

##### Jira Links:

https://harness.atlassian.net/browse/PL-25539

##### Screenshots:

<!--- Add screenshots for your changes here -->

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
