### PR TITLE
fix: [FFM-4040]: Removing or statement which causes prerequisites to appear empty on load

### DIFF
--- a/src/modules/75-cf/components/FlagActivation/FlagPrerequisites.tsx
+++ b/src/modules/75-cf/components/FlagActivation/FlagPrerequisites.tsx
@@ -98,8 +98,8 @@ export const FlagPrerequisites: React.FC<FlagPrerequisitesProps> = props => {
   })
 
   const featureList = useMemo(() => {
-    return searchedFeatures?.features?.filter(_feature => _feature.identifier !== featureFlag.identifier) || []
-  }, [featureFlag.identifier, searchedFeatures?.features?.filter])
+    return searchedFeatures?.features?.filter(_feature => _feature.identifier !== featureFlag.identifier)
+  }, [featureFlag.identifier, searchedFeatures?.features])
 
   const [isEditingPrerequisites, setEditingPrerequisites] = useState<boolean>(false)
 

--- a/src/modules/75-cf/components/FlagActivation/__tests__/__snapshots__/FlagPrerequisites.test.tsx.snap
+++ b/src/modules/75-cf/components/FlagActivation/__tests__/__snapshots__/FlagPrerequisites.test.tsx.snap
@@ -54,7 +54,7 @@ exports[`FlagPrerequisites it should render correctly 1`] = `
                         placeholder="- Select -"
                         style="padding-right: 0px;"
                         type="text"
-                        value=""
+                        value="Bool_2"
                       />
                       <span
                         class="bp3-input-action"
@@ -172,7 +172,7 @@ exports[`FlagPrerequisites it should render correctly 1`] = `
                         placeholder="- Select -"
                         style="padding-right: 0px;"
                         type="text"
-                        value=""
+                        value="Multivar_1"
                       />
                       <span
                         class="bp3-input-action"
@@ -290,7 +290,7 @@ exports[`FlagPrerequisites it should render correctly 1`] = `
                         placeholder="- Select -"
                         style="padding-right: 0px;"
                         type="text"
-                        value=""
+                        value="Test_Bool_1"
                       />
                       <span
                         class="bp3-input-action"


### PR DESCRIPTION
### Summary

No need to initially check for undefined because we do it later down the line in the form itself. Doing this meant on load it was always returning '[]'.

The snapshot test was also incorrectly checking that the textbox contained "" instead of the actual pre-requisite flag name.

#### Screenshots

Fix:
<img width="1281" alt="image" src="https://user-images.githubusercontent.com/103498167/180472550-0f104efc-4ba9-46b4-b4fc-0ae0b904b87d.png">


#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier: `fix prettier`
</details>
