### PR TITLE
fix: [CDB-97]: Fixed potential error when DashboardView url fails to return

### DIFF
--- a/src/modules/45-dashboards/pages/dashboardView/DashboardView.tsx
+++ b/src/modules/45-dashboards/pages/dashboardView/DashboardView.tsx
@@ -53,14 +53,20 @@ const DashboardViewPage: React.FC = () => {
   }, [viewId])
 
   React.useEffect(() => {
-    window.addEventListener('message', function (event) {
+    const lookerEventHandler = (event: MessageEvent<string>): void => {
       if (event.origin === DASHBOARDS_ORIGIN) {
         const onChangeData = JSON.parse(event.data)
         if (onChangeData && onChangeData.type === 'page:changed' && onChangeData.page?.url?.includes('embed/explore')) {
           history.go(0)
         }
       }
-    })
+    }
+
+    window.addEventListener('message', lookerEventHandler)
+
+    return () => {
+      window.removeEventListener('message', lookerEventHandler)
+    }
   }, [])
 
   const { data: folderDetail } = useGetFolderDetail({ queryParams: { accountId, folderId } })

--- a/src/modules/45-dashboards/pages/dashboardView/DashboardView.tsx
+++ b/src/modules/45-dashboards/pages/dashboardView/DashboardView.tsx
@@ -27,7 +27,7 @@ const DashboardViewPage: React.FC = () => {
   const { includeBreadcrumbs } = useDashboardsContext()
 
   const { accountId, viewId, folderId } = useParams<AccountPathProps & { viewId: string; folderId: string }>()
-  const [embedUrl, setEmbedUrl] = React.useState('')
+  const [embedUrl, setEmbedUrl] = React.useState<string>()
   const [iframeState] = React.useState(0)
   const history = useHistory()
   const query = location.href.split('?')[1]
@@ -43,8 +43,10 @@ const DashboardViewPage: React.FC = () => {
     error
   } = useCreateSignedUrl({ queryParams: { accountId, dashboardId: viewId, src: signedQueryUrl } })
 
+  const responseMessages = useMemo(() => (error?.data as ErrorResponse)?.responseMessages, [error])
+
   const generateSignedUrl = async (): Promise<void> => {
-    const { resource = '' } = (await createSignedUrl()) || {}
+    const { resource } = (await createSignedUrl()) || {}
     setEmbedUrl(resource)
   }
 
@@ -85,21 +87,22 @@ const DashboardViewPage: React.FC = () => {
         label: folderDetail.resource
       })
     }
-    dashboardDetail &&
+    embedUrl &&
+      dashboardDetail &&
       links.push({
         url: routes.toViewCustomDashboard({ viewId, folderId, accountId }),
         label: dashboardDetail.title
       })
     includeBreadcrumbs(links)
-  }, [folderDetail, dashboardDetail, accountId, viewId])
+  }, [folderDetail, dashboardDetail, accountId, viewId, embedUrl])
 
   return (
     <Page.Body
       className={css.pageContainer}
       loading={loading}
-      error={(error?.data as ErrorResponse)?.responseMessages}
+      error={responseMessages}
       noData={{
-        when: () => embedUrl === '',
+        when: () => embedUrl === undefined,
         icon: 'dashboard',
         message: 'Dashboard not available'
       }}

--- a/src/modules/45-dashboards/pages/dashboardView/DashboardView.tsx
+++ b/src/modules/45-dashboards/pages/dashboardView/DashboardView.tsx
@@ -44,7 +44,7 @@ const DashboardViewPage: React.FC = () => {
   } = useCreateSignedUrl({ queryParams: { accountId, dashboardId: viewId, src: signedQueryUrl } })
 
   const generateSignedUrl = async (): Promise<void> => {
-    const { resource } = await createSignedUrl()
+    const { resource = '' } = (await createSignedUrl()) || {}
     setEmbedUrl(resource)
   }
 
@@ -99,7 +99,15 @@ const DashboardViewPage: React.FC = () => {
       }}
     >
       <Layout.Vertical className={css.frame}>
-        <iframe src={embedUrl} key={iframeState} height="100%" width="100%" frameBorder="0" id="dashboard-render" />
+        <iframe
+          src={embedUrl}
+          key={iframeState}
+          height="100%"
+          width="100%"
+          frameBorder="0"
+          id="dashboard-render"
+          data-testid="dashboard-iframe"
+        />
       </Layout.Vertical>
     </Page.Body>
   )

--- a/src/modules/45-dashboards/pages/dashboardView/__tests__/DashboardView.test.tsx
+++ b/src/modules/45-dashboards/pages/dashboardView/__tests__/DashboardView.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react'
-import { render, RenderResult, screen } from '@testing-library/react'
+import { render, RenderResult, screen, waitFor } from '@testing-library/react'
 import { TestWrapper } from '@common/utils/testUtils'
 import routes from '@common/RouteDefinitions'
 import { accountPathProps } from '@common/utils/routeUtils'
@@ -34,6 +34,12 @@ jest.mock('@dashboards/pages/DashboardsContext', () => ({
 
 const useDashboardsContextMock = useDashboardsContext as jest.Mock
 
+const generateMockSignedUrl = (mockUrl = ''): Promise<sharedService.SignedUrlResponse> => {
+  return new Promise(resolve => {
+    resolve({ resource: mockUrl })
+  })
+}
+
 describe('DashboardView', () => {
   const useCreateSignedUrlMock = jest.spyOn(sharedService, 'useCreateSignedUrl')
   const useGetDashboardDetailMock = jest.spyOn(sharedService, 'useGetDashboardDetail')
@@ -47,7 +53,7 @@ describe('DashboardView', () => {
     useGetDashboardDetailMock.mockReturnValue({ resource: true, title: 'dashboard name' } as any)
     useDashboardsContextMock.mockReturnValue({ includeBreadcrumbs: includeBreadcrumbs, breadcrumbs: [] })
     useCreateSignedUrlMock.mockReturnValue({
-      mutate: () => new Promise(() => void 0),
+      mutate: generateMockSignedUrl,
       loading: true,
       error: null
     } as any)
@@ -59,9 +65,21 @@ describe('DashboardView', () => {
     expect(screen.getByText('Loading, please wait...')).toBeInTheDocument()
   })
 
+  test('it should display Dashboard iframe when dashboard URL returned', async () => {
+    useCreateSignedUrlMock.mockReturnValue({
+      mutate: () => generateMockSignedUrl('mockUrl'),
+      loading: false,
+      error: null
+    } as any)
+
+    renderComponent()
+
+    await waitFor(() => expect(screen.getByTestId('dashboard-iframe')).toBeInTheDocument())
+  })
+
   test('it should display Dashboard not available when dashboard request returns no URL', async () => {
     useCreateSignedUrlMock.mockReturnValue({
-      mutate: () => new Promise(() => void 0),
+      mutate: generateMockSignedUrl,
       loading: false,
       error: null
     } as any)
@@ -74,7 +92,7 @@ describe('DashboardView', () => {
   test('it should display an error message when dashboard request fails', async () => {
     const testErrorMessage = 'this the actual error message'
     useCreateSignedUrlMock.mockReturnValue({
-      mutate: () => new Promise(() => void 0),
+      mutate: generateMockSignedUrl,
       loading: false,
       error: { data: { responseMessages: testErrorMessage } }
     } as any)

--- a/src/modules/45-dashboards/pages/dashboardView/__tests__/DashboardView.test.tsx
+++ b/src/modules/45-dashboards/pages/dashboardView/__tests__/DashboardView.test.tsx
@@ -114,6 +114,12 @@ describe('DashboardView', () => {
   test('it should include a dashboard in breadcrumbs when a dashboard details has been retrieved', async () => {
     useGetFolderDetailMock.mockReturnValue({ data: null } as any)
 
+    useCreateSignedUrlMock.mockReturnValue({
+      mutate: () => generateMockSignedUrl('mockUrl'),
+      loading: false,
+      error: null
+    } as any)
+
     const mockDashboardTitle = 'Test Dashboard'
     const mockDashboardDetail: sharedService.GetDashboardDetailResponse = {
       resource: true,
@@ -121,6 +127,8 @@ describe('DashboardView', () => {
     }
     useGetDashboardDetailMock.mockReturnValue({ data: mockDashboardDetail } as any)
     renderComponent()
+
+    await waitFor(() => expect(screen.getByTestId('dashboard-iframe')).toBeInTheDocument())
 
     expect(includeBreadcrumbs).toBeCalledWith([
       { label: mockDashboardTitle, url: `/account/${accountId}/dashboards/folder/${folderId}/view/${viewId}` }


### PR DESCRIPTION
### Summary

- A fix has been applied to prevent a potential TypeError occurring when a Dashboard signedUrl isn't returned from the Dashboard Service.

#### Screenshots

N/A

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [X] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier: `fix prettier`
</details>
