### PR TITLE
fix: [SRM-10723]: Spacing on ET SRM list

### DIFF
--- a/src/modules/85-cv/pages/monitored-service/components/ServiceHealth/components/ErrorTracking/ErrorTracking.tsx
+++ b/src/modules/85-cv/pages/monitored-service/components/ServiceHealth/components/ErrorTracking/ErrorTracking.tsx
@@ -6,8 +6,7 @@
  */
 
 import React from 'react'
-import { Container, Heading, Card, NoDataCard } from '@wings-software/uicore'
-import { FontVariation } from '@harness/design-system'
+import { Container, Card, NoDataCard } from '@wings-software/uicore'
 import { useParams } from 'react-router-dom'
 import noServiceAvailableImage from '@cv/assets/noServiceAvailable.png'
 import { useStrings } from 'framework/strings'
@@ -28,10 +27,7 @@ const ErrorTracking: React.FC<MetricsAndLogsProps> = props => {
   }
 
   return (
-    <Container margin={{ bottom: 'medium' }}>
-      <Heading level={2} font={{ variation: FontVariation.H6 }} padding={{ bottom: 'small' }}>
-        {getString('errors')}
-      </Heading>
+    <Container style={{ height: '100%' }}>
       {startTime && endTime ? (
         <ChildAppMounter<EventListProps>
           ChildApp={EventList}


### PR DESCRIPTION
##### Summary:

Fix spacing on the ET Errors tab in SRM

##### Jira Links:

https://harness.atlassian.net/browse/SRM-10723

##### Screenshots:

![image](https://user-images.githubusercontent.com/2991478/173453363-f2371ef4-ff7c-4c14-8a5b-ba64579f7499.png)


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
