### PR TITLE
fix: [PIE-4097]: Reposition the rerun icon to the right

### DIFF
--- a/src/modules/70-pipeline/pages/execution/ExecutionPipelineView/ExecutionGraphView/ExecutionStageDetailsHeader/ExecutionStageDetailsHeader.tsx
+++ b/src/modules/70-pipeline/pages/execution/ExecutionPipelineView/ExecutionGraphView/ExecutionStageDetailsHeader/ExecutionStageDetailsHeader.tsx
@@ -17,7 +17,7 @@ import type { StageDetailProps } from '@pipeline/factories/ExecutionFactory/type
 import factory from '@pipeline/factories/ExecutionFactory'
 import type { StageType } from '@pipeline/utils/stageHelpers'
 import { Duration } from '@common/components/Duration/Duration'
-import { ExecutionStatus, isExecutionFailed } from '@pipeline/utils/statusHelpers'
+import { ExecutionStatus, isExecutionComplete, isExecutionFailed } from '@pipeline/utils/statusHelpers'
 import ExecutionStatusLabel from '@pipeline/components/ExecutionStatusLabel/ExecutionStatusLabel'
 import ExecutionActions from '@pipeline/components/ExecutionActions/ExecutionActions'
 import { usePermission } from '@rbac/hooks/usePermission'
@@ -106,47 +106,47 @@ export function ExecutionStageDetailsHeader(): React.ReactElement {
       <div className={css.stageDetails}>
         <div className={css.lhs} data-has-sibling={Boolean(stage && stageDetail?.component)}>
           <div className={css.stageTop}>
-            <div className={css.stageName}>
-              {stage?.name}
-              {!!pipelineExecutionDetail?.pipelineExecutionSummary?.allowStageExecutions && (
-                <RbacButton
-                  icon="repeat"
-                  tooltip={getString('pipeline.execution.actions.rerunStage')}
-                  onClick={runPipeline}
-                  variation={ButtonVariation.ICON}
-                  disabled={!canExecute}
-                  minimal
-                  withoutBoxShadow
-                  small
-                  tooltipProps={{
-                    isDark: true
-                  }}
-                />
-              )}
-            </div>
-            <ExecutionActions
-              executionStatus={stageNode?.status as ExecutionStatus}
-              refetch={refetch}
-              params={{
-                orgIdentifier,
-                pipelineIdentifier,
-                projectIdentifier,
-                accountId,
-                executionIdentifier,
-                module,
-                repoIdentifier: pipelineExecutionDetail?.pipelineExecutionSummary?.gitDetails?.repoIdentifier,
-                connectorRef: pipelineExecutionDetail?.pipelineExecutionSummary?.connectorRef,
-                repoName: pipelineExecutionDetail?.pipelineExecutionSummary?.gitDetails?.repoName,
-                branch: pipelineExecutionDetail?.pipelineExecutionSummary?.gitDetails?.branch,
-                storeType: pipelineExecutionDetail?.pipelineExecutionSummary?.storeType as StoreType
-              }}
-              noMenu
-              stageName={stageNode?.name}
-              stageId={stageNode?.uuid}
-              canEdit={canEdit}
-              canExecute={canExecute}
-              modules={pipelineExecutionDetail?.pipelineExecutionSummary?.modules}
-            />
+            <div className={css.stageName}>{stage?.name}</div>
+            {!!pipelineExecutionDetail?.pipelineExecutionSummary?.allowStageExecutions &&
+            isExecutionComplete(stage?.status as ExecutionStatus) ? (
+              <RbacButton
+                icon="repeat"
+                tooltip={getString('pipeline.execution.actions.rerunStage')}
+                onClick={runPipeline}
+                variation={ButtonVariation.ICON}
+                disabled={!canExecute}
+                minimal
+                withoutBoxShadow
+                small
+                tooltipProps={{
+                  isDark: true
+                }}
+              />
+            ) : (
+              <ExecutionActions
+                executionStatus={stageNode?.status as ExecutionStatus}
+                refetch={refetch}
+                params={{
+                  orgIdentifier,
+                  pipelineIdentifier,
+                  projectIdentifier,
+                  accountId,
+                  executionIdentifier,
+                  module,
+                  repoIdentifier: pipelineExecutionDetail?.pipelineExecutionSummary?.gitDetails?.repoIdentifier,
+                  connectorRef: pipelineExecutionDetail?.pipelineExecutionSummary?.connectorRef,
+                  repoName: pipelineExecutionDetail?.pipelineExecutionSummary?.gitDetails?.repoName,
+                  branch: pipelineExecutionDetail?.pipelineExecutionSummary?.gitDetails?.branch,
+                  storeType: pipelineExecutionDetail?.pipelineExecutionSummary?.storeType as StoreType
+                }}
+                noMenu
+                stageName={stageNode?.name}
+                stageId={stageNode?.uuid}
+                canEdit={canEdit}
+                canExecute={canExecute}
+                modules={pipelineExecutionDetail?.pipelineExecutionSummary?.modules}
+              />
+            )}
           </div>
           {times}
           {/* TODO: Need to uncomment and finish */}


### PR DESCRIPTION
##### Summary:

Reposition the rerun icon to the right

##### Jira Links:

https://harness.atlassian.net/browse/PIE-4097

##### Screenshots:

Before:
![image-2021-10-26-12-53-48-729](https://user-images.githubusercontent.com/73639897/174003593-455a1d20-e076-42e9-ac51-4543f9a95161.png)

After:

https://user-images.githubusercontent.com/73639897/174003639-6680e307-b021-4f30-a03b-1da76897e361.mov



You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
