### PR TITLE
fix: [PIE-2157]: changed the placeholder text for failure strategy step

### DIFF
--- a/src/modules/70-pipeline/components/PipelineSteps/AdvancedSteps/FailureStrategyPanel/FailureTypeMultiSelect.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/AdvancedSteps/FailureStrategyPanel/FailureTypeMultiSelect.tsx
@@ -139,6 +139,7 @@ export function FailureTypeMultiSelect(props: ConnectedFailureTypeMultiSelectPro
           popoverProps={{ minimal: true }}
           itemRenderer={itemRenderer}
           tagRenderer={tagRenderer}
+          placeholder={getString('pipeline.failureTypetext')}
           tagInputProps={{
             onRemove,
             tagProps: { className: css.tag },

--- a/src/modules/70-pipeline/components/PipelineSteps/AdvancedSteps/FailureStrategyPanel/__tests__/__snapshots__/FailureStrategyPanel.test.tsx.snap
+++ b/src/modules/70-pipeline/components/PipelineSteps/AdvancedSteps/FailureStrategyPanel/__tests__/__snapshots__/FailureStrategyPanel.test.tsx.snap
@@ -148,7 +148,7 @@ exports[`<FailureStrategyPanel /> tests adding a new strategy works 1`] = `
                   <input
                     class="bp3-input-ghost bp3-multi-select-tag-input-input"
                     name="failureStrategies[0].onFailure.errors"
-                    placeholder="Search..."
+                    placeholder="pipeline.failureTypetext"
                     value=""
                   />
                 </div>
@@ -850,7 +850,7 @@ exports[`<FailureStrategyPanel /> tests when AllErrors is selected, select is di
                   class="bp3-input-ghost bp3-multi-select-tag-input-input"
                   disabled=""
                   name="failureStrategies[0].onFailure.errors"
-                  placeholder="Search..."
+                  placeholder="pipeline.failureTypetext"
                   value=""
                 />
               </div>

--- a/src/modules/70-pipeline/components/PipelineSteps/AdvancedSteps/FailureStrategyPanel/__tests__/__snapshots__/ManualIntervention.test.tsx.snap
+++ b/src/modules/70-pipeline/components/PipelineSteps/AdvancedSteps/FailureStrategyPanel/__tests__/__snapshots__/ManualIntervention.test.tsx.snap
@@ -148,7 +148,7 @@ exports[`Failure Strategy: ManualIntervention strategy works with simple fallbac
                   <input
                     class="bp3-input-ghost bp3-multi-select-tag-input-input"
                     name="failureStrategies[0].onFailure.errors"
-                    placeholder="Search..."
+                    placeholder="pipeline.failureTypetext"
                     value=""
                   />
                 </div>

--- a/src/modules/70-pipeline/components/PipelineSteps/AdvancedSteps/FailureStrategyPanel/__tests__/__snapshots__/Retry.test.tsx.snap
+++ b/src/modules/70-pipeline/components/PipelineSteps/AdvancedSteps/FailureStrategyPanel/__tests__/__snapshots__/Retry.test.tsx.snap
@@ -148,7 +148,7 @@ exports[`Failure Strategy: Retry strategy works with simple fallback 1`] = `
                   <input
                     class="bp3-input-ghost bp3-multi-select-tag-input-input"
                     name="failureStrategies[0].onFailure.errors"
-                    placeholder="Search..."
+                    placeholder="pipeline.failureTypetext"
                     value=""
                   />
                 </div>

--- a/src/modules/70-pipeline/strings/strings.en.yaml
+++ b/src/modules/70-pipeline/strings/strings.en.yaml
@@ -809,6 +809,7 @@ myBuildsText: My Builds
 noBuckets: No buckets found with given region
 gitRepo: Git Repo
 buildRepo: Build Repo
+failureTypetext: Select Failure Type
 stepDescription:
   HTTP: Run HTTP requests containing URLs, methods, headers, assertions, and variables.
   SHELLSCRIPT: Execute scripts in the shell session. The scripts can be executed on the pod/instance running a Harness Delegate or on a remote host in the infrastructure.

--- a/src/stringTypes.ts
+++ b/src/stringTypes.ts
@@ -2851,6 +2851,7 @@ export interface StringsMap {
   'pipeline.failureStrategies.validation.strategiesRequired': string
   'pipeline.failureStrategies.validation.strategyRequired': string
   'pipeline.failureStrategies.validation.timeoutRequired': string
+  'pipeline.failureTypetext': string
   'pipeline.featureRestriction.initialDeploymentLimitExceeded': string
   'pipeline.featureRestriction.initialDeploymentWarning': string
   'pipeline.featureRestriction.integratedApprovalsJira': string


### PR DESCRIPTION
##### Summary:

Changed the failure strategy step placeholder text

##### Jira Links:

https://harness.atlassian.net/browse/PIE-2157

##### Screenshots:

After:- 
<img width="594" alt="Screenshot 2022-06-15 at 3 22 53 PM" src="https://user-images.githubusercontent.com/106532291/173799471-aa8936d6-0133-4303-acbe-95eb3bce2904.png">

Before:- 

<img width="576" alt="Screenshot 2022-06-15 at 3 24 20 PM" src="https://user-images.githubusercontent.com/106532291/173799707-b2645a5c-89b1-4c91-99b6-4673c936fdbc.png">



You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
