### PR TITLE
feat: [SRM-11096]: fixing the scenario where templatised monitored service is created with all fixed inputs

### DIFF
--- a/src/modules/85-cv/components/PipelineSteps/ContinousVerification/components/ContinousVerificationWidget/components/ContinousVerificationWidgetSections/components/SelectMonitoredServiceType/SelectMonitoredServiceType.utils.ts
+++ b/src/modules/85-cv/components/PipelineSteps/ContinousVerification/components/ContinousVerificationWidget/components/ContinousVerificationWidgetSections/components/SelectMonitoredServiceType/SelectMonitoredServiceType.utils.ts
@@ -39,7 +39,7 @@ export function getUpdatedSpecs(
   templateData?: TemplateSummaryResponse
 ): ContinousVerificationData['spec'] {
   let newSpecs = { ...formValues.spec }
-  const inputSet = parse(templateInputYaml?.data as string)
+  const inputSet = templateInputYaml?.data ? parse(templateInputYaml?.data as string) : {}
   const { versionLabel = '', identifier = '' } = templateData || {}
   const updatedMonitoredService = {
     ...formValues.spec.monitoredService,

--- a/src/modules/85-cv/components/PipelineSteps/ContinousVerification/components/ContinousVerificationWidget/components/ContinousVerificationWidgetSections/components/SelectMonitoredServiceType/__tests__/SelectMonitoredServiceType.mock.ts
+++ b/src/modules/85-cv/components/PipelineSteps/ContinousVerification/components/ContinousVerificationWidget/components/ContinousVerificationWidgetSections/components/SelectMonitoredServiceType/__tests__/SelectMonitoredServiceType.mock.ts
@@ -311,3 +311,128 @@ export const mockedFormikWithTemplatesData = {
   validateOnChange: true,
   validateOnMount: false
 } as any
+
+export const mockedTemplateInputYaml = {
+  status: 'SUCCESS',
+  data: 'type: "Application"\nserviceRef: "<+input>"\nenvironmentRef: "<+input>"\nsources:\n  healthSources:\n  - identifier: "AddD_Health_source"\n    type: "AppDynamics"\n    spec:\n      applicationName: "<+input>"\n      tierName: "<+input>"\n      metricDefinitions:\n      - identifier: "appdMetric"\n        completeMetricPath: "<+input>"\n        analysis:\n          deploymentVerification:\n            serviceInstanceMetricPath: "<+input>"\nvariables:\n- name: "connectorRef"\n  type: "String"\n  value: "<+input>"\n',
+  metaData: null,
+  correlationId: '423a4b39-90cd-4d49-9dc5-0a55a29cdb4b'
+} as any
+
+export const mockedTemplateData = {
+  accountId: 'zEaak-FLS425IEO7OLzMUg',
+  orgIdentifier: 'SRM',
+  projectIdentifier: 'SRM',
+  identifier: 'Complete_Monitored_service_templates',
+  name: 'Complete Monitored service templates',
+  description: '',
+  tags: {},
+  yaml: 'template:\n    name: Complete Monitored service templates\n    identifier: Complete_Monitored_service_templates\n    versionLabel: "1.0"\n    type: MonitoredService\n    projectIdentifier: SRM\n    orgIdentifier: SRM\n    tags: {}\n    spec:\n        serviceRef: <+input>\n        environmentRef: <+input>\n        type: Application\n        sources:\n            changeSources:\n                - name: Harness CD Next Gen\n                  identifier: harness_cd_next_gen\n                  type: HarnessCDNextGen\n                  enabled: true\n                  category: Deployment\n                  spec: {}\n            healthSources:\n                - name: AddD Health source\n                  identifier: AddD_Health_source\n                  type: AppDynamics\n                  spec:\n                      applicationName: <+input>\n                      tierName: <+input>\n                      metricData:\n                          Errors: true\n                          Performance: true\n                      metricDefinitions:\n                          - identifier: appdMetric\n                            metricName: appdMetric\n                            baseFolder: ""\n                            metricPath: ""\n                            completeMetricPath: <+input>\n                            groupName: group-1\n                            sli:\n                                enabled: true\n                            analysis:\n                                riskProfile:\n                                    category: Errors\n                                    metricType: ERROR\n                                    thresholdTypes:\n                                        - ACT_WHEN_HIGHER\n                                liveMonitoring:\n                                    enabled: true\n                                deploymentVerification:\n                                    enabled: true\n                                    serviceInstanceMetricPath: <+input>\n                      feature: Application Monitoring\n                      connectorRef: <+monitoredService.variables.connectorRef>\n                      metricPacks:\n                          - identifier: Errors\n                          - identifier: Performance\n        variables:\n            - name: connectorRef\n              type: String\n              value: <+input>\n',
+  versionLabel: '1.0',
+  templateEntityType: 'MonitoredService',
+  childType: 'Application',
+  templateScope: 'project',
+  version: 2,
+  gitDetails: {
+    objectId: '',
+    branch: '',
+    repoIdentifier: '',
+    rootFolder: '',
+    filePath: '',
+    repoName: '',
+    commitId: '',
+    fileUrl: ''
+  },
+  entityValidityDetails: {
+    valid: true,
+    invalidYaml: ''
+  },
+  lastUpdatedAt: 1657260572124,
+  createdAt: 1657259935668,
+  stableTemplate: true
+} as any
+
+export const updatedSpecs = {
+  healthSources: [],
+  initialMonitoredService: {
+    spec: {
+      monitoredServiceTemplateRef: 'Complete_Monitored_service_templates',
+      templateInputs: {
+        environmentRef: '<+input>',
+        serviceRef: '<+input>',
+        sources: {
+          healthSources: [
+            {
+              identifier: 'AddD_Health_source',
+              spec: {
+                applicationName: '<+input>',
+                metricDefinitions: [
+                  {
+                    analysis: {
+                      deploymentVerification: {
+                        serviceInstanceMetricPath: '<+input>'
+                      }
+                    },
+                    completeMetricPath: '<+input>',
+                    identifier: 'appdMetric'
+                  }
+                ],
+                tierName: '<+input>'
+              },
+              type: 'AppDynamics'
+            }
+          ]
+        },
+        type: 'Application',
+        variables: [{ name: 'connectorRef', type: 'String', value: '<+input>' }]
+      },
+      versionLabel: '1.0'
+    },
+    type: 'Template'
+  },
+  monitoredService: {
+    spec: {
+      monitoredServiceTemplateRef: 'Complete_Monitored_service_templates',
+      templateInputs: {
+        environmentRef: '<+input>',
+        serviceRef: '<+input>',
+        sources: {
+          healthSources: [
+            {
+              identifier: 'AddD_Health_source',
+              spec: {
+                applicationName: '<+input>',
+                metricDefinitions: [
+                  {
+                    analysis: {
+                      deploymentVerification: {
+                        serviceInstanceMetricPath: '<+input>'
+                      }
+                    },
+                    completeMetricPath: '<+input>',
+                    identifier: 'appdMetric'
+                  }
+                ],
+                tierName: '<+input>'
+              },
+              type: 'AppDynamics'
+            }
+          ]
+        },
+        type: 'Application',
+        variables: [{ name: 'connectorRef', type: 'String', value: '<+input>' }]
+      },
+      versionLabel: '1.0'
+    },
+    type: 'Template'
+  },
+  monitoredServiceRef: '',
+  spec: {
+    baseline: '',
+    deploymentTag: '<+serviceConfig.artifacts.primary.tag>',
+    duration: { label: '5 min', value: '5m' },
+    sensitivity: { label: 'High', value: 'HIGH' },
+    trafficsplit: ''
+  },
+  type: 'Rolling'
+}

--- a/src/modules/85-cv/components/PipelineSteps/ContinousVerification/components/ContinousVerificationWidget/components/ContinousVerificationWidgetSections/components/SelectMonitoredServiceType/__tests__/SelectMonitoredServiceType.test.tsx
+++ b/src/modules/85-cv/components/PipelineSteps/ContinousVerification/components/ContinousVerificationWidget/components/ContinousVerificationWidgetSections/components/SelectMonitoredServiceType/__tests__/SelectMonitoredServiceType.test.tsx
@@ -11,7 +11,13 @@ import type { MultiTypeInputType } from '@harness/uicore'
 import { TestWrapper } from '@common/utils/testUtils'
 
 import SelectMonitoredServiceType, { SelectMonitoredServiceTypeProps } from '../SelectMonitoredServiceType'
-import { mockedFormikWithTemplatesData } from './SelectMonitoredServiceType.mock'
+import {
+  mockedFormikWithTemplatesData,
+  mockedTemplateData,
+  mockedTemplateInputYaml,
+  updatedSpecs
+} from './SelectMonitoredServiceType.mock'
+import { getUpdatedSpecs } from '../SelectMonitoredServiceType.utils'
 
 jest.mock('services/cv', () => {
   return {
@@ -90,5 +96,11 @@ describe('Unit tests for SelectMonitoredServiceType', () => {
     const { queryByText } = render(<WrapperComponent {...props} />)
     const useTemplateButton = queryByText('common.useTemplate')
     expect(useTemplateButton).toBeInTheDocument()
+  })
+
+  test('Validate getUpdatedSpecs method', () => {
+    expect(getUpdatedSpecs(mockedFormikWithTemplatesData.values, mockedTemplateInputYaml, mockedTemplateData)).toEqual(
+      updatedSpecs
+    )
   })
 })


### PR DESCRIPTION
1. Fixing the scenario where templatised monitored service is created with all fixed inputs

### Summary

<!-- ✍️ A clear and concise description...-->

#### Screenshots

NA
<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier: `fix prettier`
</details>
