### PR TITLE
fix: [PL-24388]: make sidenav sticky and content height flexible

### DIFF
--- a/src/modules/10-common/layouts/layouts.module.scss
+++ b/src/modules/10-common/layouts/layouts.module.scss
@@ -48,7 +48,7 @@
 }
 
 .children {
-  height: 100vh;
+  min-height: 100vh;
   overflow-y: auto;
   background-color: var(--primary-bg);
 }
@@ -67,7 +67,7 @@
 
 .rhs {
   overflow-y: auto;
-  height: 100vh;
+  min-height: 100vh;
 }
 
 .main {

--- a/src/modules/10-common/navigation/MainNav/MainNav.module.scss
+++ b/src/modules/10-common/navigation/MainNav/MainNav.module.scss
@@ -12,6 +12,11 @@
   flex-direction: column;
   justify-content: space-between;
   z-index: 16;
+  /* sticky positioning */
+  height: 880px;
+  position: sticky;
+  bottom: 0;
+  align-self: flex-end;
 
   .navList {
     list-style: none;


### PR DESCRIPTION
##### Summary:

Makes SideNav sticky and RHS content height flexible (minimum 100vh)

##### Screenshots:

https://user-images.githubusercontent.com/47316575/174168777-3bf0ebb1-3910-405d-a56d-a1f839d12c9b.mov


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
