### PR TITLE
fix: [CDS-38365]: Openshift template and param support added for custom manifest, and runtimeview implemented for file store

### DIFF
--- a/src/modules/31-filestore/components/FileStoreList/FileStoreList.module.scss.d.ts
+++ b/src/modules/31-filestore/components/FileStoreList/FileStoreList.module.scss.d.ts
@@ -7,6 +7,7 @@
  **/
 // this is an auto-generated file, do not update this manually
 declare const styles: {
+  readonly expressiondWrapper: string
   readonly group: string
   readonly label: string
   readonly selectFieldContainer: string

--- a/src/modules/31-filestore/components/MultiTypeFileSelect/FileStoreSelect/FileStoreSelectField.tsx
+++ b/src/modules/31-filestore/components/MultiTypeFileSelect/FileStoreSelect/FileStoreSelectField.tsx
@@ -49,7 +49,7 @@ export interface FileStoreFieldData {
 function FileStoreInput(props: FormikFileStoreInput): React.ReactElement {
   const { getString } = useStrings()
   const { formik, label, name, tooltipProps, placeholder, readonly = false, onChange } = props
-  const fileStoreValue = get(formik.values, name)
+  const fileStoreValue = get(formik?.values, name)
   const prepareFileStoreValue = (scopeType: string, path: string): string => {
     switch (scopeType) {
       case Scope.ACCOUNT:

--- a/src/modules/70-pipeline/components/ManifestSelection/ManifestInterface.ts
+++ b/src/modules/70-pipeline/components/ManifestSelection/ManifestInterface.ts
@@ -208,8 +208,9 @@ export interface HarnessFileStoreFormData {
 export interface CustomManifestManifestDataType {
   identifier: string
   extractionScript: string
-  valuesPaths: Array<any> | string
-  skipResourceVersioning: boolean
   filePath: string
   delegateSelectors: Array<string> | string
+  valuesPaths?: Array<{ path: string }> | string
+  paramsPaths?: Array<{ path: string }> | string
+  skipResourceVersioning?: boolean
 }

--- a/src/modules/70-pipeline/components/ManifestSelection/ManifestListView/ManifestListView.tsx
+++ b/src/modules/70-pipeline/components/ManifestSelection/ManifestListView/ManifestListView.tsx
@@ -323,12 +323,15 @@ function ManifestListView({
   const getLastSteps = useCallback((): Array<React.ReactElement<StepProps<ConnectorConfigDTO>>> => {
     const arr: Array<React.ReactElement<StepProps<ConnectorConfigDTO>>> = []
     let manifestDetailStep = null
+    const isGitTypeStores = [
+      ManifestStoreMap.Git,
+      ManifestStoreMap.Github,
+      ManifestStoreMap.GitLab,
+      ManifestStoreMap.Bitbucket
+    ].includes(manifestStore as ManifestStores)
 
     switch (true) {
-      case selectedManifest === ManifestDataType.HelmChart &&
-        [ManifestStoreMap.Git, ManifestStoreMap.Github, ManifestStoreMap.GitLab, ManifestStoreMap.Bitbucket].includes(
-          manifestStore as ManifestStores
-        ):
+      case selectedManifest === ManifestDataType.HelmChart && isGitTypeStores:
         manifestDetailStep = <HelmWithGIT {...lastStepProps()} />
         break
       case selectedManifest === ManifestDataType.HelmChart && manifestStore === ManifestStoreMap.Http:
@@ -343,16 +346,16 @@ function ManifestListView({
       case selectedManifest === ManifestDataType.HelmChart && manifestStore === ManifestStoreMap.Gcs:
         manifestDetailStep = <HelmWithGcs {...lastStepProps()} />
         break
-      case selectedManifest === ManifestDataType.OpenshiftTemplate:
+      case selectedManifest === ManifestDataType.OpenshiftTemplate && isGitTypeStores:
         manifestDetailStep = <OpenShiftTemplateWithGit {...lastStepProps()} />
         break
       case selectedManifest === ManifestDataType.Kustomize:
         manifestDetailStep = <KustomizeWithGIT {...lastStepProps()} />
         break
-      case selectedManifest === ManifestDataType.OpenshiftParam:
+      case selectedManifest === ManifestDataType.OpenshiftParam && isGitTypeStores:
         manifestDetailStep = <OpenShiftParamWithGit {...lastStepProps()} />
         break
-      case selectedManifest === ManifestDataType.KustomizePatches:
+      case selectedManifest === ManifestDataType.KustomizePatches && isGitTypeStores:
         manifestDetailStep = <KustomizePatchDetails {...lastStepProps()} />
         break
       case selectedManifest === ManifestDataType.ServerlessAwsLambda:
@@ -376,9 +379,7 @@ function ManifestListView({
         manifestDetailStep = <CustomRemoteManifest {...lastStepProps()} />
         break
       case [ManifestDataType.K8sManifest, ManifestDataType.Values].includes(selectedManifest as ManifestTypes) &&
-        [ManifestStoreMap.Git, ManifestStoreMap.Github, ManifestStoreMap.GitLab, ManifestStoreMap.Bitbucket].includes(
-          manifestStore as ManifestStores
-        ):
+        isGitTypeStores:
       default:
         manifestDetailStep = <K8sValuesManifest {...lastStepProps()} />
         break

--- a/src/modules/70-pipeline/components/ManifestSelection/ManifestWizardSteps/HarnessFileStore/__tests__/__snapshots__/HarnessFileStore.test.tsx.snap
+++ b/src/modules/70-pipeline/components/ManifestSelection/ManifestWizardSteps/HarnessFileStore/__tests__/__snapshots__/HarnessFileStore.test.tsx.snap
@@ -1,0 +1,789 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Custom remote tests initial rendering 1`] = `
+<div>
+  <div
+    class="Layout--vertical Layout--layout-spacing-medium StyledProps--main optionsViewContainer"
+    style="height: inherit;"
+  >
+    <p
+      class="StyledProps--font StyledProps--main StyledProps--font-variation-h3 StyledProps--margin-bottom-medium"
+    >
+      Manifest details
+    </p>
+    <div
+      class="OverlaySpinner--overlaySpinner"
+    >
+      <form
+        action="#"
+      >
+        <div
+          class="Layout--vertical StyledProps--main manifestForm StyledProps--flex StyledProps--flex-justifyContent-space-between StyledProps--flex-alignItems-flex-start"
+        >
+          <div
+            class="manifestStepWidth"
+          >
+            <div
+              class="halfWidth"
+            >
+              <div
+                class="bp3-form-group"
+              >
+                <label
+                  class="bp3-label"
+                  for="identifier"
+                >
+                  <span
+                    class="Tooltip--acenter"
+                    data-tooltip-id="manifestDetails_identifier"
+                  >
+                    pipeline.manifestType.manifestIdentifier
+                  </span>
+                   
+                  <span
+                    class="bp3-text-muted"
+                  />
+                </label>
+                <div
+                  class="bp3-form-content"
+                >
+                  <div
+                    class="bp3-input-group"
+                  >
+                    <input
+                      autocomplete="off"
+                      class="bp3-input"
+                      name="identifier"
+                      placeholder="pipeline.manifestType.manifestPlaceholder"
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="halfWidth"
+            >
+              <div
+                class="bp3-form-group"
+              >
+                <label
+                  class="bp3-label"
+                  for="files"
+                >
+                  <div
+                    class="formLabel"
+                  >
+                    <span
+                      class="Tooltip--acenter"
+                      data-tooltip-id="manifestDetails_files"
+                    >
+                      resourcePage.fileStore
+                    </span>
+                    <div
+                      class="bp3-popover-wrapper typeSelectorWrapper"
+                    >
+                      <div
+                        class="bp3-popover-target typeSelector"
+                      >
+                        <button
+                          class="bp3-button bp3-minimal Button--button StyledProps--font StyledProps--main btn Button--iconOnly Button--without-shadow"
+                          type="button"
+                        >
+                          <span
+                            class="bp3-button-text"
+                          >
+                            <span
+                              class="bp3-icon StyledProps--main icon fixed"
+                              data-icon="fixed-input"
+                            >
+                              <svg
+                                height="12"
+                                viewBox="0 0 9 9"
+                                width="12"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M5.61 7.55c.62-.7.3-1.42.18-2.35a.32.32 0 01.1-.29l1.43-1.42a.76.76 0 01.28-.15c.39-.1 1 0 1.28-.29a.34.34 0 000-.51L6.46.12a.33.33 0 00-.52 0c-.28.29-.2.9-.28 1.3a.53.53 0 01-.13.23L4.09 3.12a.29.29 0 01-.28.09c-.89-.11-1.6-.49-2.27.11-.29.26-.29.43 0 .7l1.31 1.34.15.16-.15.15-2.7 2.69a.36.36 0 000 .54.36.36 0 00.54-.05l2.63-2.68.17-.17.17.16c.45.46.9.91 1.36 1.36.21.21.42.22.59.03z"
+                                  fill="currentColor"
+                                />
+                              </svg>
+                            </span>
+                          </span>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                   
+                  <span
+                    class="bp3-text-muted"
+                  />
+                </label>
+                <div
+                  class="bp3-form-content"
+                >
+                  <div
+                    class="Layout--vertical StyledProps--main"
+                  >
+                    <div
+                      class="Layout--horizontal StyledProps--main StyledProps--margin-top-medium"
+                    >
+                      <div
+                        class="bp3-form-group"
+                        style="width: 100%;"
+                      >
+                        <div
+                          class="bp3-form-content"
+                        >
+                          <div
+                            class="Layout--vertical StyledProps--main"
+                          >
+                            <div
+                              class="StyledProps--font StyledProps--main container StyledProps--flex StyledProps--flex-alignItems-center StyledProps--flex-justifyContent-space-between"
+                            >
+                              <p
+                                class="StyledProps--font StyledProps--main StyledProps--color StyledProps--color-grey500 StyledProps--padding-left-xsmall"
+                              >
+                                - 
+                                select
+                                 -
+                              </p>
+                              <div
+                                class="StyledProps--font StyledProps--main StyledProps--padding-right-small"
+                              >
+                                <span
+                                  class="bp3-icon bp3-icon-chevron-down StyledProps--main StyledProps--margin-right-small StyledProps--margin-left-small"
+                                  icon="chevron-down"
+                                >
+                                  <svg
+                                    data-icon="chevron-down"
+                                    height="16"
+                                    viewBox="0 0 16 16"
+                                    width="16"
+                                  >
+                                    <desc>
+                                      chevron-down
+                                    </desc>
+                                    <path
+                                      d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                                      fill-rule="evenodd"
+                                    />
+                                  </svg>
+                                </span>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <span>
+                      <button
+                        class="bp3-button bp3-minimal Button--button StyledProps--font StyledProps--main Button--with-current-color Button--without-shadow Button--variation Button--variation-primary"
+                        type="button"
+                      >
+                        <span
+                          class="bp3-button-text"
+                        >
+                          add
+                        </span>
+                      </button>
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="halfWidth"
+            >
+              <div
+                class="bp3-form-group"
+              >
+                <label
+                  class="bp3-label"
+                  for="valuesPaths"
+                >
+                  <div
+                    class="formLabel"
+                  >
+                    <span
+                      class="Tooltip--acenter"
+                      data-tooltip-id="manifestDetails_valuesPaths"
+                    >
+                      pipeline.manifestType.valuesYamlPath
+                    </span>
+                    <div
+                      class="bp3-popover-wrapper typeSelectorWrapper"
+                    >
+                      <div
+                        class="bp3-popover-target typeSelector"
+                      >
+                        <button
+                          class="bp3-button bp3-minimal Button--button StyledProps--font StyledProps--main btn Button--iconOnly Button--without-shadow"
+                          type="button"
+                        >
+                          <span
+                            class="bp3-button-text"
+                          >
+                            <span
+                              class="bp3-icon StyledProps--main icon fixed"
+                              data-icon="fixed-input"
+                            >
+                              <svg
+                                height="12"
+                                viewBox="0 0 9 9"
+                                width="12"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M5.61 7.55c.62-.7.3-1.42.18-2.35a.32.32 0 01.1-.29l1.43-1.42a.76.76 0 01.28-.15c.39-.1 1 0 1.28-.29a.34.34 0 000-.51L6.46.12a.33.33 0 00-.52 0c-.28.29-.2.9-.28 1.3a.53.53 0 01-.13.23L4.09 3.12a.29.29 0 01-.28.09c-.89-.11-1.6-.49-2.27.11-.29.26-.29.43 0 .7l1.31 1.34.15.16-.15.15-2.7 2.69a.36.36 0 000 .54.36.36 0 00.54-.05l2.63-2.68.17-.17.17.16c.45.46.9.91 1.36 1.36.21.21.42.22.59.03z"
+                                  fill="currentColor"
+                                />
+                              </svg>
+                            </span>
+                          </span>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                   
+                  <span
+                    class="bp3-text-muted"
+                  />
+                </label>
+                <div
+                  class="bp3-form-content"
+                >
+                  <div
+                    class="Layout--vertical StyledProps--main"
+                  >
+                    <div
+                      class="Layout--horizontal StyledProps--main StyledProps--margin-top-medium"
+                    >
+                      <div
+                        class="bp3-form-group"
+                        style="width: 100%;"
+                      >
+                        <div
+                          class="bp3-form-content"
+                        >
+                          <div
+                            class="Layout--vertical StyledProps--main"
+                          >
+                            <div
+                              class="StyledProps--font StyledProps--main container StyledProps--flex StyledProps--flex-alignItems-center StyledProps--flex-justifyContent-space-between"
+                            >
+                              <p
+                                class="StyledProps--font StyledProps--main StyledProps--color StyledProps--color-grey500 StyledProps--padding-left-xsmall"
+                              >
+                                - 
+                                select
+                                 -
+                              </p>
+                              <div
+                                class="StyledProps--font StyledProps--main StyledProps--padding-right-small"
+                              >
+                                <span
+                                  class="bp3-icon bp3-icon-chevron-down StyledProps--main StyledProps--margin-right-small StyledProps--margin-left-small"
+                                  icon="chevron-down"
+                                >
+                                  <svg
+                                    data-icon="chevron-down"
+                                    height="16"
+                                    viewBox="0 0 16 16"
+                                    width="16"
+                                  >
+                                    <desc>
+                                      chevron-down
+                                    </desc>
+                                    <path
+                                      d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                                      fill-rule="evenodd"
+                                    />
+                                  </svg>
+                                </span>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <span>
+                      <button
+                        class="bp3-button bp3-minimal Button--button StyledProps--font StyledProps--main Button--with-current-color Button--without-shadow Button--variation Button--variation-primary"
+                        type="button"
+                      >
+                        <span
+                          class="bp3-button-text"
+                        >
+                          add
+                        </span>
+                      </button>
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="Layout--horizontal Layout--layout-spacing-medium StyledProps--main saveBtn"
+          >
+            <button
+              class="bp3-button Button--button StyledProps--font StyledProps--main Button--with-current-color Button--withLeftIcon Button--variation Button--variation-secondary"
+              type="button"
+            >
+              <span
+                class="bp3-icon bp3-icon-chevron-left StyledProps--main StyledProps--padding-right-xsmall"
+                icon="chevron-left"
+              >
+                <svg
+                  data-icon="chevron-left"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  width="16"
+                >
+                  <desc>
+                    chevron-left
+                  </desc>
+                  <path
+                    d="M7.41 8l3.29-3.29c.19-.18.3-.43.3-.71a1.003 1.003 0 00-1.71-.71l-4 4C5.11 7.47 5 7.72 5 8c0 .28.11.53.29.71l4 4a1.003 1.003 0 001.42-1.42L7.41 8z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
+              <span
+                class="bp3-button-text"
+              >
+                back
+              </span>
+            </button>
+            <button
+              class="bp3-button Button--button StyledProps--font StyledProps--main Button--with-current-color Button--withRightIcon Button--variation Button--variation-primary"
+              type="submit"
+            >
+              <span
+                class="bp3-button-text"
+              >
+                submit
+              </span>
+              <span
+                class="bp3-icon bp3-icon-chevron-right StyledProps--main"
+                icon="chevron-right"
+              >
+                <svg
+                  data-icon="chevron-right"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  width="16"
+                >
+                  <desc>
+                    chevron-right
+                  </desc>
+                  <path
+                    d="M10.71 7.29l-4-4a1.003 1.003 0 00-1.42 1.42L8.59 8 5.3 11.29c-.19.18-.3.43-.3.71a1.003 1.003 0 001.71.71l4-4c.18-.18.29-.43.29-.71 0-.28-.11-.53-.29-.71z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Custom remote tests when fields are runtime input 1`] = `
+<div>
+  <div
+    class="Layout--vertical Layout--layout-spacing-medium StyledProps--main optionsViewContainer"
+    style="height: inherit;"
+  >
+    <p
+      class="StyledProps--font StyledProps--main StyledProps--font-variation-h3 StyledProps--margin-bottom-medium"
+    >
+      Manifest details
+    </p>
+    <div
+      class="OverlaySpinner--overlaySpinner"
+    >
+      <form
+        action="#"
+      >
+        <div
+          class="Layout--vertical StyledProps--main manifestForm StyledProps--flex StyledProps--flex-justifyContent-space-between StyledProps--flex-alignItems-flex-start"
+        >
+          <div
+            class="manifestStepWidth"
+          >
+            <div
+              class="halfWidth"
+            >
+              <div
+                class="bp3-form-group"
+              >
+                <label
+                  class="bp3-label"
+                  for="identifier"
+                >
+                  <span
+                    class="Tooltip--acenter"
+                    data-tooltip-id="manifestDetails_identifier"
+                  >
+                    pipeline.manifestType.manifestIdentifier
+                  </span>
+                   
+                  <span
+                    class="bp3-text-muted"
+                  />
+                </label>
+                <div
+                  class="bp3-form-content"
+                >
+                  <div
+                    class="bp3-input-group"
+                  >
+                    <input
+                      autocomplete="off"
+                      class="bp3-input"
+                      name="identifier"
+                      placeholder="pipeline.manifestType.manifestPlaceholder"
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="halfWidth"
+            >
+              <div
+                class="bp3-form-group"
+              >
+                <label
+                  class="bp3-label"
+                  for="files"
+                >
+                  <div
+                    class="formLabel"
+                  >
+                    <span
+                      class="Tooltip--acenter"
+                      data-tooltip-id="manifestDetails_files"
+                    >
+                      resourcePage.fileStore
+                    </span>
+                    <div
+                      class="bp3-popover-wrapper typeSelectorWrapper"
+                    >
+                      <div
+                        class="bp3-popover-target typeSelector"
+                      >
+                        <button
+                          class="bp3-button bp3-minimal Button--button StyledProps--font StyledProps--main btn Button--iconOnly Button--without-shadow"
+                          type="button"
+                        >
+                          <span
+                            class="bp3-button-text"
+                          >
+                            <span
+                              class="bp3-icon StyledProps--main icon fixed"
+                              data-icon="fixed-input"
+                            >
+                              <svg
+                                height="12"
+                                viewBox="0 0 9 9"
+                                width="12"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M5.61 7.55c.62-.7.3-1.42.18-2.35a.32.32 0 01.1-.29l1.43-1.42a.76.76 0 01.28-.15c.39-.1 1 0 1.28-.29a.34.34 0 000-.51L6.46.12a.33.33 0 00-.52 0c-.28.29-.2.9-.28 1.3a.53.53 0 01-.13.23L4.09 3.12a.29.29 0 01-.28.09c-.89-.11-1.6-.49-2.27.11-.29.26-.29.43 0 .7l1.31 1.34.15.16-.15.15-2.7 2.69a.36.36 0 000 .54.36.36 0 00.54-.05l2.63-2.68.17-.17.17.16c.45.46.9.91 1.36 1.36.21.21.42.22.59.03z"
+                                  fill="currentColor"
+                                />
+                              </svg>
+                            </span>
+                          </span>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                   
+                  <span
+                    class="bp3-text-muted"
+                  />
+                </label>
+                <div
+                  class="bp3-form-content"
+                >
+                  <div
+                    class="Layout--vertical StyledProps--main"
+                  >
+                    <div
+                      class="Layout--horizontal StyledProps--main StyledProps--margin-top-medium"
+                    >
+                      <div
+                        class="bp3-form-group"
+                        style="width: 100%;"
+                      >
+                        <div
+                          class="bp3-form-content"
+                        >
+                          <div
+                            class="Layout--vertical StyledProps--main"
+                          >
+                            <div
+                              class="StyledProps--font StyledProps--main container StyledProps--flex StyledProps--flex-alignItems-center StyledProps--flex-justifyContent-space-between"
+                            >
+                              <p
+                                class="StyledProps--font StyledProps--main StyledProps--color StyledProps--color-grey500 StyledProps--padding-left-xsmall"
+                              >
+                                - 
+                                select
+                                 -
+                              </p>
+                              <div
+                                class="StyledProps--font StyledProps--main StyledProps--padding-right-small"
+                              >
+                                <span
+                                  class="bp3-icon bp3-icon-chevron-down StyledProps--main StyledProps--margin-right-small StyledProps--margin-left-small"
+                                  icon="chevron-down"
+                                >
+                                  <svg
+                                    data-icon="chevron-down"
+                                    height="16"
+                                    viewBox="0 0 16 16"
+                                    width="16"
+                                  >
+                                    <desc>
+                                      chevron-down
+                                    </desc>
+                                    <path
+                                      d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                                      fill-rule="evenodd"
+                                    />
+                                  </svg>
+                                </span>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <span>
+                      <button
+                        class="bp3-button bp3-minimal Button--button StyledProps--font StyledProps--main Button--with-current-color Button--without-shadow Button--variation Button--variation-primary"
+                        type="button"
+                      >
+                        <span
+                          class="bp3-button-text"
+                        >
+                          add
+                        </span>
+                      </button>
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="halfWidth"
+            >
+              <div
+                class="bp3-form-group"
+              >
+                <label
+                  class="bp3-label"
+                  for="valuesPaths"
+                >
+                  <div
+                    class="formLabel"
+                  >
+                    <span
+                      class="Tooltip--acenter"
+                      data-tooltip-id="manifestDetails_valuesPaths"
+                    >
+                      pipeline.manifestType.valuesYamlPath
+                    </span>
+                    <div
+                      class="bp3-popover-wrapper typeSelectorWrapper"
+                    >
+                      <div
+                        class="bp3-popover-target typeSelector"
+                      >
+                        <button
+                          class="bp3-button bp3-minimal Button--button StyledProps--font StyledProps--main btn Button--iconOnly Button--without-shadow"
+                          type="button"
+                        >
+                          <span
+                            class="bp3-button-text"
+                          >
+                            <span
+                              class="bp3-icon StyledProps--main icon fixed"
+                              data-icon="fixed-input"
+                            >
+                              <svg
+                                height="12"
+                                viewBox="0 0 9 9"
+                                width="12"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M5.61 7.55c.62-.7.3-1.42.18-2.35a.32.32 0 01.1-.29l1.43-1.42a.76.76 0 01.28-.15c.39-.1 1 0 1.28-.29a.34.34 0 000-.51L6.46.12a.33.33 0 00-.52 0c-.28.29-.2.9-.28 1.3a.53.53 0 01-.13.23L4.09 3.12a.29.29 0 01-.28.09c-.89-.11-1.6-.49-2.27.11-.29.26-.29.43 0 .7l1.31 1.34.15.16-.15.15-2.7 2.69a.36.36 0 000 .54.36.36 0 00.54-.05l2.63-2.68.17-.17.17.16c.45.46.9.91 1.36 1.36.21.21.42.22.59.03z"
+                                  fill="currentColor"
+                                />
+                              </svg>
+                            </span>
+                          </span>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                   
+                  <span
+                    class="bp3-text-muted"
+                  />
+                </label>
+                <div
+                  class="bp3-form-content"
+                >
+                  <div
+                    class="Layout--vertical StyledProps--main"
+                  >
+                    <div
+                      class="Layout--horizontal StyledProps--main StyledProps--margin-top-medium"
+                    >
+                      <div
+                        class="bp3-form-group"
+                        style="width: 100%;"
+                      >
+                        <div
+                          class="bp3-form-content"
+                        >
+                          <div
+                            class="Layout--vertical StyledProps--main"
+                          >
+                            <div
+                              class="StyledProps--font StyledProps--main container StyledProps--flex StyledProps--flex-alignItems-center StyledProps--flex-justifyContent-space-between"
+                            >
+                              <p
+                                class="StyledProps--font StyledProps--main StyledProps--color StyledProps--color-grey500 StyledProps--padding-left-xsmall"
+                              >
+                                - 
+                                select
+                                 -
+                              </p>
+                              <div
+                                class="StyledProps--font StyledProps--main StyledProps--padding-right-small"
+                              >
+                                <span
+                                  class="bp3-icon bp3-icon-chevron-down StyledProps--main StyledProps--margin-right-small StyledProps--margin-left-small"
+                                  icon="chevron-down"
+                                >
+                                  <svg
+                                    data-icon="chevron-down"
+                                    height="16"
+                                    viewBox="0 0 16 16"
+                                    width="16"
+                                  >
+                                    <desc>
+                                      chevron-down
+                                    </desc>
+                                    <path
+                                      d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                                      fill-rule="evenodd"
+                                    />
+                                  </svg>
+                                </span>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <span>
+                      <button
+                        class="bp3-button bp3-minimal Button--button StyledProps--font StyledProps--main Button--with-current-color Button--without-shadow Button--variation Button--variation-primary"
+                        type="button"
+                      >
+                        <span
+                          class="bp3-button-text"
+                        >
+                          add
+                        </span>
+                      </button>
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="Layout--horizontal Layout--layout-spacing-medium StyledProps--main saveBtn"
+          >
+            <button
+              class="bp3-button Button--button StyledProps--font StyledProps--main Button--with-current-color Button--withLeftIcon Button--variation Button--variation-secondary"
+              type="button"
+            >
+              <span
+                class="bp3-icon bp3-icon-chevron-left StyledProps--main StyledProps--padding-right-xsmall"
+                icon="chevron-left"
+              >
+                <svg
+                  data-icon="chevron-left"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  width="16"
+                >
+                  <desc>
+                    chevron-left
+                  </desc>
+                  <path
+                    d="M7.41 8l3.29-3.29c.19-.18.3-.43.3-.71a1.003 1.003 0 00-1.71-.71l-4 4C5.11 7.47 5 7.72 5 8c0 .28.11.53.29.71l4 4a1.003 1.003 0 001.42-1.42L7.41 8z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
+              <span
+                class="bp3-button-text"
+              >
+                back
+              </span>
+            </button>
+            <button
+              class="bp3-button Button--button StyledProps--font StyledProps--main Button--with-current-color Button--withRightIcon Button--variation Button--variation-primary"
+              type="submit"
+            >
+              <span
+                class="bp3-button-text"
+              >
+                submit
+              </span>
+              <span
+                class="bp3-icon bp3-icon-chevron-right StyledProps--main"
+                icon="chevron-right"
+              >
+                <svg
+                  data-icon="chevron-right"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  width="16"
+                >
+                  <desc>
+                    chevron-right
+                  </desc>
+                  <path
+                    d="M10.71 7.29l-4-4a1.003 1.003 0 00-1.42 1.42L8.59 8 5.3 11.29c-.19.18-.3.43-.3.71a1.003 1.003 0 001.71.71l4-4c.18-.18.29-.43.29-.71 0-.28-.11-.53-.29-.71z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+`;

--- a/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/ManifestSource/HelmChartManifestSource/HelmChartManifestSource.tsx
+++ b/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/ManifestSource/HelmChartManifestSource/HelmChartManifestSource.tsx
@@ -25,6 +25,8 @@ import { GitConfigDTO, useGetBucketListForS3, useGetGCSBucketList } from 'servic
 import { TriggerDefaultFieldList } from '@triggers/pages/triggers/utils/TriggersWizardPageUtils'
 import type { Scope } from '@common/interfaces/SecretsInterface'
 import type { CommandFlags } from '@pipeline/components/ManifestSelection/ManifestInterface'
+import { FileSelectList } from '@filestore/components/FileStoreList/FileStoreList'
+import { SELECT_FILES_TYPE } from '@filestore/utils/constants'
 import {
   getDefaultQueryParam,
   getFinalQueryParamData,
@@ -36,6 +38,7 @@ import {
 import { isFieldFixedType, isFieldRuntime } from '../../K8sServiceSpecHelper'
 import ExperimentalInput from '../../K8sServiceSpecForms/ExperimentalInput'
 import CustomRemoteManifestRuntimeFields from '../ManifestSourceRuntimeFields/CustomRemoteManifestRuntimeFields'
+import ManifestCommonRuntimeFields from '../ManifestSourceRuntimeFields/ManifestCommonRuntimeFields'
 import css from '../../KubernetesManifests/KubernetesManifests.module.scss'
 
 const Content = (props: ManifestSourceRenderProps): React.ReactElement => {
@@ -60,6 +63,7 @@ const Content = (props: ManifestSourceRenderProps): React.ReactElement => {
   const { getString } = useStrings()
   const { expressions } = useVariablesExpression()
   const [showRepoName, setShowRepoName] = useState(true)
+  const manifestStoreType = get(template, `${manifestPath}.spec.store.type`, null)
 
   const { data: regionData } = useListAwsRegions({
     queryParams: {
@@ -139,7 +143,6 @@ const Content = (props: ManifestSourceRenderProps): React.ReactElement => {
   }
 
   const renderBucketListforS3Gcs = (): React.ReactElement | null => {
-    const manifestStoreType = get(template, `${manifestPath}.spec.store.type`, null)
     if (manifestStoreType === ManifestStoreMap.S3) {
       return (
         <ExperimentalInput
@@ -428,20 +431,35 @@ const Content = (props: ManifestSourceRenderProps): React.ReactElement => {
 
       {isFieldRuntime(`${manifestPath}.spec.valuesPaths`, template) && (
         <div className={css.verticalSpacingInput}>
-          <List
-            labelClassName={css.listLabel}
-            label={getString('pipeline.manifestType.valuesYamlPath')}
-            name={`${path}.${manifestPath}.spec.valuesPaths`}
-            placeholder={getString('pipeline.manifestType.manifestPathPlaceholder')}
-            disabled={isFieldDisabled(`${manifestPath}.spec.valuesPaths`)}
-            style={{ marginBottom: 'var(--spacing-small)' }}
-            expressions={expressions}
-            isNameOfArrayType
-          />
+          {manifestStoreType === ManifestStoreMap.Harness ? (
+            <FileSelectList
+              labelClassName={css.listLabel}
+              label={getString('pipeline.manifestType.valuesYamlPath')}
+              name={`${path}.${manifestPath}.spec.valuesPaths`}
+              placeholder={getString('pipeline.manifestType.manifestPathPlaceholder')}
+              disabled={isFieldDisabled(`${manifestPath}.spec.valuesPaths`)}
+              style={{ marginBottom: 'var(--spacing-small)' }}
+              expressions={expressions}
+              isNameOfArrayType
+              type={SELECT_FILES_TYPE.FILE_STORE}
+              formik={formik}
+            />
+          ) : (
+            <List
+              labelClassName={css.listLabel}
+              label={getString('pipeline.manifestType.valuesYamlPath')}
+              name={`${path}.${manifestPath}.spec.valuesPaths`}
+              placeholder={getString('pipeline.manifestType.manifestPathPlaceholder')}
+              disabled={isFieldDisabled(`${manifestPath}.spec.valuesPaths`)}
+              style={{ marginBottom: 'var(--spacing-small)' }}
+              expressions={expressions}
+              isNameOfArrayType
+            />
+          )}
         </div>
       )}
       <CustomRemoteManifestRuntimeFields {...props} />
-
+      <ManifestCommonRuntimeFields {...props} />
       {isFieldRuntime(`${manifestPath}.spec.skipResourceVersioning`, template) && (
         <div className={css.verticalSpacingInput}>
           <FormMultiTypeCheckboxField

--- a/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/ManifestSource/KustomizeManifestSource/KustomizeManifestSource.tsx
+++ b/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/ManifestSource/KustomizeManifestSource/KustomizeManifestSource.tsx
@@ -17,6 +17,7 @@ import List from '@common/components/List/List'
 import { isFieldRuntime } from '../../K8sServiceSpecHelper'
 import { isFieldfromTriggerTabDisabled } from '../ManifestSourceUtils'
 import ManifestGitStoreRuntimeFields from '../ManifestSourceRuntimeFields/ManifestGitStoreRuntimeFields'
+import ManifestCommonRuntimeFields from '../ManifestSourceRuntimeFields/ManifestCommonRuntimeFields'
 import css from '../../KubernetesManifests/KubernetesManifests.module.scss'
 
 const Content = (props: ManifestSourceRenderProps): React.ReactElement => {
@@ -46,6 +47,7 @@ const Content = (props: ManifestSourceRenderProps): React.ReactElement => {
       className={cx(css.inputWidth, css.layoutVerticalSpacing)}
     >
       <ManifestGitStoreRuntimeFields {...props} />
+      <ManifestCommonRuntimeFields {...props} />
       {isFieldRuntime(`${manifestPath}.spec.store.spec.folderPath`, template) && (
         <div className={css.verticalSpacingInput}>
           <FormInput.MultiTextInput

--- a/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/ManifestSource/KustomizePatchesManifestSource/KustomizePatchesManifestSource.tsx
+++ b/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/ManifestSource/KustomizePatchesManifestSource/KustomizePatchesManifestSource.tsx
@@ -16,6 +16,7 @@ import List from '@common/components/List/List'
 import { isFieldRuntime } from '../../K8sServiceSpecHelper'
 import { isFieldfromTriggerTabDisabled } from '../ManifestSourceUtils'
 import ManifestGitStoreRuntimeFields from '../ManifestSourceRuntimeFields/ManifestGitStoreRuntimeFields'
+import ManifestCommonRuntimeFields from '../ManifestSourceRuntimeFields/ManifestCommonRuntimeFields'
 import css from '../../KubernetesManifests/KubernetesManifests.module.scss'
 
 const Content = (props: ManifestSourceRenderProps): React.ReactElement => {
@@ -44,6 +45,7 @@ const Content = (props: ManifestSourceRenderProps): React.ReactElement => {
       className={cx(css.inputWidth, css.layoutVerticalSpacing)}
     >
       <ManifestGitStoreRuntimeFields {...props} />
+      <ManifestCommonRuntimeFields {...props} />
       {isFieldRuntime(`${manifestPath}.spec.store.spec.paths`, template) && (
         <div className={css.verticalSpacingInput}>
           <List

--- a/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/ManifestSource/ManifestSourceRuntimeFields/K8sValuesYamlManifestContent.tsx
+++ b/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/ManifestSource/ManifestSourceRuntimeFields/K8sValuesYamlManifestContent.tsx
@@ -8,15 +8,20 @@
 import React from 'react'
 import cx from 'classnames'
 import { Layout } from '@harness/uicore'
+import { get } from 'lodash-es'
 import { StringKeys, useStrings } from 'framework/strings'
 import { useVariablesExpression } from '@pipeline/components/PipelineStudio/PiplineHooks/useVariablesExpression'
 import { FormMultiTypeCheckboxField } from '@common/components'
 import List from '@common/components/List/List'
 import type { ManifestSourceRenderProps } from '@cd/factory/ManifestSourceFactory/ManifestSourceBase'
+import { FileSelectList } from '@filestore/components/FileStoreList/FileStoreList'
+import { SELECT_FILES_TYPE } from '@filestore/utils/constants'
+import { ManifestStoreMap } from '@pipeline/components/ManifestSelection/Manifesthelper'
 import { isFieldRuntime } from '../../K8sServiceSpecHelper'
 import { isFieldfromTriggerTabDisabled } from '../ManifestSourceUtils'
 import ManifestGitStoreRuntimeFields from './ManifestGitStoreRuntimeFields'
 import CustomRemoteManifestRuntimeFields from './CustomRemoteManifestRuntimeFields'
+import ManifestCommonRuntimeFields from './ManifestCommonRuntimeFields'
 import css from '../../KubernetesManifests/KubernetesManifests.module.scss'
 
 interface K8sValuesYamlManifestRenderProps extends ManifestSourceRenderProps {
@@ -37,7 +42,7 @@ const K8sValuesYamlManifestContent = (props: K8sValuesYamlManifestRenderProps): 
   } = props
   const { getString } = useStrings()
   const { expressions } = useVariablesExpression()
-
+  const manifestStoreType = get(template, `${manifestPath}.spec.store.type`, null)
   const isFieldDisabled = (fieldName: string): boolean => {
     // /* instanbul ignore else */
     if (readonly) {
@@ -51,7 +56,6 @@ const K8sValuesYamlManifestContent = (props: K8sValuesYamlManifestRenderProps): 
       fromTrigger
     )
   }
-
   return (
     <Layout.Vertical
       data-name="manifest"
@@ -59,6 +63,7 @@ const K8sValuesYamlManifestContent = (props: K8sValuesYamlManifestRenderProps): 
       className={cx(css.inputWidth, css.layoutVerticalSpacing)}
     >
       <ManifestGitStoreRuntimeFields {...props} />
+      <ManifestCommonRuntimeFields {...props} />
       <CustomRemoteManifestRuntimeFields {...props} />
       {isFieldRuntime(`${manifestPath}.spec.store.spec.paths`, template) && (
         <div className={css.verticalSpacingInput}>
@@ -77,16 +82,31 @@ const K8sValuesYamlManifestContent = (props: K8sValuesYamlManifestRenderProps): 
 
       {isFieldRuntime(`${manifestPath}.spec.valuesPaths`, template) && (
         <div className={css.verticalSpacingInput}>
-          <List
-            labelClassName={css.listLabel}
-            label={getString('pipeline.manifestType.valuesYamlPath')}
-            name={`${path}.${manifestPath}.spec.valuesPaths`}
-            placeholder={getString('pipeline.manifestType.manifestPathPlaceholder')}
-            disabled={isFieldDisabled(`${manifestPath}.spec.valuesPaths`)}
-            style={{ marginBottom: 'var(--spacing-small)' }}
-            expressions={expressions}
-            isNameOfArrayType
-          />
+          {manifestStoreType === ManifestStoreMap.Harness ? (
+            <FileSelectList
+              labelClassName={css.listLabel}
+              label={getString('pipeline.manifestType.valuesYamlPath')}
+              name={`${path}.${manifestPath}.spec.valuesPaths`}
+              placeholder={getString('pipeline.manifestType.manifestPathPlaceholder')}
+              disabled={isFieldDisabled(`${manifestPath}.spec.valuesPaths`)}
+              style={{ marginBottom: 'var(--spacing-small)' }}
+              expressions={expressions}
+              isNameOfArrayType
+              type={SELECT_FILES_TYPE.FILE_STORE}
+              formik={formik}
+            />
+          ) : (
+            <List
+              labelClassName={css.listLabel}
+              label={getString('pipeline.manifestType.valuesYamlPath')}
+              name={`${path}.${manifestPath}.spec.valuesPaths`}
+              placeholder={getString('pipeline.manifestType.manifestPathPlaceholder')}
+              disabled={isFieldDisabled(`${manifestPath}.spec.valuesPaths`)}
+              style={{ marginBottom: 'var(--spacing-small)' }}
+              expressions={expressions}
+              isNameOfArrayType
+            />
+          )}
         </div>
       )}
 

--- a/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/ManifestSource/ManifestSourceRuntimeFields/ManifestCommonRuntimeFields.tsx
+++ b/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/ManifestSource/ManifestSourceRuntimeFields/ManifestCommonRuntimeFields.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import React from 'react'
+import type { ManifestSourceRenderProps } from '@cd/factory/ManifestSourceFactory/ManifestSourceBase'
+import { useStrings } from 'framework/strings'
+import { useVariablesExpression } from '@pipeline/components/PipelineStudio/PiplineHooks/useVariablesExpression'
+import { FileSelectList } from '@filestore/components/FileStoreList/FileStoreList'
+import { SELECT_FILES_TYPE } from '@filestore/utils/constants'
+import { isFieldRuntime } from '../../K8sServiceSpecHelper'
+import { isFieldfromTriggerTabDisabled } from '../ManifestSourceUtils'
+import css from '../../KubernetesManifests/KubernetesManifests.module.scss'
+
+const ManifestCommonRuntimeFields = ({
+  template,
+  path,
+  manifestPath,
+  manifest,
+  fromTrigger,
+  readonly,
+  formik,
+  stageIdentifier
+}: ManifestSourceRenderProps): React.ReactElement => {
+  const { getString } = useStrings()
+  const { expressions } = useVariablesExpression()
+  const isFieldDisabled = (fieldName: string): boolean => {
+    // /* instanbul ignore else */
+    if (readonly) {
+      return true
+    }
+    return isFieldfromTriggerTabDisabled(
+      fieldName,
+      formik,
+      stageIdentifier,
+      manifest?.identifier as string,
+      fromTrigger
+    )
+  }
+  return (
+    <>
+      {isFieldRuntime(`${manifestPath}.spec.store.spec.files`, template) && (
+        <div className={css.verticalSpacingInput}>
+          <FileSelectList
+            labelClassName={css.listLabel}
+            label={getString('resourcePage.fileStore')}
+            name={`${path}.${manifestPath}.spec.store.spec.files`}
+            placeholder={getString('pipeline.manifestType.manifestPathPlaceholder')}
+            disabled={isFieldDisabled(`${manifestPath}.spec.store.spec.files`)}
+            style={{ marginBottom: 'var(--spacing-small)' }}
+            expressions={expressions}
+            isNameOfArrayType
+            type={SELECT_FILES_TYPE.FILE_STORE}
+            formik={formik}
+          />
+        </div>
+      )}
+    </>
+  )
+}
+export default ManifestCommonRuntimeFields

--- a/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/ManifestSource/ManifestSourceRuntimeFields/__tests__/ManifestCommonRuntimeFields.test.tsx
+++ b/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/ManifestSource/ManifestSourceRuntimeFields/__tests__/ManifestCommonRuntimeFields.test.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import React from 'react'
+import { render } from '@testing-library/react'
+
+import { MultiTypeInputType } from '@harness/uicore'
+import type { ManifestConfigWrapper, ServiceSpec } from 'services/cd-ng'
+import { TestWrapper } from '@common/utils/testUtils'
+import { ManifestSourceBaseFactory } from '@cd/factory/ManifestSourceFactory/ManifestSourceBaseFactory'
+import { StepViewType } from '@pipeline/components/AbstractSteps/Step'
+import { manifests, template, path, stageIdentifier } from './mocks'
+import { KubernetesManifests } from '../../../KubernetesManifests/KubernetesManifests'
+
+describe('K8sManifestSource tests', () => {
+  const commonProps = {
+    template: template as ServiceSpec,
+    manifests: manifests as ManifestConfigWrapper[],
+    manifestSourceBaseFactory: new ManifestSourceBaseFactory(),
+    stepViewType: StepViewType.DeploymentForm,
+    stageIdentifier,
+    path,
+    initialValues: { manifests: manifests as ManifestConfigWrapper[] },
+    allowableTypes: [MultiTypeInputType.FIXED, MultiTypeInputType.EXPRESSION]
+  }
+  test('Should match snapshot', () => {
+    const { container } = render(
+      <TestWrapper>
+        <KubernetesManifests {...commonProps} readonly={false} fromTrigger={false} />
+      </TestWrapper>
+    )
+    expect(container).toMatchSnapshot()
+  })
+  test('renders correctly when fromTrigger and readonly is true', () => {
+    const { getByText } = render(
+      <TestWrapper>
+        <KubernetesManifests {...commonProps} readonly={true} fromTrigger={true} />
+      </TestWrapper>
+    )
+    expect(getByText('resourcePage.fileStore')).toBeTruthy()
+  })
+})

--- a/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/ManifestSource/ManifestSourceRuntimeFields/__tests__/__snapshots__/ManifestCommonRuntimeFields.test.tsx.snap
+++ b/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/ManifestSource/ManifestSourceRuntimeFields/__tests__/__snapshots__/ManifestCommonRuntimeFields.test.tsx.snap
@@ -1,0 +1,384 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`K8sManifestSource tests Should match snapshot 1`] = `
+<div>
+  <div
+    class="nopadLeft accordionSummary"
+    id="Stage.STG1.Service.Manifests"
+  >
+    <div
+      class="subheading"
+    >
+      pipelineSteps.deploy.serviceSpecifications.deploymentTypes.manifests
+    </div>
+    <div>
+      <p
+        class="StyledProps--font StyledProps--main inputheader StyledProps--margin-top-medium"
+      >
+        ident
+      </p>
+      <div
+        class="Layout--vertical StyledProps--main inputWidth layoutVerticalSpacing"
+        data-name="manifest"
+      >
+        <div
+          class="verticalSpacingInput"
+        >
+          <div>
+            <div
+              class="label listLabel"
+            >
+              resourcePage.fileStore
+            </div>
+            <div
+              class="bp3-card bp3-elevation-0 Card--card"
+              style="width: 100%;"
+            >
+              <div
+                class="group"
+              >
+                <div
+                  class="selectFieldWrapper"
+                  style="flex-grow: 1;"
+                >
+                  <div
+                    class="bp3-form-group"
+                    style="flex-grow: 1; margin-bottom: 0px; margin-top: 0px;"
+                  >
+                    <label
+                      class="bp3-label"
+                      for="stages[0].stage.spec.serviceConfig.serviceDefinition.spec.manifests[0].manifest.spec.store.spec.files[0]"
+                    >
+                      <div
+                        class="StyledProps--font StyledProps--main StyledProps--flex"
+                      >
+                        
+                      </div>
+                       
+                      <span
+                        class="bp3-text-muted"
+                      />
+                    </label>
+                    <div
+                      class="bp3-form-content"
+                    >
+                      <div
+                        class="StyledProps--font StyledProps--main StyledProps--flex"
+                      >
+                        <div
+                          class="selectFieldWrapper"
+                        >
+                          <div
+                            class="bp3-form-group"
+                            style="width: 100%;"
+                          >
+                            <div
+                              class="bp3-form-content"
+                            >
+                              <div
+                                class="Layout--vertical StyledProps--main"
+                              >
+                                <div
+                                  class="StyledProps--font StyledProps--main container StyledProps--flex StyledProps--flex-alignItems-center StyledProps--flex-justifyContent-space-between"
+                                >
+                                  <p
+                                    class="StyledProps--font StyledProps--main StyledProps--color StyledProps--color-grey500 StyledProps--padding-left-xsmall"
+                                  >
+                                    - 
+                                    pipeline.manifestType.manifestPathPlaceholder
+                                     -
+                                  </p>
+                                  <div
+                                    class="StyledProps--font StyledProps--main StyledProps--padding-right-small"
+                                  >
+                                    <span
+                                      class="bp3-icon bp3-icon-chevron-down StyledProps--main StyledProps--margin-right-small StyledProps--margin-left-small"
+                                      icon="chevron-down"
+                                    >
+                                      <svg
+                                        data-icon="chevron-down"
+                                        height="16"
+                                        viewBox="0 0 16 16"
+                                        width="16"
+                                      >
+                                        <desc>
+                                          chevron-down
+                                        </desc>
+                                        <path
+                                          d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                                          fill-rule="evenodd"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div
+                          class="bp3-popover-wrapper typeSelectorWrapper"
+                        >
+                          <div
+                            class="bp3-popover-target typeSelector"
+                          >
+                            <button
+                              class="bp3-button bp3-minimal Button--button StyledProps--font StyledProps--main btn Button--iconOnly Button--without-shadow"
+                              type="button"
+                            >
+                              <span
+                                class="bp3-button-text"
+                              >
+                                <span
+                                  class="bp3-icon StyledProps--main icon fixed"
+                                  data-icon="fixed-input"
+                                >
+                                  <svg
+                                    height="12"
+                                    viewBox="0 0 9 9"
+                                    width="12"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M5.61 7.55c.62-.7.3-1.42.18-2.35a.32.32 0 01.1-.29l1.43-1.42a.76.76 0 01.28-.15c.39-.1 1 0 1.28-.29a.34.34 0 000-.51L6.46.12a.33.33 0 00-.52 0c-.28.29-.2.9-.28 1.3a.53.53 0 01-.13.23L4.09 3.12a.29.29 0 01-.28.09c-.89-.11-1.6-.49-2.27.11-.29.26-.29.43 0 .7l1.31 1.34.15.16-.15.15-2.7 2.69a.36.36 0 000 .54.36.36 0 00.54-.05l2.63-2.68.17-.17.17.16c.45.46.9.91 1.36 1.36.21.21.42.22.59.03z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <button
+                  class="bp3-button bp3-minimal Button--button StyledProps--font StyledProps--main Button--with-current-color Button--iconOnly Button--without-shadow Button--withLeftIcon"
+                  data-testid="remove-stages[0].stage.spec.serviceConfig.serviceDefinition.spec.manifests[0].manifest.spec.store.spec.files-[0]"
+                  type="button"
+                >
+                  <span
+                    class="bp3-icon StyledProps--main"
+                    data-icon="main-trash"
+                  >
+                    <svg
+                      height="20"
+                      viewBox="0 0 16 20"
+                      width="20"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M1.143 8.48a1.2 1.2 0 011.189-1.36h10.649a1.2 1.2 0 011.194 1.321l-1.039 10.208a1.2 1.2 0 01-1.193 1.079H3.716a1.2 1.2 0 01-1.189-1.04L1.143 8.48zm11.837-.16H2.332l1.385 10.207h8.226L12.98 8.32zM5.916 1.594a.6.6 0 01.719-.452l4.224.965a.6.6 0 01.452.719L11 4.179l3.86.882a.6.6 0 01-.267 1.17L1.535 3.248a.6.6 0 11.267-1.17l3.805.87.309-1.354zm.86 1.62l3.056.698.175-.768-3.055-.698-.175.768z"
+                        fill="currentColor"
+                        fill-rule="evenodd"
+                      />
+                      <path
+                        clip-rule="evenodd"
+                        d="M8 10.808a.5.5 0 01.5.5v5a.5.5 0 01-1 0v-5a.5.5 0 01.5-.5zm-2.761.012a.5.5 0 01.541.454l.436 4.981a.5.5 0 11-.996.087l-.436-4.98a.5.5 0 01.455-.542zM10.762 10.82a.5.5 0 01.455.541l-.436 4.981a.5.5 0 11-.996-.087l.435-4.98a.5.5 0 01.542-.455z"
+                        fill="currentColor"
+                        fill-rule="evenodd"
+                        opacity="0.3"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </div>
+              <button
+                class="bp3-button bp3-minimal Button--button StyledProps--font StyledProps--main StyledProps--intent-primary Button--with-current-color Button--without-shadow"
+                data-testid="add-stages[0].stage.spec.serviceConfig.serviceDefinition.spec.manifests[0].manifest.spec.store.spec.files"
+                type="button"
+              >
+                <span
+                  class="bp3-button-text"
+                >
+                  plusAdd
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+        <div
+          class="verticalSpacingInput"
+        >
+          <div>
+            <div
+              class="label listLabel"
+            >
+              pipeline.manifestType.valuesYamlPath
+            </div>
+            <div
+              class="bp3-card bp3-elevation-0 Card--card"
+              style="width: 100%;"
+            >
+              <div
+                class="group"
+              >
+                <div
+                  class="selectFieldWrapper"
+                  style="flex-grow: 1;"
+                >
+                  <div
+                    class="bp3-form-group"
+                    style="flex-grow: 1; margin-bottom: 0px; margin-top: 0px;"
+                  >
+                    <label
+                      class="bp3-label"
+                      for="stages[0].stage.spec.serviceConfig.serviceDefinition.spec.manifests[0].manifest.spec.valuesPaths[0]"
+                    >
+                      <div
+                        class="StyledProps--font StyledProps--main StyledProps--flex"
+                      >
+                        
+                      </div>
+                       
+                      <span
+                        class="bp3-text-muted"
+                      />
+                    </label>
+                    <div
+                      class="bp3-form-content"
+                    >
+                      <div
+                        class="StyledProps--font StyledProps--main StyledProps--flex"
+                      >
+                        <div
+                          class="selectFieldWrapper"
+                        >
+                          <div
+                            class="bp3-form-group"
+                            style="width: 100%;"
+                          >
+                            <div
+                              class="bp3-form-content"
+                            >
+                              <div
+                                class="Layout--vertical StyledProps--main"
+                              >
+                                <div
+                                  class="StyledProps--font StyledProps--main container StyledProps--flex StyledProps--flex-alignItems-center StyledProps--flex-justifyContent-space-between"
+                                >
+                                  <p
+                                    class="StyledProps--font StyledProps--main StyledProps--color StyledProps--color-grey500 StyledProps--padding-left-xsmall"
+                                  >
+                                    - 
+                                    pipeline.manifestType.manifestPathPlaceholder
+                                     -
+                                  </p>
+                                  <div
+                                    class="StyledProps--font StyledProps--main StyledProps--padding-right-small"
+                                  >
+                                    <span
+                                      class="bp3-icon bp3-icon-chevron-down StyledProps--main StyledProps--margin-right-small StyledProps--margin-left-small"
+                                      icon="chevron-down"
+                                    >
+                                      <svg
+                                        data-icon="chevron-down"
+                                        height="16"
+                                        viewBox="0 0 16 16"
+                                        width="16"
+                                      >
+                                        <desc>
+                                          chevron-down
+                                        </desc>
+                                        <path
+                                          d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                                          fill-rule="evenodd"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div
+                          class="bp3-popover-wrapper typeSelectorWrapper"
+                        >
+                          <div
+                            class="bp3-popover-target typeSelector"
+                          >
+                            <button
+                              class="bp3-button bp3-minimal Button--button StyledProps--font StyledProps--main btn Button--iconOnly Button--without-shadow"
+                              type="button"
+                            >
+                              <span
+                                class="bp3-button-text"
+                              >
+                                <span
+                                  class="bp3-icon StyledProps--main icon fixed"
+                                  data-icon="fixed-input"
+                                >
+                                  <svg
+                                    height="12"
+                                    viewBox="0 0 9 9"
+                                    width="12"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M5.61 7.55c.62-.7.3-1.42.18-2.35a.32.32 0 01.1-.29l1.43-1.42a.76.76 0 01.28-.15c.39-.1 1 0 1.28-.29a.34.34 0 000-.51L6.46.12a.33.33 0 00-.52 0c-.28.29-.2.9-.28 1.3a.53.53 0 01-.13.23L4.09 3.12a.29.29 0 01-.28.09c-.89-.11-1.6-.49-2.27.11-.29.26-.29.43 0 .7l1.31 1.34.15.16-.15.15-2.7 2.69a.36.36 0 000 .54.36.36 0 00.54-.05l2.63-2.68.17-.17.17.16c.45.46.9.91 1.36 1.36.21.21.42.22.59.03z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <button
+                  class="bp3-button bp3-minimal Button--button StyledProps--font StyledProps--main Button--with-current-color Button--iconOnly Button--without-shadow Button--withLeftIcon"
+                  data-testid="remove-stages[0].stage.spec.serviceConfig.serviceDefinition.spec.manifests[0].manifest.spec.valuesPaths-[0]"
+                  type="button"
+                >
+                  <span
+                    class="bp3-icon StyledProps--main"
+                    data-icon="main-trash"
+                  >
+                    <svg
+                      height="20"
+                      viewBox="0 0 16 20"
+                      width="20"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M1.143 8.48a1.2 1.2 0 011.189-1.36h10.649a1.2 1.2 0 011.194 1.321l-1.039 10.208a1.2 1.2 0 01-1.193 1.079H3.716a1.2 1.2 0 01-1.189-1.04L1.143 8.48zm11.837-.16H2.332l1.385 10.207h8.226L12.98 8.32zM5.916 1.594a.6.6 0 01.719-.452l4.224.965a.6.6 0 01.452.719L11 4.179l3.86.882a.6.6 0 01-.267 1.17L1.535 3.248a.6.6 0 11.267-1.17l3.805.87.309-1.354zm.86 1.62l3.056.698.175-.768-3.055-.698-.175.768z"
+                        fill="currentColor"
+                        fill-rule="evenodd"
+                      />
+                      <path
+                        clip-rule="evenodd"
+                        d="M8 10.808a.5.5 0 01.5.5v5a.5.5 0 01-1 0v-5a.5.5 0 01.5-.5zm-2.761.012a.5.5 0 01.541.454l.436 4.981a.5.5 0 11-.996.087l-.436-4.98a.5.5 0 01.455-.542zM10.762 10.82a.5.5 0 01.455.541l-.436 4.981a.5.5 0 11-.996-.087l.435-4.98a.5.5 0 01.542-.455z"
+                        fill="currentColor"
+                        fill-rule="evenodd"
+                        opacity="0.3"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </div>
+              <button
+                class="bp3-button bp3-minimal Button--button StyledProps--font StyledProps--main StyledProps--intent-primary Button--with-current-color Button--without-shadow"
+                data-testid="add-stages[0].stage.spec.serviceConfig.serviceDefinition.spec.manifests[0].manifest.spec.valuesPaths"
+                type="button"
+              >
+                <span
+                  class="bp3-button-text"
+                >
+                  plusAdd
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/ManifestSource/ManifestSourceRuntimeFields/__tests__/mocks.ts
+++ b/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/ManifestSource/ManifestSourceRuntimeFields/__tests__/mocks.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+export const path = 'stages[0].stage.spec.serviceConfig.serviceDefinition.spec'
+export const stageIdentifier = 'STG1'
+export const manifests = [
+  {
+    manifest: {
+      identifier: 'manifestIdentifier',
+      type: 'K8sManifest',
+      spec: {
+        valuesPaths: '<+input>',
+        store: {
+          type: 'Harness',
+          spec: {
+            files: '<+input>'
+          }
+        }
+      }
+    }
+  }
+]
+
+export const template = {
+  manifests: [
+    {
+      manifest: {
+        identifier: 'ident',
+        type: 'K8sManifest',
+        spec: {
+          valuesPaths: '<+input>',
+          store: {
+            type: 'Harness',
+            spec: {
+              files: '<+input>'
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/ManifestSource/OpenshiftParamManifestSource/OpenshiftParamManifestSource.tsx
+++ b/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/ManifestSource/OpenshiftParamManifestSource/OpenshiftParamManifestSource.tsx
@@ -16,6 +16,7 @@ import List from '@common/components/List/List'
 import { isFieldRuntime } from '../../K8sServiceSpecHelper'
 import { isFieldfromTriggerTabDisabled } from '../ManifestSourceUtils'
 import ManifestGitStoreRuntimeFields from '../ManifestSourceRuntimeFields/ManifestGitStoreRuntimeFields'
+import ManifestCommonRuntimeFields from '../ManifestSourceRuntimeFields/ManifestCommonRuntimeFields'
 import css from '../../KubernetesManifests/KubernetesManifests.module.scss'
 
 const Content = (props: ManifestSourceRenderProps): React.ReactElement => {
@@ -44,7 +45,7 @@ const Content = (props: ManifestSourceRenderProps): React.ReactElement => {
       className={cx(css.inputWidth, css.layoutVerticalSpacing)}
     >
       <ManifestGitStoreRuntimeFields {...props} />
-
+      <ManifestCommonRuntimeFields {...props} />
       {isFieldRuntime(`${manifestPath}.spec.store.spec.paths`, template) && (
         <div className={css.verticalSpacingInput}>
           <List

--- a/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/ManifestSource/OpenshiftParamManifestSource/__tests__/mocks.ts
+++ b/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/ManifestSource/OpenshiftParamManifestSource/__tests__/mocks.ts
@@ -37,6 +37,22 @@ export const manifests = [
         }
       }
     }
+  },
+  {
+    manifest: {
+      identifier: 'manifestIdentifier',
+      type: 'OpenShiftParams',
+      spec: {
+        store: {
+          type: 'CustomeRemote',
+          spec: {
+            filePath: 'file-path',
+            extractionScript: 'script',
+            delegateSelectors: ['delegate-selector']
+          }
+        }
+      }
+    }
   }
 ]
 
@@ -69,6 +85,22 @@ export const template = {
             type: 'InheritFromManifest',
             spec: {
               paths: ['./filepath']
+            }
+          }
+        }
+      }
+    },
+    {
+      manifest: {
+        identifier: 'ident',
+        type: 'OpenShiftParams',
+        spec: {
+          store: {
+            type: 'CustomeRemote',
+            spec: {
+              filePath: '<+input>',
+              extractionScript: 'script',
+              delegateSelectors: ['delegate-selector']
             }
           }
         }

--- a/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/ManifestSource/OpenshiftTemplateManifestSource/OpenshiftTemplateManifestSource.tsx
+++ b/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/ManifestSource/OpenshiftTemplateManifestSource/OpenshiftTemplateManifestSource.tsx
@@ -17,6 +17,7 @@ import List from '@common/components/List/List'
 import { isFieldRuntime } from '../../K8sServiceSpecHelper'
 import { isFieldfromTriggerTabDisabled } from '../ManifestSourceUtils'
 import ManifestGitStoreRuntimeFields from '../ManifestSourceRuntimeFields/ManifestGitStoreRuntimeFields'
+import ManifestCommonRuntimeFields from '../ManifestSourceRuntimeFields/ManifestCommonRuntimeFields'
 import css from '../../KubernetesManifests/KubernetesManifests.module.scss'
 
 const Content = (props: ManifestSourceRenderProps): React.ReactElement => {
@@ -46,7 +47,7 @@ const Content = (props: ManifestSourceRenderProps): React.ReactElement => {
       className={cx(css.inputWidth, css.layoutVerticalSpacing)}
     >
       <ManifestGitStoreRuntimeFields {...props} />
-
+      <ManifestCommonRuntimeFields {...props} />
       {isFieldRuntime(`${manifestPath}.spec.store.spec.paths`, template) && (
         <div className={css.verticalSpacingInput}>
           <FormInput.MultiTextInput

--- a/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/ManifestSource/OpenshiftTemplateManifestSource/__tests__/__snapshots__/OpenshiftTemplateManifestSource.test.tsx.snap
+++ b/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/ManifestSource/OpenshiftTemplateManifestSource/__tests__/__snapshots__/OpenshiftTemplateManifestSource.test.tsx.snap
@@ -238,6 +238,310 @@ exports[`OpenshiftTemplateManifestSource tests Should match snapshot 1`] = `
         </div>
       </div>
     </div>
+    <div>
+      <p
+        class="StyledProps--font StyledProps--main inputheader StyledProps--margin-top-medium"
+      >
+        OpenShift
+      </p>
+      <div
+        class="Layout--vertical StyledProps--main inputWidth layoutVerticalSpacing"
+        data-name="manifest"
+      >
+        <div
+          class="verticalSpacingInput"
+          data-name="connectorRefContainer"
+        >
+          <div
+            class="connectorLabel"
+          >
+            <div
+              class="StyledProps--font StyledProps--main"
+              style="margin-bottom: 5px;"
+            >
+              connector
+            </div>
+            <div
+              style="display: flex; align-items: center;"
+            >
+              <div
+                class="bp3-form-group"
+                style="margin-bottom: 0px;"
+              >
+                <div
+                  class="bp3-form-content"
+                >
+                  <div
+                    class="Layout--horizontal StyledProps--main MultiTypeInput--main"
+                    style="width: 391px;"
+                  >
+                    <button
+                      class="bp3-button bp3-minimal Button--button StyledProps--font StyledProps--main container Button--iconOnly Button--without-shadow Button--withRightIcon"
+                      data-testid="cr-field-stages[0].stage.spec.serviceConfig.serviceDefinition.spec.manifests[1].manifest.spec.store.spec.connectorRef"
+                      style="width: 391px;"
+                      type="button"
+                    >
+                      <span
+                        class="bp3-button-text"
+                      >
+                        <span
+                          class="placeholder"
+                        />
+                      </span>
+                      <span
+                        class="bp3-icon bp3-icon-chevron-down StyledProps--main"
+                        icon="chevron-down"
+                      >
+                        <svg
+                          data-icon="chevron-down"
+                          height="14"
+                          viewBox="0 0 16 16"
+                          width="14"
+                        >
+                          <desc>
+                            chevron-down
+                          </desc>
+                          <path
+                            d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </span>
+                    </button>
+                    <span
+                      class="bp3-popover-wrapper MultiTypeInput--wrapper"
+                    >
+                      <span
+                        class="bp3-popover-target"
+                      >
+                        <button
+                          class="MultiTypeInput--btn MultiTypeInput--FIXED"
+                        >
+                          <span
+                            class="bp3-icon StyledProps--main"
+                            data-icon="fixed-input"
+                          >
+                            <svg
+                              height="12"
+                              viewBox="0 0 9 9"
+                              width="12"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M5.61 7.55c.62-.7.3-1.42.18-2.35a.32.32 0 01.1-.29l1.43-1.42a.76.76 0 01.28-.15c.39-.1 1 0 1.28-.29a.34.34 0 000-.51L6.46.12a.33.33 0 00-.52 0c-.28.29-.2.9-.28 1.3a.53.53 0 01-.13.23L4.09 3.12a.29.29 0 01-.28.09c-.89-.11-1.6-.49-2.27.11-.29.26-.29.43 0 .7l1.31 1.34.15.16-.15.15-2.7 2.69a.36.36 0 000 .54.36.36 0 00.54-.05l2.63-2.68.17-.17.17.16c.45.46.9.91 1.36 1.36.21.21.42.22.59.03z"
+                                fill="currentColor"
+                              />
+                            </svg>
+                          </span>
+                        </button>
+                      </span>
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="verticalSpacingInput"
+        >
+          <div
+            class="bp3-form-group"
+          >
+            <label
+              class="bp3-label"
+              for="stages[0].stage.spec.serviceConfig.serviceDefinition.spec.manifests[1].manifest.spec.store.spec.repoName"
+            >
+              common.repositoryName
+               
+              <span
+                class="bp3-text-muted"
+              />
+            </label>
+            <div
+              class="bp3-form-content"
+            >
+              <div
+                class="Layout--horizontal StyledProps--main MultiTypeInput--main"
+              >
+                <div
+                  class="bp3-input-group MultiTypeInput--input"
+                >
+                  <input
+                    autocomplete="off"
+                    class="bp3-input"
+                    name="stages[0].stage.spec.serviceConfig.serviceDefinition.spec.manifests[1].manifest.spec.store.spec.repoName"
+                    type="text"
+                    value=""
+                  />
+                </div>
+                <span
+                  class="bp3-popover-wrapper MultiTypeInput--wrapper"
+                >
+                  <span
+                    class="bp3-popover-target"
+                  >
+                    <button
+                      class="MultiTypeInput--btn MultiTypeInput--FIXED"
+                    >
+                      <span
+                        class="bp3-icon StyledProps--main"
+                        data-icon="fixed-input"
+                      >
+                        <svg
+                          height="12"
+                          viewBox="0 0 9 9"
+                          width="12"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M5.61 7.55c.62-.7.3-1.42.18-2.35a.32.32 0 01.1-.29l1.43-1.42a.76.76 0 01.28-.15c.39-.1 1 0 1.28-.29a.34.34 0 000-.51L6.46.12a.33.33 0 00-.52 0c-.28.29-.2.9-.28 1.3a.53.53 0 01-.13.23L4.09 3.12a.29.29 0 01-.28.09c-.89-.11-1.6-.49-2.27.11-.29.26-.29.43 0 .7l1.31 1.34.15.16-.15.15-2.7 2.69a.36.36 0 000 .54.36.36 0 00.54-.05l2.63-2.68.17-.17.17.16c.45.46.9.91 1.36 1.36.21.21.42.22.59.03z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                      </span>
+                    </button>
+                  </span>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="verticalSpacingInput"
+        >
+          <div
+            class="bp3-form-group multiTypeCheckbox"
+          >
+            <div
+              class="bp3-form-content"
+            >
+              <div
+                class="Layout--horizontal StyledProps--main MultiTypeInput--main"
+              >
+                <label
+                  class="bp3-control bp3-checkbox StyledProps--font Checkbox--checkbox input StyledProps--main"
+                >
+                  <input
+                    name="stages[0].stage.spec.serviceConfig.serviceDefinition.spec.manifests[1].manifest.spec.skipResourceVersioning"
+                    type="checkbox"
+                  />
+                  <span
+                    class="bp3-control-indicator"
+                  />
+                  skipResourceVersion
+                </label>
+                <span
+                  class="bp3-popover-wrapper MultiTypeInput--wrapper"
+                >
+                  <span
+                    class="bp3-popover-target"
+                  >
+                    <button
+                      class="MultiTypeInput--btn MultiTypeInput--FIXED"
+                    >
+                      <span
+                        class="bp3-icon StyledProps--main"
+                        data-icon="fixed-input"
+                      >
+                        <svg
+                          height="12"
+                          viewBox="0 0 9 9"
+                          width="12"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M5.61 7.55c.62-.7.3-1.42.18-2.35a.32.32 0 01.1-.29l1.43-1.42a.76.76 0 01.28-.15c.39-.1 1 0 1.28-.29a.34.34 0 000-.51L6.46.12a.33.33 0 00-.52 0c-.28.29-.2.9-.28 1.3a.53.53 0 01-.13.23L4.09 3.12a.29.29 0 01-.28.09c-.89-.11-1.6-.49-2.27.11-.29.26-.29.43 0 .7l1.31 1.34.15.16-.15.15-2.7 2.69a.36.36 0 000 .54.36.36 0 00.54-.05l2.63-2.68.17-.17.17.16c.45.46.9.91 1.36 1.36.21.21.42.22.59.03z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                      </span>
+                    </button>
+                  </span>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div>
+      <p
+        class="StyledProps--font StyledProps--main inputheader StyledProps--margin-top-medium"
+      >
+        ident
+      </p>
+      <div
+        class="Layout--vertical StyledProps--main inputWidth layoutVerticalSpacing"
+        data-name="manifest"
+      >
+        <div
+          class="verticalSpacingInput"
+        >
+          <div
+            class="bp3-form-group"
+          >
+            <label
+              class="bp3-label"
+              for="stages[0].stage.spec.serviceConfig.serviceDefinition.spec.manifests[2].manifest.spec.store.spec.filePath"
+            >
+              pipeline.manifestType.customRemoteExtractedFileLocation
+               
+              <span
+                class="bp3-text-muted"
+              />
+            </label>
+            <div
+              class="bp3-form-content"
+            >
+              <div
+                class="Layout--horizontal StyledProps--main MultiTypeInput--main"
+              >
+                <div
+                  class="bp3-input-group MultiTypeInput--input"
+                >
+                  <input
+                    autocomplete="off"
+                    class="bp3-input"
+                    name="stages[0].stage.spec.serviceConfig.serviceDefinition.spec.manifests[2].manifest.spec.store.spec.filePath"
+                    type="text"
+                    value=""
+                  />
+                </div>
+                <span
+                  class="bp3-popover-wrapper MultiTypeInput--wrapper"
+                >
+                  <span
+                    class="bp3-popover-target"
+                  >
+                    <button
+                      class="MultiTypeInput--btn MultiTypeInput--FIXED"
+                    >
+                      <span
+                        class="bp3-icon StyledProps--main"
+                        data-icon="fixed-input"
+                      >
+                        <svg
+                          height="12"
+                          viewBox="0 0 9 9"
+                          width="12"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M5.61 7.55c.62-.7.3-1.42.18-2.35a.32.32 0 01.1-.29l1.43-1.42a.76.76 0 01.28-.15c.39-.1 1 0 1.28-.29a.34.34 0 000-.51L6.46.12a.33.33 0 00-.52 0c-.28.29-.2.9-.28 1.3a.53.53 0 01-.13.23L4.09 3.12a.29.29 0 01-.28.09c-.89-.11-1.6-.49-2.27.11-.29.26-.29.43 0 .7l1.31 1.34.15.16-.15.15-2.7 2.69a.36.36 0 000 .54.36.36 0 00.54-.05l2.63-2.68.17-.17.17.16c.45.46.9.91 1.36 1.36.21.21.42.22.59.03z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                      </span>
+                    </button>
+                  </span>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -439,6 +743,306 @@ exports[`OpenshiftTemplateManifestSource tests Should match snapshot with fromTr
                   />
                   skipResourceVersion
                 </label>
+                <span
+                  class="bp3-popover-wrapper MultiTypeInput--wrapper"
+                >
+                  <span
+                    class="bp3-popover-target"
+                  >
+                    <button
+                      class="MultiTypeInput--btn MultiTypeInput--FIXED"
+                    >
+                      <span
+                        class="bp3-icon StyledProps--main"
+                        data-icon="fixed-input"
+                      >
+                        <svg
+                          height="12"
+                          viewBox="0 0 9 9"
+                          width="12"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M5.61 7.55c.62-.7.3-1.42.18-2.35a.32.32 0 01.1-.29l1.43-1.42a.76.76 0 01.28-.15c.39-.1 1 0 1.28-.29a.34.34 0 000-.51L6.46.12a.33.33 0 00-.52 0c-.28.29-.2.9-.28 1.3a.53.53 0 01-.13.23L4.09 3.12a.29.29 0 01-.28.09c-.89-.11-1.6-.49-2.27.11-.29.26-.29.43 0 .7l1.31 1.34.15.16-.15.15-2.7 2.69a.36.36 0 000 .54.36.36 0 00.54-.05l2.63-2.68.17-.17.17.16c.45.46.9.91 1.36 1.36.21.21.42.22.59.03z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                      </span>
+                    </button>
+                  </span>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div>
+      <p
+        class="StyledProps--font StyledProps--main inputheader StyledProps--margin-top-medium"
+      />
+      <div
+        class="Layout--vertical StyledProps--main inputWidth layoutVerticalSpacing"
+        data-name="manifest"
+      >
+        <div
+          class="verticalSpacingInput"
+          data-name="connectorRefContainer"
+        >
+          <div
+            class="connectorLabel"
+          >
+            <div
+              class="StyledProps--font StyledProps--main"
+              style="margin-bottom: 5px;"
+            >
+              connector
+            </div>
+            <div
+              style="display: flex; align-items: center;"
+            >
+              <div
+                class="bp3-form-group"
+                style="margin-bottom: 0px;"
+              >
+                <div
+                  class="bp3-form-content"
+                >
+                  <div
+                    class="Layout--horizontal StyledProps--main MultiTypeInput--main"
+                    style="width: 391px;"
+                  >
+                    <button
+                      class="bp3-button bp3-minimal Button--button StyledProps--font StyledProps--main container Button--iconOnly Button--without-shadow Button--withRightIcon"
+                      data-testid="cr-field-stages[0].stage.spec.serviceConfig.serviceDefinition.spec.manifests[1].manifest.spec.store.spec.connectorRef"
+                      style="width: 391px;"
+                      type="button"
+                    >
+                      <span
+                        class="bp3-button-text"
+                      >
+                        <span
+                          class="placeholder"
+                        />
+                      </span>
+                      <span
+                        class="bp3-icon bp3-icon-chevron-down StyledProps--main"
+                        icon="chevron-down"
+                      >
+                        <svg
+                          data-icon="chevron-down"
+                          height="14"
+                          viewBox="0 0 16 16"
+                          width="14"
+                        >
+                          <desc>
+                            chevron-down
+                          </desc>
+                          <path
+                            d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </span>
+                    </button>
+                    <span
+                      class="bp3-popover-wrapper MultiTypeInput--wrapper"
+                    >
+                      <span
+                        class="bp3-popover-target"
+                      >
+                        <button
+                          class="MultiTypeInput--btn MultiTypeInput--FIXED"
+                        >
+                          <span
+                            class="bp3-icon StyledProps--main"
+                            data-icon="fixed-input"
+                          >
+                            <svg
+                              height="12"
+                              viewBox="0 0 9 9"
+                              width="12"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M5.61 7.55c.62-.7.3-1.42.18-2.35a.32.32 0 01.1-.29l1.43-1.42a.76.76 0 01.28-.15c.39-.1 1 0 1.28-.29a.34.34 0 000-.51L6.46.12a.33.33 0 00-.52 0c-.28.29-.2.9-.28 1.3a.53.53 0 01-.13.23L4.09 3.12a.29.29 0 01-.28.09c-.89-.11-1.6-.49-2.27.11-.29.26-.29.43 0 .7l1.31 1.34.15.16-.15.15-2.7 2.69a.36.36 0 000 .54.36.36 0 00.54-.05l2.63-2.68.17-.17.17.16c.45.46.9.91 1.36 1.36.21.21.42.22.59.03z"
+                                fill="currentColor"
+                              />
+                            </svg>
+                          </span>
+                        </button>
+                      </span>
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="verticalSpacingInput"
+        >
+          <div
+            class="bp3-form-group"
+          >
+            <label
+              class="bp3-label"
+              for="stages[0].stage.spec.serviceConfig.serviceDefinition.spec.manifests[1].manifest.spec.store.spec.repoName"
+            >
+              common.repositoryName
+               
+              <span
+                class="bp3-text-muted"
+              />
+            </label>
+            <div
+              class="bp3-form-content"
+            >
+              <div
+                class="Layout--horizontal StyledProps--main MultiTypeInput--main"
+              >
+                <div
+                  class="bp3-input-group MultiTypeInput--input"
+                >
+                  <input
+                    autocomplete="off"
+                    class="bp3-input"
+                    name="stages[0].stage.spec.serviceConfig.serviceDefinition.spec.manifests[1].manifest.spec.store.spec.repoName"
+                    type="text"
+                    value=""
+                  />
+                </div>
+                <span
+                  class="bp3-popover-wrapper MultiTypeInput--wrapper"
+                >
+                  <span
+                    class="bp3-popover-target"
+                  >
+                    <button
+                      class="MultiTypeInput--btn MultiTypeInput--FIXED"
+                    >
+                      <span
+                        class="bp3-icon StyledProps--main"
+                        data-icon="fixed-input"
+                      >
+                        <svg
+                          height="12"
+                          viewBox="0 0 9 9"
+                          width="12"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M5.61 7.55c.62-.7.3-1.42.18-2.35a.32.32 0 01.1-.29l1.43-1.42a.76.76 0 01.28-.15c.39-.1 1 0 1.28-.29a.34.34 0 000-.51L6.46.12a.33.33 0 00-.52 0c-.28.29-.2.9-.28 1.3a.53.53 0 01-.13.23L4.09 3.12a.29.29 0 01-.28.09c-.89-.11-1.6-.49-2.27.11-.29.26-.29.43 0 .7l1.31 1.34.15.16-.15.15-2.7 2.69a.36.36 0 000 .54.36.36 0 00.54-.05l2.63-2.68.17-.17.17.16c.45.46.9.91 1.36 1.36.21.21.42.22.59.03z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                      </span>
+                    </button>
+                  </span>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="verticalSpacingInput"
+        >
+          <div
+            class="bp3-form-group multiTypeCheckbox"
+          >
+            <div
+              class="bp3-form-content"
+            >
+              <div
+                class="Layout--horizontal StyledProps--main MultiTypeInput--main"
+              >
+                <label
+                  class="bp3-control bp3-checkbox StyledProps--font Checkbox--checkbox input StyledProps--main"
+                >
+                  <input
+                    name="stages[0].stage.spec.serviceConfig.serviceDefinition.spec.manifests[1].manifest.spec.skipResourceVersioning"
+                    type="checkbox"
+                  />
+                  <span
+                    class="bp3-control-indicator"
+                  />
+                  skipResourceVersion
+                </label>
+                <span
+                  class="bp3-popover-wrapper MultiTypeInput--wrapper"
+                >
+                  <span
+                    class="bp3-popover-target"
+                  >
+                    <button
+                      class="MultiTypeInput--btn MultiTypeInput--FIXED"
+                    >
+                      <span
+                        class="bp3-icon StyledProps--main"
+                        data-icon="fixed-input"
+                      >
+                        <svg
+                          height="12"
+                          viewBox="0 0 9 9"
+                          width="12"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M5.61 7.55c.62-.7.3-1.42.18-2.35a.32.32 0 01.1-.29l1.43-1.42a.76.76 0 01.28-.15c.39-.1 1 0 1.28-.29a.34.34 0 000-.51L6.46.12a.33.33 0 00-.52 0c-.28.29-.2.9-.28 1.3a.53.53 0 01-.13.23L4.09 3.12a.29.29 0 01-.28.09c-.89-.11-1.6-.49-2.27.11-.29.26-.29.43 0 .7l1.31 1.34.15.16-.15.15-2.7 2.69a.36.36 0 000 .54.36.36 0 00.54-.05l2.63-2.68.17-.17.17.16c.45.46.9.91 1.36 1.36.21.21.42.22.59.03z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                      </span>
+                    </button>
+                  </span>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div>
+      <p
+        class="StyledProps--font StyledProps--main inputheader StyledProps--margin-top-medium"
+      />
+      <div
+        class="Layout--vertical StyledProps--main inputWidth layoutVerticalSpacing"
+        data-name="manifest"
+      >
+        <div
+          class="verticalSpacingInput"
+        >
+          <div
+            class="bp3-form-group"
+          >
+            <label
+              class="bp3-label"
+              for="stages[0].stage.spec.serviceConfig.serviceDefinition.spec.manifests[2].manifest.spec.store.spec.filePath"
+            >
+              pipeline.manifestType.customRemoteExtractedFileLocation
+               
+              <span
+                class="bp3-text-muted"
+              />
+            </label>
+            <div
+              class="bp3-form-content"
+            >
+              <div
+                class="Layout--horizontal StyledProps--main MultiTypeInput--main"
+              >
+                <div
+                  class="bp3-input-group MultiTypeInput--input"
+                >
+                  <input
+                    autocomplete="off"
+                    class="bp3-input"
+                    name="stages[0].stage.spec.serviceConfig.serviceDefinition.spec.manifests[2].manifest.spec.store.spec.filePath"
+                    type="text"
+                    value=""
+                  />
+                </div>
                 <span
                   class="bp3-popover-wrapper MultiTypeInput--wrapper"
                 >

--- a/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/ManifestSource/OpenshiftTemplateManifestSource/__tests__/mocks.ts
+++ b/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/ManifestSource/OpenshiftTemplateManifestSource/__tests__/mocks.ts
@@ -24,6 +24,43 @@ export const manifests = [
         skipResourceVersioning: '<+input>'
       }
     }
+  },
+  {
+    manifest: {
+      identifier: 'OpenShift',
+      type: 'OpenshiftTemplate',
+      spec: {
+        paramsPaths: ['params-path'],
+        store: {
+          type: 'Github',
+          spec: {
+            connectorRef: '<+input>',
+            gitFetchType: 'Branch',
+            paths: ['./'],
+            repoName: '<+input>',
+            branch: 'branch'
+          }
+        },
+        skipResourceVersioning: '<+input>'
+      }
+    }
+  },
+  {
+    manifest: {
+      identifier: 'manifestIdentifier',
+      type: 'OpenshiftTemplate',
+      spec: {
+        store: {
+          type: 'CustomeRemote',
+          spec: {
+            filePath: 'file-path',
+            extractionScript: 'script',
+            delegateSelectors: ['delegate-selector']
+          }
+        },
+        skipResourceVersioning: false
+      }
+    }
   }
 ]
 
@@ -45,6 +82,42 @@ export const template = {
             }
           },
           skipResourceVersioning: '<+input>'
+        }
+      }
+    },
+    {
+      manifest: {
+        identifier: 'OpenShift',
+        type: 'OpenshiftTemplate',
+        spec: {
+          paramsPaths: ['params-path'],
+          store: {
+            type: 'Github',
+            spec: {
+              connectorRef: '<+input>',
+              gitFetchType: 'Branch',
+              paths: ['./'],
+              repoName: '<+input>',
+              branch: 'branch'
+            }
+          },
+          skipResourceVersioning: '<+input>'
+        }
+      }
+    },
+    {
+      manifest: {
+        identifier: 'ident',
+        type: 'K8sManifest',
+        spec: {
+          store: {
+            type: 'CustomeRemote',
+            spec: {
+              filePath: '<+input>',
+              extractionScript: 'script',
+              delegateSelectors: ['delegate-selector']
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
### Summary

<!-- ✍️ A clear and concise description...-->

#### Screenshots

NA
<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [x] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [x] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier: `fix prettier`
</details>
