### PR TITLE
fix: [FFM-2487]: Moving the gitsync toolbar from top of Target details page to above flag details.

### DIFF
--- a/src/modules/75-cf/components/TargetManagementDetailPageTemplate/TargetManagementDetailPageTemplate.tsx
+++ b/src/modules/75-cf/components/TargetManagementDetailPageTemplate/TargetManagementDetailPageTemplate.tsx
@@ -19,7 +19,6 @@ import useActiveEnvironment from '@cf/hooks/useActiveEnvironment'
 import { useDocumentTitle } from '@common/hooks/useDocumentTitle'
 import { useFFGitSyncContext } from '@cf/contexts/ff-git-sync-context/FFGitSyncContext'
 import { DetailPageTemplate, DetailPageTemplateProps } from '../DetailPageTemplate/DetailPageTemplate'
-import TargetManagementToolbar from '../TargetManagementToolbar/TargetManagementToolbar'
 
 import css from './TargetManagementDetailPageTemplate.module.scss'
 
@@ -113,8 +112,6 @@ const TargetManagementDetailPageTemplate: FC<TargetManagementDetailPageTemplateP
       {...detailPageTemplateProps}
     >
       <div className={cx(css.layout, ...modifiers)}>
-        {isGitSyncActionsEnabled ? <TargetManagementToolbar /> : <div />}
-
         <div className={css.contentLayout}>
           <div className={css.leftBar}>{leftBar}</div>
           <div className={css.mainContent}>{children}</div>

--- a/src/modules/75-cf/components/TargetManagementDetailPageTemplate/__tests__/TargetManagementDetailPageTemplate.test.tsx
+++ b/src/modules/75-cf/components/TargetManagementDetailPageTemplate/__tests__/TargetManagementDetailPageTemplate.test.tsx
@@ -12,9 +12,7 @@ import userEvent from '@testing-library/user-event'
 import { merge } from 'lodash-es'
 import { TestWrapper } from '@common/utils/testUtils'
 import type { Segment, Target } from 'services/cf'
-import * as gitSync from '@cf/hooks/useGitSync'
 import * as useDocumentTitle from '@common/hooks/useDocumentTitle'
-import { FFGitSyncProvider } from '@cf/contexts/ff-git-sync-context/FFGitSyncContext'
 import TargetManagementDetailPageTemplate, {
   TargetManagementDetailPageTemplateProps
 } from '../TargetManagementDetailPageTemplate'
@@ -47,24 +45,15 @@ const renderComponent = (
 ): RenderResult =>
   render(
     <TestWrapper>
-      <FFGitSyncProvider>
-        <TargetManagementDetailPageTemplate
-          item={mockTarget}
-          openDeleteDialog={jest.fn()}
-          leftBar={<div />}
-          {...props}
-        />
-      </FFGitSyncProvider>
+      <TargetManagementDetailPageTemplate item={mockTarget} openDeleteDialog={jest.fn()} leftBar={<div />} {...props} />
     </TestWrapper>
   )
 
 describe('TargetManagementDetailPageTemplate', () => {
-  const useGitSyncMock = jest.spyOn(gitSync, 'useGitSync')
   const useDocumentTitleMock = jest.spyOn(useDocumentTitle, 'useDocumentTitle')
 
   beforeEach(() => {
     jest.clearAllMocks()
-    useGitSyncMock.mockReturnValue({ isGitSyncActionsEnabled: false } as any)
   })
 
   test('it should display the item name, identifier and created date', async () => {
@@ -112,22 +101,6 @@ describe('TargetManagementDetailPageTemplate', () => {
     renderComponent({ children: <div data-testid={testId}>Main content</div> })
 
     expect(screen.getByTestId(testId)).toBeInTheDocument()
-  })
-
-  describe('gitSync', () => {
-    test('it should not display the Target Management Toolbar when gitSync is disabled', async () => {
-      renderComponent()
-
-      expect(screen.queryByTestId('target-management-toolbar')).not.toBeInTheDocument()
-    })
-
-    test('it should display the Target Management Toolbar when gitSync is enabled', async () => {
-      useGitSyncMock.mockReturnValue({ isGitSyncActionsEnabled: true } as any)
-
-      renderComponent()
-
-      expect(screen.getByTestId('target-management-toolbar')).toBeInTheDocument()
-    })
   })
 
   describe('Target', () => {

--- a/src/modules/75-cf/components/TargetManagementFlagConfigurationPanel/TargetManagementFlagConfigurationPanel.module.scss
+++ b/src/modules/75-cf/components/TargetManagementFlagConfigurationPanel/TargetManagementFlagConfigurationPanel.module.scss
@@ -42,3 +42,10 @@
 .footer {
   grid-area: footer;
 }
+
+.flaggitsync {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 4px;
+}

--- a/src/modules/75-cf/components/TargetManagementFlagConfigurationPanel/TargetManagementFlagConfigurationPanel.module.scss
+++ b/src/modules/75-cf/components/TargetManagementFlagConfigurationPanel/TargetManagementFlagConfigurationPanel.module.scss
@@ -6,7 +6,7 @@
  */
 
 .layout {
-  height: calc(100vh - var(--page-header-height) - var(--git-sync-toolbar-height, 0px));
+  height: calc(100vh - var(--page-header-height));
   display: grid;
   grid-template-rows: auto 1fr auto auto;
   grid-template-areas:

--- a/src/modules/75-cf/components/TargetManagementFlagConfigurationPanel/TargetManagementFlagConfigurationPanel.module.scss.d.ts
+++ b/src/modules/75-cf/components/TargetManagementFlagConfigurationPanel/TargetManagementFlagConfigurationPanel.module.scss.d.ts
@@ -7,6 +7,7 @@
  **/
 // this is an auto-generated file, do not update this manually
 declare const styles: {
+  readonly flaggitsync: string
   readonly footer: string
   readonly layout: string
   readonly listing: string

--- a/src/modules/75-cf/components/TargetManagementFlagConfigurationPanel/TargetManagementFlagConfigurationPanel.tsx
+++ b/src/modules/75-cf/components/TargetManagementFlagConfigurationPanel/TargetManagementFlagConfigurationPanel.tsx
@@ -14,6 +14,7 @@ import type { Feature, Segment, Target } from 'services/cf'
 import { useStrings } from 'framework/strings'
 import { CF_DEFAULT_PAGE_SIZE } from '@cf/utils/CFUtils'
 import usePercentageRolloutValidationSchema from '@cf/hooks/usePercentageRolloutValidationSchema'
+import { useFFGitSyncContext } from '@cf/contexts/ff-git-sync-context/FFGitSyncContext'
 import TargetManagementFlagsListing from '../TargetManagementFlagsListing/TargetManagementFlagsListing'
 import NoSearchResults from '../NoData/NoSearchResults'
 import NoFlags, { NoFlagsProps } from './NoFlags'
@@ -24,6 +25,7 @@ import FormButtons from './FormButtons'
 import AddFlagButton from './AddFlagButton'
 import { STATUS, TargetManagementFlagConfigurationPanelFormValues as FormValues } from './types'
 
+import TargetManagementToolbar from '../TargetManagementToolbar/TargetManagementToolbar'
 import css from './TargetManagementFlagConfigurationPanel.module.scss'
 
 export interface TargetManagementFlagConfigurationPanelProps {
@@ -56,6 +58,8 @@ const TargetManagementFlagConfigurationPanel: FC<TargetManagementFlagConfigurati
   const { disabled, planEnforcementProps, ReasonTooltip } = useFormDisabled(item)
 
   const percentageRolloutValidationSchema = usePercentageRolloutValidationSchema()
+
+  const { isGitSyncActionsEnabled } = useFFGitSyncContext()
 
   const validationSchema = useMemo(() => {
     if (!includePercentageRollout) {
@@ -159,14 +163,17 @@ const TargetManagementFlagConfigurationPanel: FC<TargetManagementFlagConfigurati
       {({ dirty, setFieldValue }) => (
         <Form className={css.layout}>
           <Page.SubHeader className={css.toolbar}>
-            <AddFlagButton
-              item={item}
-              onAdd={onAdd}
-              existingFlagIds={existingFlagIds}
-              includePercentageRollout={includePercentageRollout}
-              planEnforcementProps={planEnforcementProps}
-              title={addFlagsDialogTitle}
-            />
+            <div className={css.flaggitsync}>
+              <AddFlagButton
+                item={item}
+                onAdd={onAdd}
+                existingFlagIds={existingFlagIds}
+                includePercentageRollout={includePercentageRollout}
+                planEnforcementProps={planEnforcementProps}
+                title={addFlagsDialogTitle}
+              />
+              {isGitSyncActionsEnabled ? <TargetManagementToolbar /> : <div />}
+            </div>
             <ExpandingSearchInput alwaysExpanded onChange={onSearch} />
           </Page.SubHeader>
 


### PR DESCRIPTION
##### Summary:

New design for the gitsync functionality in the Target & Target Groups detail page. Moving the gitsync toolbar from the top to the flag configuration panel.

##### Jira Links:

Effects both: 
https://harness.atlassian.net/browse/FFM-3647
https://harness.atlassian.net/browse/FFM-3657

As they both share a component.

##### Screenshots:

**

> Before:

_Target Groups_

![image](https://user-images.githubusercontent.com/103498167/173058500-0a326dd2-d1d6-49ff-ab70-b64f1b394f95.png)


_Target_

![image](https://user-images.githubusercontent.com/103498167/173058438-902f533e-f12a-410d-8486-127279388061.png)

**
**

> After:

_Target Groups_

![Pasted Graphic 5](https://user-images.githubusercontent.com/103498167/173058361-9679ae49-4de1-4d8e-b0e9-6f921313fa46.png)


_Target_

![Pasted Graphic 4](https://user-images.githubusercontent.com/103498167/173058380-867d2c32-2db4-495e-b04c-1fdb26cdc3f7.png)

**

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
