### PR TITLE
feat: [SRM-10749]: Changed ET CI End time to be fixed after build has finish

### DIFF
--- a/src/modules/70-pipeline/pages/execution/ExecutionErrorTrackingView/ExecutionErrorTrackingView.tsx
+++ b/src/modules/70-pipeline/pages/execution/ExecutionErrorTrackingView/ExecutionErrorTrackingView.tsx
@@ -40,7 +40,11 @@ export default function ExecutionErrorTrackingView(): React.ReactElement | null 
         environmentId={'_INTERNAL_ET_CI'}
         versionId={pipelineExecutionDetail.pipelineExecutionSummary.runSequence.toString()}
         fromDateTime={Math.floor(pipelineExecutionDetail.pipelineExecutionSummary.startTs / 1000)}
-        toDateTime={Math.floor(Date.now() / 1000)}
+        toDateTime={Math.floor(
+          pipelineExecutionDetail.pipelineExecutionSummary.endTs
+            ? pipelineExecutionDetail.pipelineExecutionSummary.endTs / 1000 + 60 * 30
+            : Date.now() / 1000
+        )}
       />
     </Container>
   )


### PR DESCRIPTION
##### Summary:

The Error Tracking will use different time ranges depending on if the build is running or if it has completed. The time range always uses build start time for the start of the time range. The ending time will be one of 2 cases:
1. current time - When the build is currently running so there are no build end time
2. build end time + 30 mins - When the build is competed (build end time is available)

##### Jira Links:

https://harness.atlassian.net/browse/SRM-10749

##### Screenshots:

Only api calls. screenshots are NA

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
