### PR TITLE
fix: [PIE-1787]: Added MI tab under approval stage with failure strategy

### DIFF
--- a/src/modules/70-pipeline/components/execution/StepDetails/views/HarnessApprovalView/HarnessApprovalView.tsx
+++ b/src/modules/70-pipeline/components/execution/StepDetails/views/HarnessApprovalView/HarnessApprovalView.tsx
@@ -146,14 +146,15 @@ export function HarnessApprovalView(props: HarnessApprovalViewProps): React.Reac
           />
         }
       />
-      {isManualInterruption ? (
+      {isManualInterruption && (
         <Tabs.Tab
           id={ApprovalStepTab.MANUAL_INTERVENTION}
           key={ApprovalStepTab.MANUAL_INTERVENTION}
           title={getString('pipeline.failureStrategies.strategiesLabel.ManualIntervention')}
           panel={<ManualInterventionTab step={step} allowedStrategies={failureStrategies} />}
         />
-      ) : (
+      )}
+      {activeTab === ApprovalStepTab.APPROVAL && (
         <>
           <Tabs.Expander />
           <Button
@@ -161,7 +162,6 @@ export function HarnessApprovalView(props: HarnessApprovalViewProps): React.Reac
             intent="primary"
             icon="refresh"
             iconProps={{ size: 12, style: { marginRight: 'var(--spacing-2)' } }}
-            style={{ transform: 'translateY(-5px)' }}
             onClick={() => refetch()}
           >
             {getString('common.refresh')}

--- a/src/modules/70-pipeline/components/execution/StepDetails/views/HarnessApprovalView/HarnessApprovalView.tsx
+++ b/src/modules/70-pipeline/components/execution/StepDetails/views/HarnessApprovalView/HarnessApprovalView.tsx
@@ -5,14 +5,14 @@
  * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
  */
 
-import React from 'react'
+import React, { useEffect } from 'react'
 import { Spinner, Tabs } from '@blueprintjs/core'
 import { Button, Layout, PageError } from '@wings-software/uicore'
 import { get, merge } from 'lodash-es'
 
 import { useStrings } from 'framework/strings'
 import type { StepDetailProps } from '@pipeline/factories/ExecutionFactory/types'
-import { isExecutionWaiting } from '@pipeline/utils/statusHelpers'
+import { isExecutionWaiting, isExecutionWaitingForIntervention } from '@pipeline/utils/statusHelpers'
 
 import { HarnessApprovalTab } from '@pipeline/components/execution/StepDetails/tabs/HarnessApprovalTab/HarnessApprovalTab'
 import { PipelineDetailsTab } from '@pipeline/components/execution/StepDetails/tabs/PipelineDetailsTab/PipelineDetailsTab'
@@ -22,6 +22,11 @@ import {
   AuthMock,
   ApprovalMock
 } from '@pipeline/components/execution/StepDetails/views/HarnessApprovalView/useHarnessApproval'
+import { ManualInterventionTab } from '@pipeline/components/execution/StepDetails/tabs/ManualInterventionTab/ManualInterventionTab'
+import { StepMode } from '@pipeline/utils/stepUtils'
+import { allowedStrategiesAsPerStep } from '@pipeline/components/PipelineSteps/AdvancedSteps/FailureStrategyPanel/StrategySelection/StrategyConfig'
+import { Strategy } from '@pipeline/utils/FailureStrategyUtils'
+import { StageType } from '@pipeline/utils/stageHelpers'
 import tabCss from '../DefaultView/DefaultView.module.scss'
 
 export interface HarnessApprovalViewProps extends StepDetailProps {
@@ -29,10 +34,35 @@ export interface HarnessApprovalViewProps extends StepDetailProps {
   getApprovalAuthorizationMock?: AuthMock
 }
 
+enum ApprovalStepTab {
+  APPROVAL = 'APPROVAL',
+  PIPELINE_DETAILS = 'PIPELINE_DETAILS',
+  INPUT = 'INPUT',
+  OUTPUT = 'OUTPUT',
+  MANUAL_INTERVENTION = 'MANUAL_INTERVENTION'
+}
+
 export function HarnessApprovalView(props: HarnessApprovalViewProps): React.ReactElement {
-  const { step, mock, getApprovalAuthorizationMock } = props
+  const { step, mock, getApprovalAuthorizationMock, stageType = StageType.DEPLOY } = props
   const approvalInstanceId = get(step, 'executableResponses[0].async.callbackIds[0]') || ''
+  const manuallySelected = React.useRef(false)
+  const [activeTab, setActiveTab] = React.useState(ApprovalStepTab.APPROVAL)
   const isWaiting = isExecutionWaiting(step.status)
+  const isManualInterruption = isExecutionWaitingForIntervention(step.status)
+  const failureStrategies = allowedStrategiesAsPerStep(stageType)[StepMode.STEP].filter(
+    st => st !== Strategy.ManualIntervention
+  )
+
+  useEffect(() => {
+    if (!manuallySelected.current) {
+      let tab = ApprovalStepTab.APPROVAL
+      if (isManualInterruption) {
+        tab = ApprovalStepTab.MANUAL_INTERVENTION
+      }
+      setActiveTab(tab)
+    }
+  }, [step.identifier, isManualInterruption])
+
   const { getString } = useStrings()
 
   const {
@@ -64,10 +94,19 @@ export function HarnessApprovalView(props: HarnessApprovalViewProps): React.Reac
   }
 
   return (
-    <Tabs id="step-details" className={tabCss.tabs} renderActiveTabPanelOnly>
+    <Tabs
+      id="step-details"
+      className={tabCss.tabs}
+      renderActiveTabPanelOnly
+      selectedTabId={activeTab}
+      onChange={newTab => {
+        manuallySelected.current = true
+        setActiveTab(newTab as ApprovalStepTab)
+      }}
+    >
       <Tabs.Tab
-        key="Approval"
-        id="Approval"
+        key={ApprovalStepTab.APPROVAL}
+        id={ApprovalStepTab.APPROVAL}
         title={getString('approvalStage.title')}
         panel={
           <HarnessApprovalTab
@@ -84,20 +123,20 @@ export function HarnessApprovalView(props: HarnessApprovalViewProps): React.Reac
         }
       />
       <Tabs.Tab
-        id="PipelineDetails"
-        key="PipelineDetails"
+        id={ApprovalStepTab.PIPELINE_DETAILS}
+        key={ApprovalStepTab.PIPELINE_DETAILS}
         title={getString('common.pipelineDetails')}
         panel={<PipelineDetailsTab />}
       />
       <Tabs.Tab
-        id="Input"
-        key="Input"
+        id={ApprovalStepTab.INPUT}
+        key={ApprovalStepTab.INPUT}
         title={getString('common.input')}
         panel={<InputOutputTab baseFqn={step.baseFqn} mode="input" data={step.stepParameters} />}
       />
       <Tabs.Tab
-        id="Output"
-        key="Output"
+        id={ApprovalStepTab.OUTPUT}
+        key={ApprovalStepTab.OUTPUT}
         title={getString('outputLabel')}
         panel={
           <InputOutputTab
@@ -107,17 +146,28 @@ export function HarnessApprovalView(props: HarnessApprovalViewProps): React.Reac
           />
         }
       />
-      <Tabs.Expander />
-      <Button
-        minimal
-        intent="primary"
-        icon="refresh"
-        iconProps={{ size: 12, style: { marginRight: 'var(--spacing-2)' } }}
-        style={{ transform: 'translateY(-5px)' }}
-        onClick={() => refetch()}
-      >
-        {getString('common.refresh')}
-      </Button>
+      {isManualInterruption ? (
+        <Tabs.Tab
+          id={ApprovalStepTab.MANUAL_INTERVENTION}
+          key={ApprovalStepTab.MANUAL_INTERVENTION}
+          title={getString('pipeline.failureStrategies.strategiesLabel.ManualIntervention')}
+          panel={<ManualInterventionTab step={step} allowedStrategies={failureStrategies} />}
+        />
+      ) : (
+        <>
+          <Tabs.Expander />
+          <Button
+            minimal
+            intent="primary"
+            icon="refresh"
+            iconProps={{ size: 12, style: { marginRight: 'var(--spacing-2)' } }}
+            style={{ transform: 'translateY(-5px)' }}
+            onClick={() => refetch()}
+          >
+            {getString('common.refresh')}
+          </Button>
+        </>
+      )}
     </Tabs>
   )
 }


### PR DESCRIPTION
### Summary

Added Manual Intervention tab under approval stage with failure strategy.

#### Screenshots


https://user-images.githubusercontent.com/73639897/179738854-c4dc4c6b-6a24-4fd1-9028-b48b4e822162.mov



#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier: `fix prettier`
</details>
