### PR TITLE
fix: [CDS-39753]: updation/edit of steps/rollbackSteps based on rollack state

### DIFF
--- a/src/modules/70-pipeline/components/PipelineStudio/ExecutionGraph/ExecutionGraphUtil.ts
+++ b/src/modules/70-pipeline/components/PipelineStudio/ExecutionGraph/ExecutionGraphUtil.ts
@@ -96,6 +96,23 @@ export const getDefaultDependencyServiceState = (): StepState => ({
   isStepGroup: false,
   stepType: StepType.SERVICE
 })
+interface GetStepFromNodeProps {
+  stepData: ExecutionWrapper | undefined
+  node?: DefaultNodeModel
+  isComplete: boolean
+  isFindParallelNode: boolean
+  nodeId?: string
+  parentId?: string
+  isRollback?: boolean
+}
+
+interface RemoveStepOrGroupProps {
+  state: ExecutionGraphState
+  entity: any
+  skipFlatten?: boolean
+  newPipelineStudioEnabled?: boolean
+  isRollback?: boolean
+}
 
 export type StepStateMap = Map<string, StepState>
 
@@ -154,15 +171,15 @@ export const getDependencyFromNodeV1 = (
   return { node: _service, parent: servicesData }
 }
 
-export const getStepFromNode = (
-  stepData: ExecutionWrapper | undefined,
-  node?: DefaultNodeModel,
+export const getStepFromNode = ({
+  stepData,
+  node,
   isComplete = false,
   isFindParallelNode = false,
-  nodeId?: string,
-  parentId?: string,
-  isRollback?: boolean
-): { node: ExecutionWrapper | undefined; parent: ExecutionWrapper[] } => {
+  nodeId,
+  parentId,
+  isRollback
+}: GetStepFromNodeProps): { node: ExecutionWrapper | undefined; parent: ExecutionWrapper[] } => {
   let data = stepData
   if (parentId) {
     const group = getStepFromId(data, defaultTo(parentId, ''), false, false, Boolean(isRollback)).node
@@ -442,13 +459,13 @@ export const updateStepsState = (
   }
 }
 
-export const removeStepOrGroup = (
-  state: ExecutionGraphState,
-  entity: any,
+export const removeStepOrGroup = ({
+  state,
+  entity,
   skipFlatten = false,
-  newPipelineStudioEnabled?: boolean,
+  newPipelineStudioEnabled,
   isRollback = false
-): boolean => {
+}: RemoveStepOrGroupProps): boolean => {
   if (newPipelineStudioEnabled) {
     return removeStepOrGroupV2(state, entity, skipFlatten, isRollback)
   }

--- a/src/modules/70-pipeline/components/PipelineStudio/ExecutionGraph/ExecutionGraphUtil.ts
+++ b/src/modules/70-pipeline/components/PipelineStudio/ExecutionGraph/ExecutionGraphUtil.ts
@@ -160,23 +160,31 @@ export const getStepFromNode = (
   isComplete = false,
   isFindParallelNode = false,
   nodeId?: string,
-  parentId?: string
+  parentId?: string,
+  isRollback?: boolean
 ): { node: ExecutionWrapper | undefined; parent: ExecutionWrapper[] } => {
   let data = stepData
   if (parentId) {
-    const group = getStepFromId(data, defaultTo(parentId, ''), false).node
+    const group = getStepFromId(data, defaultTo(parentId, ''), false, false, Boolean(isRollback)).node
     if (group) {
       data = group
     }
   }
-  return getStepFromId(data, nodeId || node?.getIdentifier() || '', isComplete, isFindParallelNode)
+  return getStepFromId(
+    data,
+    nodeId || node?.getIdentifier() || '',
+    isComplete,
+    isFindParallelNode,
+    data?.rollbackSteps && isRollback ? isRollback : false
+  )
 }
 
 export const getStepFromId = (
   stageData: ExecutionWrapper | undefined,
   id: string,
   isComplete = false,
-  isFindParallelNode = false
+  isFindParallelNode = false,
+  isRollback?: boolean
 ): {
   node: ExecutionWrapper | undefined
   parent: ExecutionWrapper[]
@@ -184,21 +192,16 @@ export const getStepFromId = (
   parallelParentIdx?: number
   parallelParentParent?: ExecutionWrapper[]
 } => {
-  let returnObj = getStepFromIdInternal(
-    (stageData as ExecutionElementConfig)?.steps,
+  return getStepFromIdInternal(
+    (stageData as ExecutionElementConfig)?.[isRollback ? 'rollbackSteps' : 'steps'],
     id,
     isComplete,
-    isFindParallelNode
+    isFindParallelNode,
+    undefined,
+    undefined,
+    undefined,
+    Boolean(isRollback)
   )
-  if (!returnObj.node) {
-    returnObj = getStepFromIdInternal(
-      (stageData as ExecutionElementConfig)?.rollbackSteps,
-      id,
-      isComplete,
-      isFindParallelNode
-    )
-  }
-  return returnObj
 }
 
 const getStepFromIdInternal = (
@@ -208,7 +211,8 @@ const getStepFromIdInternal = (
   isFindParallelNode = false,
   _parallelParent: ExecutionWrapperConfig | undefined = undefined,
   _parallelParentIdx: number | undefined = undefined,
-  _parallelParentParent: ExecutionWrapperConfig[] | undefined = undefined
+  _parallelParentParent: ExecutionWrapperConfig[] | undefined = undefined,
+  isRollback = false
 ): {
   node: ExecutionWrapper | undefined
   parent: ExecutionWrapper[]
@@ -258,7 +262,7 @@ const getStepFromIdInternal = (
               parallelParentIdx = _parallelParentIdx
               return false
             } else {
-              const response = getStepFromId(nodeP.stepGroup, id, isComplete, isFindParallelNode)
+              const response = getStepFromId(nodeP.stepGroup, id, isComplete, isFindParallelNode, isRollback)
               if (response.node) {
                 parent = response.parent
                 stepResp = response.node
@@ -275,7 +279,7 @@ const getStepFromIdInternal = (
           return false
         }
       } else {
-        const response = getStepFromIdInternal(node.parallel, id, isComplete, false, node, idx, stepData)
+        const response = getStepFromIdInternal(node.parallel, id, isComplete, false, node, idx, stepData, isRollback)
         if (response.node) {
           stepResp = response.node
           parent = response.parent
@@ -442,10 +446,11 @@ export const removeStepOrGroup = (
   state: ExecutionGraphState,
   entity: any,
   skipFlatten = false,
-  newPipelineStudioEnabled?: boolean
+  newPipelineStudioEnabled?: boolean,
+  isRollback = false
 ): boolean => {
   if (newPipelineStudioEnabled) {
-    return removeStepOrGroupV2(state, entity, skipFlatten)
+    return removeStepOrGroupV2(state, entity, skipFlatten, isRollback)
   }
   // 1. services
   const servicesData = state.dependenciesData
@@ -467,12 +472,12 @@ export const removeStepOrGroup = (
   let data: ExecutionWrapper = state.stepsData
   const layer = entity.getParent()
   if (layer instanceof StepGroupNodeLayerModel) {
-    const node = getStepFromId(data, layer.getIdentifier() || '', false).node
+    const node = getStepFromId(data, defaultTo(layer.getIdentifier(), ''), false, false, isRollback).node
     if (node) {
       data = node
     }
   }
-  const response = getStepFromId(data, entity.getIdentifier(), true)
+  const response = getStepFromId(data, entity.getIdentifier(), true, false, isRollback)
   if (response.node) {
     const index = response.parent.indexOf(response.node)
     if (index > -1) {
@@ -496,7 +501,12 @@ export const removeStepOrGroup = (
   return isRemoved
 }
 
-export const removeStepOrGroupV2 = (state: ExecutionGraphState, entity: any, skipFlatten = false): boolean => {
+export const removeStepOrGroupV2 = (
+  state: ExecutionGraphState,
+  entity: any,
+  skipFlatten = false,
+  isRollback = false
+): boolean => {
   // 1. services
   const servicesData = state.dependenciesData
   if (servicesData) {
@@ -517,12 +527,18 @@ export const removeStepOrGroupV2 = (state: ExecutionGraphState, entity: any, ski
   let data: ExecutionWrapper = state.stepsData
   // const layer = entity.getParent()
   if (entity?.node?.parentIdentifier) {
-    const node = getStepFromId(data, entity?.node?.parentIdentifier || '', false).node
+    const node = getStepFromId(data, defaultTo(entity?.node?.parentIdentifier, ''), false, false, isRollback).node
     if (node) {
       data = node
     }
   }
-  const response = getStepFromId(data, entity?.node?.identifier, true)
+  const response = getStepFromId(
+    data,
+    entity?.node?.identifier,
+    true,
+    false,
+    data?.rollbackSteps && isRollback ? isRollback : false
+  )
   if (response.node) {
     const index = response.parent.indexOf(response.node)
     if (index > -1) {
@@ -582,16 +598,16 @@ export const addStepOrGroup = (
     if (isLinkUnderStepGroup(entity)) {
       const layer = sourceNode.getParent()
       if (layer instanceof StepGroupNodeLayerModel) {
-        const node = getStepFromId(data, layer.getIdentifier() || '', false).node
+        const node = getStepFromId(data, defaultTo(layer.getIdentifier(), ''), false, false, isRollback).node
         if (node) {
           data = node
         }
       }
     }
-    let response = getStepFromId(data, sourceNode.getIdentifier(), true)
+    let response = getStepFromId(data, sourceNode.getIdentifier(), true, false, isRollback)
     let next = 1
     if (!response.node) {
-      response = getStepFromId(data, targetNode.getIdentifier(), true)
+      response = getStepFromId(data, targetNode.getIdentifier(), true, false, isRollback)
       next = 0
     }
     if (response.node) {
@@ -602,11 +618,11 @@ export const addStepOrGroup = (
     } else {
       // parallel next parallel case
       let nodeId = sourceNode.getIdentifier().split(EmptyNodeSeparator)[1]
-      response = getStepFromId(data, nodeId, true, true)
+      response = getStepFromId(data, nodeId, true, true, isRollback)
       next = 1
       if (!response.node) {
         nodeId = targetNode.getIdentifier().split(EmptyNodeSeparator)[2]
-        response = getStepFromId(data, nodeId, true, true)
+        response = getStepFromId(data, nodeId, true, true, isRollback)
         next = 0
       }
       if (response.node) {
@@ -619,7 +635,7 @@ export const addStepOrGroup = (
   } else if (entity instanceof CreateNewModel) {
     // Steps if you are under step group
     const groupId = entity.getIdentifier().split(EmptyNodeSeparator)[1]
-    const node = getStepFromId(data, groupId).node
+    const node = getStepFromId(data, groupId, false, false, isRollback).node
     const layer = entity.getParent()
     if (layer instanceof StepGroupNodeLayerModel) {
       const options = layer.getOptions() as StepGroupNodeLayerOptions
@@ -641,7 +657,7 @@ export const addStepOrGroup = (
     }
   } else if (entity instanceof DefaultNodeModel) {
     if (isParallel) {
-      const response = getStepFromId(data, entity.getIdentifier(), true, true) as {
+      const response = getStepFromId(data, entity.getIdentifier(), true, true, isRollback) as {
         node: ExecutionWrapperConfig
         parent: ExecutionWrapperConfig[]
       }
@@ -664,7 +680,7 @@ export const addStepOrGroup = (
     }
   } else if (entity instanceof StepGroupNodeLayerModel) {
     if (isParallel) {
-      const response = getStepFromId(data, entity.getIdentifier() || '', true, true) as {
+      const response = getStepFromId(data, defaultTo(entity.getIdentifier(), ''), true, true, isRollback) as {
         node: ExecutionWrapperConfig
         parent: ExecutionWrapperConfig[]
       }
@@ -693,15 +709,27 @@ export const addStepOrGroupV2 = (
     const sourceNode = entity?.isRightAddIcon ? entity?.node : entity?.node?.prevNode
     const targetNode = entity?.isRightAddIcon ? entity?.node?.nextNode : entity?.node
     if (entity?.node?.parentIdentifier) {
-      const node = getStepFromId(data, entity?.node?.parentIdentifier || '', false).node
+      const node = getStepFromId(data, defaultTo(entity?.node?.parentIdentifier, ''), false, false, isRollback).node
       if (node) {
         data = node
       }
     }
-    let response = getStepFromId(data, sourceNode?.identifier || '', true, sourceNode?.children?.length)
+    let response = getStepFromId(
+      data,
+      defaultTo(sourceNode?.identifier, ''),
+      true,
+      sourceNode?.children?.length,
+      data?.rollbackSteps && isRollback ? isRollback : false
+    )
     let next = 1
     if (!response.node) {
-      response = getStepFromId(data, targetNode?.identifier || '', true, targetNode?.children?.length)
+      response = getStepFromId(
+        data,
+        defaultTo(targetNode?.identifier, ''),
+        true,
+        targetNode?.children?.length,
+        data?.rollbackSteps && isRollback ? isRollback : false
+      )
       next = 0
     }
     if (response.node) {
@@ -713,7 +741,7 @@ export const addStepOrGroupV2 = (
   } else if (entity?.entityType === DiagramType.CreateNew) {
     // Steps if you are under step group
     const groupId = entity?.identifier
-    const node = getStepFromId(data, groupId).node
+    const node = getStepFromId(data, groupId, false, false, isRollback).node
     if (entity?.node?.parentIdentifier) {
       if (isExecutionElementConfig(node) && node?.steps) {
         node.steps.push(step)
@@ -736,7 +764,7 @@ export const addStepOrGroupV2 = (
     }
   } else if (entity?.entityType === DiagramType.Default) {
     if (isParallel) {
-      const response = getStepFromId(data, entity.identifier, true, true) as {
+      const response = getStepFromId(data, entity.identifier, true, true, isRollback) as {
         node: ExecutionWrapperConfig
         parent: ExecutionWrapperConfig[]
       }
@@ -759,7 +787,7 @@ export const addStepOrGroupV2 = (
     }
   } else if (entity?.entityType === DiagramType.StepGroupNode) {
     if (isParallel) {
-      const response = getStepFromId(data, entity.identifier || '', true, true) as {
+      const response = getStepFromId(data, defaultTo(entity.identifier, ''), true, true, isRollback) as {
         node: ExecutionWrapperConfig
         parent: ExecutionWrapperConfig[]
       }

--- a/src/modules/70-pipeline/components/PipelineStudio/PipelineContext/PipelineActions.ts
+++ b/src/modules/70-pipeline/components/PipelineStudio/PipelineContext/PipelineActions.ts
@@ -112,12 +112,13 @@ export interface PipelineViewData {
   }
   isDrawerOpened: boolean
   drawerData: DrawerData
+  isRollbackToggled?: boolean
 }
 
 export interface SelectionState {
-  selectedStageId?: string | undefined
-  selectedStepId?: string | undefined
-  selectedSectionId?: string | undefined
+  selectedStageId?: string
+  selectedStepId?: string
+  selectedSectionId?: string
 }
 
 export interface PipelineReducerState {

--- a/src/modules/70-pipeline/components/PipelineStudio/hooks/useSaveTemplateListener.ts
+++ b/src/modules/70-pipeline/components/PipelineStudio/hooks/useSaveTemplateListener.ts
@@ -25,7 +25,7 @@ export function useSaveTemplateListener(): void {
     state,
     state: {
       selectionState: { selectedStageId = '' },
-      pipelineView: { drawerData }
+      pipelineView: { drawerData, isRollbackToggled }
     },
     updatePipeline,
     updateStage,
@@ -65,7 +65,7 @@ export function useSaveTemplateListener(): void {
       updatePipelineView(newPipelineView)
       const stageData = produce(selectedStage, draft => {
         if (draft?.stage?.spec?.execution) {
-          updateStepWithinStage(draft.stage.spec.execution, selectedStepId, processNode)
+          updateStepWithinStage(draft.stage.spec.execution, selectedStepId, processNode, Boolean(isRollbackToggled))
         }
       })
       if (stageData?.stage) {


### PR DESCRIPTION


### Summary

- propagated `isRollback` to conditionally check `rollbackSteps/steps` while updation/addition of steps.

#### Screenshots

https://user-images.githubusercontent.com/100121280/180965016-2351d377-1dfb-4728-8e49-25aa8e23e983.mov

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier: `fix prettier`
</details>
