### PR TITLE
[WIP] fix: [OPA-456]: Initial loading spinner for Policy Engine is aligned …

### DIFF
--- a/src/modules/25-governance/RouteDestinations.tsx
+++ b/src/modules/25-governance/RouteDestinations.tsx
@@ -7,7 +7,6 @@
 
 import React, { useEffect } from 'react'
 import { Route, useHistory, useParams } from 'react-router-dom'
-import { Container } from '@wings-software/uicore'
 import routes from '@common/RouteDefinitions'
 import { accountPathProps } from '@common/utils/routeUtils'
 import { RouteWithLayout } from '@common/router'
@@ -130,11 +129,7 @@ export const GovernanceRouteDestinations: React.FC<{
         pageName={PAGE_NAME.OPAPolicyDashboard}
       >
         <GovernanceRemoteComponentMounter
-          spinner={
-            <Container height="100%" flex={{ align: 'center-center' }}>
-              <ContainerSpinner />
-            </Container>
-          }
+          spinner={<ContainerSpinner height="100vh" flex={{ align: 'center-center' }} />}
         />
       </RouteWithLayout>
     </Route>


### PR DESCRIPTION
…to the top

### Summary

Policy Engine suspense spinner no longer fixed to top of page

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier: `fix prettier`
</details>
