### PR TITLE
feat: [PIE-4406]: enhance resource constraint step hover message

### DIFF
--- a/src/modules/70-pipeline/pages/execution/ExecutionPipelineView/ExecutionGraphView/ExecutionStageDetails/ExecutionStageDetails.tsx
+++ b/src/modules/70-pipeline/pages/execution/ExecutionPipelineView/ExecutionGraphView/ExecutionStageDetails/ExecutionStageDetails.tsx
@@ -192,7 +192,7 @@ export default function ExecutionStageDetails(props: ExecutionStageDetailsProps)
       event.target,
       {
         event,
-        data: { data: stageData }
+        data: { data: stageData, module: stage?.module, moduleInfo: stage?.moduleInfo }
       },
       { useArrows: true, darkMode: false, fixedPosition: false, placement: 'top' }
     )

--- a/src/modules/70-pipeline/pages/execution/ExecutionPipelineView/ExecutionGraphView/ExecutionStageDetails/components/ResourceConstraints/ResourceConstraints.tsx
+++ b/src/modules/70-pipeline/pages/execution/ExecutionPipelineView/ExecutionGraphView/ExecutionStageDetails/components/ResourceConstraints/ResourceConstraints.tsx
@@ -72,6 +72,9 @@ export default function ResourceConstraintTooltip(props: ResourceConstraintToolt
                 ? getString('pipeline.resourceConstraints.serverlessInfraEntity')
                 : getString('pipeline.resourceConstraints.k8sNamespaceText')
             })}
+            <a href="https://docs.harness.io/article/jrzwrdpvm2" target="_blank" rel="noopener noreferrer">
+              {getString('learnMore')}
+            </a>
           </Text>
           {props?.data?.executionList?.map((pipeline: ResourceConstraintDetail, index: number) => (
             <Container key={`${pipeline.pipelineIdentifier}-${index}`}>

--- a/src/modules/70-pipeline/pages/execution/ExecutionPipelineView/ExecutionGraphView/ExecutionStageDetails/components/ResourceConstraints/__test__/__snapshots__/ResourceConstraints.test.tsx.snap
+++ b/src/modules/70-pipeline/pages/execution/ExecutionPipelineView/ExecutionGraphView/ExecutionStageDetails/components/ResourceConstraints/__test__/__snapshots__/ResourceConstraints.test.tsx.snap
@@ -12,6 +12,13 @@ exports[`ResourceConstraintTooltip matches snapshot 1`] = `
         class="StyledProps--font StyledProps--main StyledProps--font-size-small"
       >
         pipeline.resourceConstraints.infoText
+        <a
+          href="https://docs.harness.io/article/jrzwrdpvm2"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          learnMore
+        </a>
       </p>
       <div
         class="StyledProps--font StyledProps--main"

--- a/src/modules/70-pipeline/strings/strings.en.yaml
+++ b/src/modules/70-pipeline/strings/strings.en.yaml
@@ -481,7 +481,7 @@ execution:
     abortTitle: Abort Execution?
 resourceConstraints:
   title: Resource Constraint
-  infoText: 'You have {{executioncount}} {{executiontext}} in queue that have to complete before your execution begins. Only one execution on a {{infraEntityText}} is allowed at a time.'
+  infoText: You have {{executioncount}} Pipeline {{executiontext}} queued for this {{infraEntityText}}. Only one execution on the same {{infraEntityText}} is allowed at a time.
   currentlyExecuting: ' ( currently executing )'
   yourPipeline: ' ( your execution )'
   k8sNamespaceText: K8s namespace


### PR DESCRIPTION
### Summary
- enhance resource constraint step hover message as suggested by docs team
- For serverless deployment type `K8s namespace` word was appearing in Resource Constraints message popover which happened due to new refactoring in diagram, fixed this issue

#### Screenshots
<img width="1792" alt="Screenshot 2022-07-08 at 4 03 56 PM" src="https://user-images.githubusercontent.com/81295223/177976165-b4beb79d-823c-423c-9cb3-b10bdbf69bff.png">

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [x] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier: `fix prettier`
</details>
