### PR TITLE
fix: [CDS-38443]: Add validation on custom field add modall for service now

### DIFF
--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowCreate/ServiceNowDynamicFieldsSelector.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowCreate/ServiceNowDynamicFieldsSelector.tsx
@@ -29,6 +29,8 @@ import {
 } from './types'
 
 import css from './ServiceNowDynamicFieldsSelector.module.scss'
+import * as Yup from 'yup'
+
 function SelectFieldList(props: ServiceNowDynamicFieldsSelectorInterface) {
   const { getString } = useStrings()
   const { selectedTicketTypeKey, ticketTypeBasedFieldList } = props
@@ -107,7 +109,17 @@ function ProvideFieldList(props: ServiceNowDynamicFieldsSelectorInterface) {
         props.provideFieldList(values)
       }}
       formName="ServiceNowFields"
-      initialValues={[]}
+      initialValues={[{ name: 'test', value: '' }]}
+      validationSchema={Yup.object().shape({
+        fieldList: Yup.array()
+          .of(
+            Yup.object().shape({
+              'fieldList[0].name': Yup.string().trim().required(getString('common.validation.keyIsRequired')),
+              'fieldList[0].value': Yup.string().trim().required(getString('common.validation.valueIsRequired'))
+            })
+          )
+          .required('Must have fields')
+      })}
     >
       {(formik: FormikProps<{ fieldList: ServiceNowCreateFieldType[] }>) => {
         return (


### PR DESCRIPTION
fix: [CDS-38443]: Add validation on custom field add modall for service now

##### Summary:

<!--- Add summary of your changes here -->

##### Jira Links:

<!--- Add jira links for your changes here -->

##### Screenshots:

<!--- Add screenshots for your changes here -->

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`


[CDS-38443]: https://harness.atlassian.net/browse/CDS-38443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ