### PR TITLE
fix: [PL-26686]: Show input set error response

### DIFF
--- a/src/modules/70-pipeline/components/InputSetForm/InputSetForm.tsx
+++ b/src/modules/70-pipeline/components/InputSetForm/InputSetForm.tsx
@@ -587,11 +587,17 @@ export function InputSetForm(props: InputSetFormProps): React.ReactElement {
     ]
   )
 
-  return executionView ? (
-    child()
-  ) : isGitSimplificationEnabled && !loadingInputSet && inputSetError ? (
-    <NoEntityFound identifier={inputSetIdentifier} entityType={'inputSet'} errorObj={inputSetError.data as Error} />
-  ) : (
+  if (executionView) {
+    return child()
+  }
+
+  if (isGitSimplificationEnabled && !loadingInputSet && inputSetError) {
+    return (
+      <NoEntityFound identifier={inputSetIdentifier} entityType={'inputSet'} errorObj={inputSetError.data as Error} />
+    )
+  }
+
+  return (
     <InputSetFormWrapper
       loading={
         loadingInputSet ||

--- a/src/modules/70-pipeline/components/InputSetForm/InputSetForm.tsx
+++ b/src/modules/70-pipeline/components/InputSetForm/InputSetForm.tsx
@@ -590,7 +590,7 @@ export function InputSetForm(props: InputSetFormProps): React.ReactElement {
   return executionView ? (
     child()
   ) : isGitSimplificationEnabled && !loadingInputSet && inputSetError ? (
-    <NoEntityFound identifier={inputSetIdentifier} entityType={'inputSet'} />
+    <NoEntityFound identifier={inputSetIdentifier} entityType={'inputSet'} errorObj={inputSetError.data as Error} />
   ) : (
     <InputSetFormWrapper
       loading={


### PR DESCRIPTION
### Summary
Show error response from API if input set doesn't exist.

#### Screenshots
![Screenshot 2022-07-25 at 5 35 18 PM](https://user-images.githubusercontent.com/101629876/180773846-7e8a8b02-78ed-4a6e-b066-e24952e5f965.png)


#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier: `fix prettier`
</details>
