### PR TITLE
feat: [CDB-227]: enforce dashboards view and edit roles

### DIFF
--- a/src/modules/45-dashboards/components/DashboardCard/DashboardCard.tsx
+++ b/src/modules/45-dashboards/components/DashboardCard/DashboardCard.tsx
@@ -18,6 +18,7 @@ import type { DashboardModel } from 'services/custom-dashboards'
 import { DashboardType } from '@dashboards/types/DashboardTypes'
 import DashboardTags from '@dashboards/components/DashboardTags/DashboardTags'
 import RbacMenuItem from '@rbac/components/MenuItem/MenuItem'
+import type { PermissionRequest } from '@rbac/hooks/usePermission'
 import { PermissionIdentifier } from '@rbac/interfaces/PermissionIdentifier'
 import { ResourceType } from '@rbac/interfaces/ResourceType'
 
@@ -71,6 +72,14 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
     folderId: folderId === 'shared' ? 'shared' : dashboard?.resourceIdentifier
   })
 
+  const permissionObj: PermissionRequest = {
+    permission: PermissionIdentifier.EDIT_DASHBOARD,
+    resource: {
+      resourceType: ResourceType.DASHBOARDS,
+      resourceIdentifier: dashboard?.resourceIdentifier
+    }
+  }
+
   return (
     <Link to={cardPath}>
       <Card interactive className={cx(moduleTagCss.card)}>
@@ -79,28 +88,13 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
             menuContent={
               <Menu>
                 {dashboard?.type === DashboardType.ACCOUNT && (
-                  <RbacMenuItem
-                    icon="edit"
-                    text={getString('edit')}
-                    onClick={onEditClick}
-                    permission={{
-                      permission: PermissionIdentifier.EDIT_DASHBOARD,
-                      resource: {
-                        resourceType: ResourceType.DASHBOARDS
-                      }
-                    }}
-                  />
+                  <RbacMenuItem icon="edit" text={getString('edit')} onClick={onEditClick} permission={permissionObj} />
                 )}
                 <RbacMenuItem
                   icon="duplicate"
                   text={getString('projectCard.clone')}
                   onClick={onCloneClick}
-                  permission={{
-                    permission: PermissionIdentifier.EDIT_DASHBOARD,
-                    resource: {
-                      resourceType: ResourceType.DASHBOARDS
-                    }
-                  }}
+                  permission={permissionObj}
                 />
                 {dashboard?.type === DashboardType.ACCOUNT && (
                   <>
@@ -109,12 +103,7 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
                       icon="trash"
                       text={getString('delete')}
                       onClick={onDeleteClick}
-                      permission={{
-                        permission: PermissionIdentifier.EDIT_DASHBOARD,
-                        resource: {
-                          resourceType: ResourceType.DASHBOARDS
-                        }
-                      }}
+                      permission={permissionObj}
                     />
                   </>
                 )}

--- a/src/modules/45-dashboards/components/DashboardResourceModalBody/DashboardResourceModalBody.tsx
+++ b/src/modules/45-dashboards/components/DashboardResourceModalBody/DashboardResourceModalBody.tsx
@@ -15,7 +15,7 @@ import ResourceHandlerTable from '@rbac/components/ResourceHandlerTable/Resource
 import { PageSpinner } from '@common/components'
 
 import routes from '@common/RouteDefinitions'
-import { useGetFolder } from 'services/custom-dashboards'
+import { useGetFolder, useGetOotbFolderId } from 'services/custom-dashboards'
 
 import { useStrings } from 'framework/strings'
 
@@ -93,13 +93,27 @@ const DashboardResourceModalBody: React.FC<DashboardResourceModalBodyProps> = ({
     queryParams: { accountId: accountIdentifier, page: page + 1, pageSize: PAGE_SIZE, isAdmin: true }
   })
 
+  const { data: ootbFolder, loading: fetchingOotbFolder } = useGetOotbFolderId({
+    queryParams: { accountId: accountIdentifier }
+  })
+
+  const includeOotbBeforeOnChange = (items: string[]) => {
+    if (ootbFolder?.resource) {
+      items = items.filter((val: string) => val !== ootbFolder.resource)
+      if (items.length > 0) {
+        items.push(ootbFolder.resource)
+      }
+    }
+    onSelectChange(items)
+  }
+
   const parsedFolders =
     folders?.resource?.map((folder: { id: string; name: string }) => ({
       identifier: folder.id,
       ...folder
     })) || []
 
-  if (fetchingFolders) return <PageSpinner />
+  if (fetchingFolders || fetchingOotbFolder) return <PageSpinner />
   return parsedFolders?.length > 0 ? (
     <Container className={css.container}>
       <ResourceHandlerTable
@@ -121,7 +135,7 @@ const DashboardResourceModalBody: React.FC<DashboardResourceModalBodyProps> = ({
           pageIndex: page || 0,
           gotoPage: pageNumber => setPage(pageNumber)
         }}
-        onSelectChange={onSelectChange}
+        onSelectChange={includeOotbBeforeOnChange}
       />
     </Container>
   ) : (

--- a/src/modules/45-dashboards/constants.ts
+++ b/src/modules/45-dashboards/constants.ts
@@ -8,3 +8,4 @@
 import { Color } from '@harness/design-system'
 export const SUCCESS_COLORS = [Color.PRIMARY_7, Color.PRIMARY_6, Color.PRIMARY_5, Color.TEAL_500, Color.GREEN_400]
 export const FAIL_COLORS = [Color.RED_800, Color.RED_700, Color.RED_500, Color.ORANGE_900, Color.ORANGE_400]
+export const SHARED_FOLDER_ID = 'shared'

--- a/src/modules/45-dashboards/pages/dashboardView/DashboardView.tsx
+++ b/src/modules/45-dashboards/pages/dashboardView/DashboardView.tsx
@@ -13,6 +13,7 @@ import { Page } from '@common/exports'
 import type { AccountPathProps } from '@common/interfaces/RouteInterfaces'
 import { useStrings } from 'framework/strings'
 import { useDashboardsContext } from '@dashboards/pages/DashboardsContext'
+import { SHARED_FOLDER_ID } from '@dashboards/constants'
 import {
   ErrorResponse,
   useCreateSignedUrl,
@@ -63,7 +64,16 @@ const DashboardViewPage: React.FC = () => {
     })
   }, [])
 
-  const { data: folderDetail } = useGetFolderDetail({ queryParams: { accountId, folderId } })
+  const { data: folderDetail, refetch: fetchFolderDetail } = useGetFolderDetail({
+    lazy: true,
+    queryParams: { accountId, folderId }
+  })
+
+  React.useEffect(() => {
+    if (folderId !== SHARED_FOLDER_ID) {
+      fetchFolderDetail()
+    }
+  }, [accountId, folderId])
 
   const { data: dashboardDetail } = useGetDashboardDetail({ dashboard_id: viewId, queryParams: { accountId } })
 

--- a/src/modules/45-dashboards/pages/dashboardView/__tests__/DashboardView.test.tsx
+++ b/src/modules/45-dashboards/pages/dashboardView/__tests__/DashboardView.test.tsx
@@ -40,10 +40,11 @@ describe('DashboardView', () => {
   const useGetFolderDetailMock = jest.spyOn(sharedService, 'useGetFolderDetail')
 
   const includeBreadcrumbs = jest.fn()
+  const fetchFolderDetailMock = jest.fn()
 
   beforeEach(() => {
     jest.clearAllMocks()
-    useGetFolderDetailMock.mockReturnValue({ data: { resource: 'folder name' } } as any)
+    useGetFolderDetailMock.mockReturnValue({ data: { resource: 'folder name' }, refetch: fetchFolderDetailMock } as any)
     useGetDashboardDetailMock.mockReturnValue({ resource: true, title: 'dashboard name' } as any)
     useDashboardsContextMock.mockReturnValue({ includeBreadcrumbs: includeBreadcrumbs, breadcrumbs: [] })
     useCreateSignedUrlMock.mockReturnValue({
@@ -94,7 +95,7 @@ describe('DashboardView', () => {
   })
 
   test('it should include a dashboard in breadcrumbs when a dashboard details has been retrieved', async () => {
-    useGetFolderDetailMock.mockReturnValue({ data: null } as any)
+    useGetFolderDetailMock.mockReturnValue({ data: null, refetch: jest.fn() } as any)
 
     const mockDashboardTitle = 'Test Dashboard'
     const mockDashboardDetail: sharedService.GetDashboardDetailResponse = {
@@ -115,5 +116,11 @@ describe('DashboardView', () => {
     renderComponent('shared')
 
     expect(includeBreadcrumbs).toBeCalledWith([])
+  })
+
+  test('it should not call the folder detail endpoint when using the shared folder', async () => {
+    renderComponent('shared')
+
+    expect(fetchFolderDetailMock).not.toHaveBeenCalled()
   })
 })

--- a/src/modules/45-dashboards/pages/folders/FoldersPage.tsx
+++ b/src/modules/45-dashboards/pages/folders/FoldersPage.tsx
@@ -36,7 +36,7 @@ import type { AccountPathProps } from '@common/interfaces/RouteInterfaces'
 import { PAGE_SIZE } from '@dashboards/pages/home/HomePage'
 import FolderCard from '@dashboards/components/FolderCard/FolderCard'
 import { useStrings } from 'framework/strings'
-import { FolderModel, useGetFolders } from 'services/custom-dashboards'
+import { ErrorResponse, FolderModel, useGetFolders } from 'services/custom-dashboards'
 import CreateFolder from './form/CreateFolder'
 import { useDashboardsContext } from '../DashboardsContext'
 
@@ -190,7 +190,11 @@ const FoldersPage: React.FC = () => {
   )
 
   return (
-    <Page.Body loading={loading} error={error?.message}>
+    <Page.Body
+      loading={loading}
+      error={(error?.data as ErrorResponse)?.responseMessages}
+      retryOnError={() => reloadFolders()}
+    >
       <Layout.Horizontal
         spacing="medium"
         background={Color.GREY_0}

--- a/src/modules/45-dashboards/pages/folders/form/CreateFolder.tsx
+++ b/src/modules/45-dashboards/pages/folders/form/CreateFolder.tsx
@@ -39,8 +39,8 @@ const CreateFolder: React.FC<CreateFolderProps> = ({ onFormCompleted }) => {
         })
         onFormCompleted()
       })
-      .catch(() => {
-        setErrorMessage(getString('dashboards.createFolder.folderSubmitFail'))
+      .catch(e => {
+        setErrorMessage(e?.data?.responseMessages || getString('dashboards.createFolder.folderSubmitFail'))
       })
   }
 

--- a/src/modules/45-dashboards/pages/folders/form/UpdateFolder.tsx
+++ b/src/modules/45-dashboards/pages/folders/form/UpdateFolder.tsx
@@ -33,8 +33,8 @@ const UpdateFolder: React.FC<UpdateFolderProps> = ({ folderData, onFormCompleted
       .then(() => {
         onFormCompleted()
       })
-      .catch(() => {
-        setErrorMessage(getString('dashboards.updateFolder.folderUpdateFail'))
+      .catch(e => {
+        setErrorMessage(e?.data?.responseMessages || getString('dashboards.updateFolder.folderUpdateFail'))
       })
   }
 

--- a/src/modules/45-dashboards/pages/folders/useDeleteFolder.tsx
+++ b/src/modules/45-dashboards/pages/folders/useDeleteFolder.tsx
@@ -43,8 +43,8 @@ const useDeleteFolder = (folder: FolderModel | undefined, onSuccess: () => void)
             showSuccess(getString('dashboards.deleteFolder.success'))
             onSuccess()
           }
-        } catch (error: unknown | any) {
-          showError(error?.data?.responseMessages)
+        } catch (error) {
+          showError(error?.data?.responseMessages || getString('dashboards.deleteFolder.failed'))
         }
       }
     }

--- a/src/modules/45-dashboards/pages/home/CloneDashboardForm.tsx
+++ b/src/modules/45-dashboards/pages/home/CloneDashboardForm.tsx
@@ -42,7 +42,7 @@ const CloneDashboardForm: React.FC<CloneDashboardFormProps> = ({ hideModal, relo
       const response = await cloneDashboard({ ...completedFormData, dashboardId })
       onSuccess(response)
     } catch (e) {
-      modalErrorHandler?.showDanger(getString('dashboards.cloneDashboardModal.submitFail'))
+      modalErrorHandler?.showDanger(e?.data?.responseMessages || getString('dashboards.cloneDashboardModal.submitFail'))
     }
   }
 

--- a/src/modules/45-dashboards/pages/home/CreateDashboardForm.tsx
+++ b/src/modules/45-dashboards/pages/home/CreateDashboardForm.tsx
@@ -48,7 +48,7 @@ const CreateDashboardForm: React.FC<CreateDashboardFormProps> = ({ hideModal }) 
       const response = await createDashboard(formData)
       onSuccess(response)
     } catch (e) {
-      modalErrorHandler?.showDanger(getString('dashboards.createModal.submitFail'))
+      modalErrorHandler?.showDanger(e?.data?.responseMessages || getString('dashboards.createModal.submitFail'))
     }
   }
 

--- a/src/modules/45-dashboards/pages/home/HomePage.tsx
+++ b/src/modules/45-dashboards/pages/home/HomePage.tsx
@@ -32,12 +32,14 @@ import { Page } from '@common/exports'
 import RbacButton from '@rbac/components/Button/Button'
 import { PermissionIdentifier } from '@rbac/interfaces/PermissionIdentifier'
 import { ResourceType } from '@rbac/interfaces/ResourceType'
+import type { PermissionRequest } from '@rbac/hooks/usePermission'
 import ModuleTagsFilter from '@dashboards/components/ModuleTagsFilter/ModuleTagsFilter'
 
 import { ErrorResponse, useDeleteDashboard, useGetFolderDetail, useSearch } from 'services/custom-dashboards'
 import routes from '@common/RouteDefinitions'
 
 import { DashboardLayoutViews, MappedDashboardTagOptions } from '@dashboards/types/DashboardTypes'
+import { SHARED_FOLDER_ID } from '@dashboards/constants'
 import { useStrings } from 'framework/strings'
 import Dashboards from './Dashboards'
 import { useDashboardsContext } from '../DashboardsContext'
@@ -47,14 +49,6 @@ import css from './HomePage.module.scss'
 import moduleTagCss from '@dashboards/common/ModuleTags.module.scss'
 
 export const PAGE_SIZE = 20
-
-interface Permission {
-  resource: {
-    resourceType: ResourceType
-    resourceIdentifier?: string
-  }
-  permission: PermissionIdentifier
-}
 
 const CustomSelect = Select.ofType<SelectOption>()
 
@@ -83,6 +77,7 @@ const HomePage: React.FC = () => {
   const { getString } = useStrings()
   const { accountId, folderId } = useParams<{ accountId: string; folderId: string }>()
   const { showSuccess, showError } = useToaster()
+  const isNotShared = folderId !== SHARED_FOLDER_ID
 
   const defaultSortBy: SelectOption = {
     label: 'Select Option',
@@ -131,7 +126,7 @@ const HomePage: React.FC = () => {
   }
 
   const folderIdOrBlank = (): string => {
-    return folderId.replace('shared', '')
+    return isNotShared ? folderId : ''
   }
 
   React.useEffect(() => {
@@ -176,10 +171,10 @@ const HomePage: React.FC = () => {
     queryParams: { accountId, folderId }
   })
 
-  const { mutate: deleteDashboard, loading: deleting } = useDeleteDashboard({ queryParams: { accountId } })
+  const { mutate: deleteDashboard, loading: deleting } = useDeleteDashboard({ queryParams: { accountId, folderId } })
 
   React.useEffect(() => {
-    if (folderId !== 'shared') {
+    if (isNotShared) {
       fetchFolderDetail()
     }
   }, [accountId, folderId])
@@ -200,14 +195,14 @@ const HomePage: React.FC = () => {
     []
   )
 
-  const permissionObj: Permission = {
+  const permissionObj: PermissionRequest = {
     permission: PermissionIdentifier.EDIT_DASHBOARD,
     resource: {
       resourceType: ResourceType.DASHBOARDS
     }
   }
 
-  if (folderId !== 'shared') {
+  if (isNotShared) {
     permissionObj['resource']['resourceIdentifier'] = folderId
   }
 

--- a/src/modules/45-dashboards/pages/home/HomePage.tsx
+++ b/src/modules/45-dashboards/pages/home/HomePage.tsx
@@ -16,7 +16,8 @@ import {
   Dialog,
   ExpandingSearchInput,
   Pagination,
-  SelectOption
+  SelectOption,
+  useToaster
 } from '@harness/uicore'
 import { useModalHook } from '@harness/use-modal'
 import type { Breadcrumb } from '@harness/uicore'
@@ -81,6 +82,7 @@ const getBreadcrumbLinks = (
 const HomePage: React.FC = () => {
   const { getString } = useStrings()
   const { accountId, folderId } = useParams<{ accountId: string; folderId: string }>()
+  const { showSuccess, showError } = useToaster()
 
   const defaultSortBy: SelectOption = {
     label: 'Select Option',
@@ -215,14 +217,22 @@ const HomePage: React.FC = () => {
     )
   }, [folderDetail, accountId, folderId])
 
-  const onDeleteDashboard = (dashboardId: string): void => {
-    deleteDashboard({ dashboardId }).then(() => {
+  const onDeleteDashboard = async (dashboardId: string): Promise<void> => {
+    try {
+      await deleteDashboard({ dashboardId })
+      showSuccess(getString('dashboards.deleteDashboard.success'))
       refetchDashboards()
-    })
+    } catch (e) {
+      showError(e?.data?.responseMessages || getString('dashboards.deleteDashboard.failed'))
+    }
   }
 
   return (
-    <Page.Body loading={loading || deleting} error={(error?.data as ErrorResponse)?.responseMessages}>
+    <Page.Body
+      loading={loading || deleting}
+      error={(error?.data as ErrorResponse)?.responseMessages}
+      retryOnError={() => refetchDashboards()}
+    >
       <Layout.Horizontal>
         <Layout.Horizontal
           padding="large"

--- a/src/modules/45-dashboards/pages/home/UpdateDashboardForm.tsx
+++ b/src/modules/45-dashboards/pages/home/UpdateDashboardForm.tsx
@@ -59,7 +59,7 @@ const UpdateDashboardForm: React.FC<UpdateDashboardFormProps> = ({ hideModal, re
       const response = await updateDashboard({ ...completedFormData, dashboardId })
       onSuccess(response)
     } catch (e) {
-      modalErrorHandler?.showDanger(getString('dashboards.editModal.submitFail'))
+      modalErrorHandler?.showDanger(e?.data?.responseMessages || getString('dashboards.editModal.submitFail'))
     }
   }
 

--- a/src/modules/45-dashboards/pages/home/__tests__/CloneDashboardForm.test.tsx
+++ b/src/modules/45-dashboards/pages/home/__tests__/CloneDashboardForm.test.tsx
@@ -33,12 +33,12 @@ const mockEmptyGetFolderResponse: customDashboardServices.GetFolderResponse = {
 describe('CloneDashboardForm', () => {
   beforeEach(() => {
     jest
-      .spyOn(customDashboardServices, 'useGetFolder')
+      .spyOn(customDashboardServices, 'useGetFolders')
       .mockImplementation(() => ({ data: mockEmptyGetFolderResponse, loading: false } as any))
   })
   afterEach(() => {
     jest.spyOn(customDashboardServices, 'useCloneDashboard').mockReset()
-    jest.spyOn(customDashboardServices, 'useGetFolder').mockReset()
+    jest.spyOn(customDashboardServices, 'useGetFolders').mockReset()
   })
 
   test('it should display Clone Dashboard Form', () => {

--- a/src/modules/45-dashboards/pages/home/__tests__/DashboardForm.test.tsx
+++ b/src/modules/45-dashboards/pages/home/__tests__/DashboardForm.test.tsx
@@ -35,17 +35,20 @@ const renderComponent = (props: DashboardFormProps): RenderResult => {
 }
 
 const mockEmptyGetFolderResponse: customDashboardServices.GetFolderResponse = {
-  resource: []
+  resource: [
+    { id: 'shared', name: 'Shared Folder' },
+    { id: '1', name: 'folder_one' }
+  ] as any
 }
 
 describe('DashboardForm', () => {
   beforeEach(() => {
     jest
-      .spyOn(customDashboardServices, 'useGetFolder')
+      .spyOn(customDashboardServices, 'useGetFolders')
       .mockImplementation(() => ({ data: mockEmptyGetFolderResponse, loading: false } as any))
   })
   afterEach(() => {
-    jest.spyOn(customDashboardServices, 'useGetFolder').mockReset()
+    jest.spyOn(customDashboardServices, 'useGetFolders').mockReset()
   })
 
   test('it should display a Dashboard Form with continue button', () => {
@@ -53,5 +56,32 @@ describe('DashboardForm', () => {
 
     const saveButton = screen.getByText(result.current.getString('continue'))
     waitFor(() => expect(saveButton).toBeInTheDocument())
+  })
+
+  test('it should display the formData as the initial form values', () => {
+    const formData = {
+      description: 'tag_one,tag_two',
+      folderId: '1',
+      name: 'dashboard name'
+    }
+
+    renderComponent({ formData: formData, ...defaultProps })
+
+    expect(screen.getByDisplayValue('dashboard name')).toBeInTheDocument()
+    expect(screen.getByText('tag_one')).toBeInTheDocument()
+    expect(screen.getByText('tag_two')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('folder_one')).toBeInTheDocument()
+  })
+
+  test('it should select shared as the initial folder when the initial folder ID is not returned', () => {
+    const formData = {
+      description: 'tags',
+      folderId: '1234',
+      name: 'dashboard name'
+    }
+
+    renderComponent({ formData: formData, ...defaultProps })
+
+    expect(screen.getByDisplayValue('Shared Folder')).toBeInTheDocument()
   })
 })

--- a/src/modules/45-dashboards/pages/home/__tests__/Dashboards.test.tsx
+++ b/src/modules/45-dashboards/pages/home/__tests__/Dashboards.test.tsx
@@ -61,12 +61,12 @@ const mockEmptyGetFolderResponse: customDashboardServices.GetFolderResponse = {
 }
 
 describe('Dashboards', () => {
-  const useGetFolderMock = jest.spyOn(customDashboardServices, 'useGetFolder')
+  const useGetFoldersMock = jest.spyOn(customDashboardServices, 'useGetFolders')
 
   beforeEach(() => {
     jest.clearAllMocks()
 
-    useGetFolderMock.mockReturnValue({ data: mockEmptyGetFolderResponse, error: null, loading: false } as any)
+    useGetFoldersMock.mockReturnValue({ data: mockEmptyGetFolderResponse, error: null, loading: false } as any)
   })
 
   test('it should show an empty message when there are no dashboards', () => {

--- a/src/modules/45-dashboards/strings/strings.en.yaml
+++ b/src/modules/45-dashboards/strings/strings.en.yaml
@@ -56,10 +56,14 @@ createFolder:
   folderSubmitFail: 'Folder creation failed, Please try again.'
 updateFolder:
   folderUpdateFail: 'Failed to update folder, Please try again.'
+deleteDashboard:
+  success: 'Successfully deleted dashboard'
+  failed: 'Failed to delete dashboard'
 deleteFolder:
   confirmDeleteTitle: 'Delete {{name}} folder'
   confirmDeleteText: 'Deleting the folder {{name}} would mean that you are also deleting all the dashboards associated with it. Are you sure you want to delete the Folder?'
   success: 'Successfully deleted folder'
+  failed: 'Failed to delete folder'
 resourceModal:
   folders: 'Folder Name'
   folderDetail: 'Folder Dashboards'

--- a/src/services/custom-dashboards/index.tsx
+++ b/src/services/custom-dashboards/index.tsx
@@ -141,6 +141,10 @@ export interface GetFoldersResponse {
   responseMessages?: string
 }
 
+export interface GetOotbFolderIdResponse {
+  resource?: string
+}
+
 export interface PatchFolderRequestBody {
   folderId: string
   name: string
@@ -302,7 +306,7 @@ export interface GetFolderQueryParams {
 export type GetFolderProps = Omit<GetProps<GetFolderResponse, ErrorResponse, GetFolderQueryParams, void>, 'path'>
 
 /**
- * Get a folders details.
+ * Get all sub-folders in account.
  */
 export const GetFolder = (props: GetFolderProps) => (
   <Get<GetFolderResponse, ErrorResponse, GetFolderQueryParams, void>
@@ -315,7 +319,7 @@ export const GetFolder = (props: GetFolderProps) => (
 export type UseGetFolderProps = Omit<UseGetProps<GetFolderResponse, ErrorResponse, GetFolderQueryParams, void>, 'path'>
 
 /**
- * Get a folders details.
+ * Get all sub-folders in account.
  */
 export const useGetFolder = (props: UseGetFolderProps) =>
   useGet<GetFolderResponse, ErrorResponse, GetFolderQueryParams, void>(`/folder`, {
@@ -324,7 +328,7 @@ export const useGetFolder = (props: UseGetFolderProps) =>
   })
 
 /**
- * Get a folders details.
+ * Get all sub-folders in account.
  */
 export const getFolderPromise = (
   props: GetUsingFetchProps<GetFolderResponse, ErrorResponse, GetFolderQueryParams, void>,
@@ -451,6 +455,54 @@ export const createFolderPromise = (
     signal
   )
 
+export interface GetOotbFolderIdQueryParams {
+  accountId: string
+}
+
+export type GetOotbFolderIdProps = Omit<
+  GetProps<GetOotbFolderIdResponse, ErrorResponse, GetOotbFolderIdQueryParams, void>,
+  'path'
+>
+
+/**
+ * Get out of the box folder ID.
+ */
+export const GetOotbFolderId = (props: GetOotbFolderIdProps) => (
+  <Get<GetOotbFolderIdResponse, ErrorResponse, GetOotbFolderIdQueryParams, void>
+    path={`/folder/ootb`}
+    base={getConfig('dashboard/')}
+    {...props}
+  />
+)
+
+export type UseGetOotbFolderIdProps = Omit<
+  UseGetProps<GetOotbFolderIdResponse, ErrorResponse, GetOotbFolderIdQueryParams, void>,
+  'path'
+>
+
+/**
+ * Get out of the box folder ID.
+ */
+export const useGetOotbFolderId = (props: UseGetOotbFolderIdProps) =>
+  useGet<GetOotbFolderIdResponse, ErrorResponse, GetOotbFolderIdQueryParams, void>(`/folder/ootb`, {
+    base: getConfig('dashboard/'),
+    ...props
+  })
+
+/**
+ * Get out of the box folder ID.
+ */
+export const getOotbFolderIdPromise = (
+  props: GetUsingFetchProps<GetOotbFolderIdResponse, ErrorResponse, GetOotbFolderIdQueryParams, void>,
+  signal?: RequestInit['signal']
+) =>
+  getUsingFetch<GetOotbFolderIdResponse, ErrorResponse, GetOotbFolderIdQueryParams, void>(
+    getConfig('dashboard/'),
+    `/folder/ootb`,
+    props,
+    signal
+  )
+
 export interface GetFolderDetailQueryParams {
   accountId: string
   folderId: string
@@ -501,6 +553,7 @@ export const getFolderDetailPromise = (
   )
 
 export interface DeleteDashboardQueryParams {
+  folderId: string
   accountId: string
 }
 

--- a/src/stringTypes.ts
+++ b/src/stringTypes.ts
@@ -2461,8 +2461,11 @@ export interface StringsMap {
   'dashboards.dashboardSortingOptions.mostViewed': string
   'dashboards.dashboardSortingOptions.recentlyCreated': string
   'dashboards.dashboardSortingOptions.recentlyViewed': string
+  'dashboards.deleteDashboard.failed': string
+  'dashboards.deleteDashboard.success': string
   'dashboards.deleteFolder.confirmDeleteText': string
   'dashboards.deleteFolder.confirmDeleteTitle': string
+  'dashboards.deleteFolder.failed': string
   'dashboards.deleteFolder.success': string
   'dashboards.editModal.editDashboard': string
   'dashboards.editModal.submitFail': string


### PR DESCRIPTION
##### Summary:

CDB-227 will enforce the Dashboard View and Edit roles within the app.
The main changes happening to the UI as part of this change are
* Support displaying meaningful error messages
* Enforce roles per folder
* Include OOTB folder when assigning a resource group

##### Jira Links:

<!--- Add jira links for your changes here -->

##### Screenshots:

<!--- Add screenshots for your changes here -->

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier - `fix prettier`
