### PR TITLE
feat: [CDS-40811]: service now approval change window, v2 endpoint

### DIFF
--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/Common/ApprovalRejectionCriteria.module.scss
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/Common/ApprovalRejectionCriteria.module.scss
@@ -122,10 +122,7 @@
   margin-top: var(--spacing-xlarge);
 
   .windowSelection {
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-medium);
-    margin-top: var(--spacing-medium);
+    margin-top: var(--spacing-medium) !important;
     background-color: var(--white);
     padding: var(--spacing-medium);
   }

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/Common/ApprovalRejectionCriteria.module.scss
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/Common/ApprovalRejectionCriteria.module.scss
@@ -100,12 +100,12 @@
 }
 
 .conditionalContent {
-  background-color: white;
+  background-color: var(--white);
   padding: var(--spacing-medium);
 }
 
 .conditionalContentJexl {
-  background-color: white;
+  background-color: var(--white);
   padding: var(--spacing-large) var(--spacing-medium);
 }
 
@@ -116,4 +116,17 @@
 .title {
   color: var(--grey-800);
   font-weight: 600;
+}
+
+.approvalChangeWindow {
+  margin-top: var(--spacing-xlarge);
+
+  .windowSelection {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-medium);
+    margin-top: var(--spacing-medium);
+    background-color: var(--white);
+    padding: var(--spacing-medium);
+  }
 }

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/Common/ApprovalRejectionCriteria.module.scss.d.ts
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/Common/ApprovalRejectionCriteria.module.scss.d.ts
@@ -8,6 +8,7 @@
 // this is an auto-generated file, do not update this manually
 declare const styles: {
   readonly alignConditions: string
+  readonly approvalChangeWindow: string
   readonly box: string
   readonly conditionalContent: string
   readonly conditionalContentJexl: string
@@ -21,5 +22,6 @@ declare const styles: {
   readonly tab: string
   readonly tabs: string
   readonly title: string
+  readonly windowSelection: string
 }
 export default styles

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/ServiceNowApprovalChangeWindow.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/ServiceNowApprovalChangeWindow.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import { Color } from '@harness/design-system'
+import { FormInput, Layout, Text } from '@harness/uicore'
+import type { FormikContextType } from 'formik'
+import React from 'react'
+import { useVariablesExpression } from '@pipeline/components/PipelineStudio/PiplineHooks/useVariablesExpression'
+import { useStrings } from 'framework/strings'
+import type { ServiceNowApprovalData, ServiceNowTicketTypeSelectOption } from './types'
+import css from '../Common/ApprovalRejectionCriteria.module.scss'
+
+interface ServiceNowApprovalChangeWindowProps {
+  formik: FormikContextType<ServiceNowApprovalData>
+  fetchingServiceNowTicketTypes: boolean
+  serviceNowTicketTypesFetchErrorMessage?: string
+  readonly: boolean
+  serviceNowTicketTypesOptions: ServiceNowTicketTypeSelectOption[]
+}
+
+export function ServiceNowApprovalChangeWindow({
+  formik,
+  fetchingServiceNowTicketTypes,
+  serviceNowTicketTypesFetchErrorMessage,
+  readonly,
+  serviceNowTicketTypesOptions
+}: ServiceNowApprovalChangeWindowProps): React.ReactElement {
+  const { getString } = useStrings()
+  const { expressions } = useVariablesExpression()
+
+  const commonMultiTypeInputProps = (placeholder: string) => ({
+    disabled: !formik.values?.spec.enableChangeWindow || readonly || fetchingServiceNowTicketTypes,
+    selectItems: fetchingServiceNowTicketTypes
+      ? [{ label: getString('pipeline.serviceNowApprovalStep.fetchingTicketTypesPlaceholder'), value: '' }]
+      : serviceNowTicketTypesOptions,
+
+    placeholder: fetchingServiceNowTicketTypes
+      ? getString('pipeline.serviceNowApprovalStep.fetchingTicketTypesPlaceholder')
+      : serviceNowTicketTypesFetchErrorMessage
+      ? serviceNowTicketTypesFetchErrorMessage
+      : `${getString('select')} ${placeholder}`,
+
+    useValue: true,
+    multiTypeInputProps: {
+      selectProps: {
+        addClearBtn: true,
+        items: fetchingServiceNowTicketTypes
+          ? [{ label: getString('pipeline.serviceNowApprovalStep.fetchingTicketTypesPlaceholder'), value: '' }]
+          : serviceNowTicketTypesOptions
+      },
+      expressions
+    }
+  })
+
+  return (
+    <div className={css.approvalChangeWindow}>
+      <Text color={Color.GREY_800} font={{ weight: 'semi-bold', size: 'normal' }}>
+        {getString('pipeline.serviceNowApprovalStep.approvalChangeWindow')}
+      </Text>
+
+      <div className={css.windowSelection}>
+        <FormInput.CheckBox
+          disabled={readonly}
+          name="spec.enableChangeWindow"
+          label={getString('enable')}
+          tooltipProps={{
+            dataTooltipId: 'serviceNowApprovalEnableChangeWindow'
+          }}
+        />
+        <Layout.Horizontal spacing="medium">
+          <FormInput.MultiTypeInput
+            name="spec.changeWindow.startField"
+            label={getString('pipeline.serviceNowApprovalStep.windowStart')}
+            {...commonMultiTypeInputProps(getString('pipeline.serviceNowApprovalStep.windowStart'))}
+          />
+          <FormInput.MultiTypeInput
+            name="spec.changeWindow.endField"
+            label={getString('pipeline.serviceNowApprovalStep.windowEnd')}
+            {...commonMultiTypeInputProps(getString('pipeline.serviceNowApprovalStep.windowEnd'))}
+          />
+        </Layout.Horizontal>
+      </div>
+    </div>
+  )
+}

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/ServiceNowApprovalChangeWindow.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/ServiceNowApprovalChangeWindow.tsx
@@ -40,9 +40,7 @@ export function ServiceNowApprovalChangeWindow({
 
     placeholder: fetchingServiceNowTicketTypes
       ? getString('pipeline.serviceNowApprovalStep.fetchingTicketTypesPlaceholder')
-      : serviceNowTicketTypesFetchErrorMessage
-      ? serviceNowTicketTypesFetchErrorMessage
-      : `${getString('select')} ${placeholder}`,
+      : serviceNowTicketTypesFetchErrorMessage || `${getString('select')} ${placeholder}`,
 
     useValue: true,
     multiTypeInputProps: {
@@ -62,7 +60,7 @@ export function ServiceNowApprovalChangeWindow({
         {getString('pipeline.serviceNowApprovalStep.approvalChangeWindow')}
       </Text>
 
-      <div className={css.windowSelection}>
+      <Layout.Vertical spacing="medium" className={css.windowSelection}>
         <FormInput.CheckBox
           disabled={readonly}
           name="spec.enableChangeWindow"
@@ -83,7 +81,7 @@ export function ServiceNowApprovalChangeWindow({
             {...commonMultiTypeInputProps(getString('pipeline.serviceNowApprovalStep.windowEnd'))}
           />
         </Layout.Horizontal>
-      </div>
+      </Layout.Vertical>
     </div>
   )
 }

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/ServiceNowApprovalStepMode.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/ServiceNowApprovalStepMode.tsx
@@ -47,7 +47,7 @@ import { ConfigureOptions } from '@common/components/ConfigureOptions/ConfigureO
 import { FormMultiTypeConnectorField } from '@connectors/components/ConnectorReferenceField/FormMultiTypeConnectorField'
 import { ApprovalRejectionCriteriaType } from '@pipeline/components/PipelineSteps/Steps/Common/types'
 import {
-  useGetServiceNowIssueCreateMetadata,
+  useGetServiceNowIssueCreateMetadataV2,
   useGetServiceNowTicketTypes,
   ServiceNowFieldNG,
   ServiceNowTicketTypeDTO
@@ -74,9 +74,9 @@ function FormContent({
   refetchServiceNowTicketTypes,
   fetchingServiceNowTicketTypes,
   serviceNowTicketTypesResponse,
-  serviceNowMetadataResponse,
   serviceNowTicketTypesFetchError,
-  refetchServiceNowMetadata
+  serviceNowIssueCreateMetadataResponse,
+  refetchServiceNowIssueCreateMetadata
 }: ServiceNowFormContentInterface): JSX.Element {
   const { getString } = useStrings()
   const { expressions } = useVariablesExpression()
@@ -84,6 +84,10 @@ function FormContent({
     useParams<PipelineType<PipelinePathProps & AccountPathProps>>()
   const { repoIdentifier, branch } = useQueryParams<GitQueryParams>()
   const [ticketFieldList, setTicketFieldList] = useState<ServiceNowFieldNG[]>([])
+  const [ticketFieldInternalTypeMap, setTicketFieldInternalTypeMap] = useState<{
+    [key: string]: string[]
+  }>()
+
   const [count, setCount] = React.useState(0)
   const [serviceNowTicketTypesOptions, setServiceNowTicketTypesOptions] = useState<ServiceNowTicketTypeSelectOption[]>(
     []
@@ -104,10 +108,11 @@ function FormContent({
       : undefined
 
   useEffect(() => {
-    if (ticketTypeKeyFixedValue && serviceNowMetadataResponse?.data) {
-      setTicketFieldList(serviceNowMetadataResponse?.data)
+    if (ticketTypeKeyFixedValue && serviceNowIssueCreateMetadataResponse?.data) {
+      setTicketFieldList(serviceNowIssueCreateMetadataResponse?.data?.fields)
+      setTicketFieldInternalTypeMap(serviceNowIssueCreateMetadataResponse?.data?.fieldInternalTypeMap)
     }
-  }, [serviceNowMetadataResponse?.data, ticketTypeKeyFixedValue])
+  }, [serviceNowIssueCreateMetadataResponse?.data, ticketTypeKeyFixedValue])
 
   useEffect(() => {
     if (connectorRefFixedValue && connectorValueType === MultiTypeInputType.FIXED) {
@@ -122,7 +127,7 @@ function FormContent({
 
   useDeepCompareEffect(() => {
     if (ticketTypeKeyFixedValue && connectorRefFixedValue) {
-      refetchServiceNowMetadata({
+      refetchServiceNowIssueCreateMetadata({
         queryParams: {
           ...commonParams,
           connectorRef: connectorRefFixedValue.toString(),
@@ -338,10 +343,9 @@ function FormContent({
               />
               <ServiceNowApprovalChangeWindow
                 formik={formik}
-                fetchingServiceNowTicketTypes={fetchingServiceNowTicketTypes}
-                serviceNowTicketTypesFetchErrorMessage={serviceNowTicketTypesFetchError?.message}
+                serviceNowIssueCreateMetadataFields={ticketFieldList}
+                serviceNowIssueCreateMetadataFieldInternalTypeMap={ticketFieldInternalTypeMap}
                 readonly={!!readonly}
-                serviceNowTicketTypesOptions={serviceNowTicketTypesOptions}
               />
             </Layout.Vertical>
           }
@@ -380,15 +384,16 @@ function ServiceNowApprovalStepMode(
   })
 
   const {
-    refetch: refetchServiceNowMetadata,
-    data: serviceNowMetadataResponse,
-    error: serviceNowMetadataFetchError,
-    loading: fetchingServiceNowMetadata
-  } = useGetServiceNowIssueCreateMetadata({
+    refetch: refetchServiceNowIssueCreateMetadata,
+    data: serviceNowIssueCreateMetadataResponse,
+    error: serviceNowIssueCreateMetadataFetchError,
+    loading: fetchingServiceNowIssueCreateMetadata
+  } = useGetServiceNowIssueCreateMetadataV2({
     lazy: true,
     queryParams: {
       ...commonParams,
-      connectorRef: ''
+      connectorRef: '',
+      ticketType: ''
     }
   })
   return (
@@ -446,10 +451,10 @@ function ServiceNowApprovalStepMode(
               fetchingServiceNowTicketTypes={fetchingServiceNowTicketTypes}
               serviceNowTicketTypesResponse={serviceNowTicketTypesResponse}
               serviceNowTicketTypesFetchError={serviceNowTicketTypesFetchError}
-              refetchServiceNowMetadata={refetchServiceNowMetadata}
-              fetchingServiceNowMetadata={fetchingServiceNowMetadata}
-              serviceNowMetadataResponse={serviceNowMetadataResponse}
-              serviceNowMetadataFetchError={serviceNowMetadataFetchError}
+              refetchServiceNowIssueCreateMetadata={refetchServiceNowIssueCreateMetadata}
+              fetchingServiceNowIssueCreateMetadata={fetchingServiceNowIssueCreateMetadata}
+              serviceNowIssueCreateMetadataResponse={serviceNowIssueCreateMetadataResponse}
+              serviceNowIssueCreateMetadataFetchError={serviceNowIssueCreateMetadataFetchError}
             />
           </FormikForm>
         )

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/ServiceNowApprovalStepMode.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/ServiceNowApprovalStepMode.tsx
@@ -12,7 +12,8 @@ import {
   FormikForm,
   FormInput,
   getMultiTypeFromValue,
-  MultiTypeInputType
+  MultiTypeInputType,
+  Layout
 } from '@wings-software/uicore'
 import * as Yup from 'yup'
 import type { FormikProps } from 'formik'
@@ -58,6 +59,7 @@ import {
 import { StringKeys, useStrings } from 'framework/strings'
 import { ConnectorRefSchema } from '@common/utils/Validation'
 import { ServiceNowApprovalRejectionCriteria } from './ServiceNowApprovalRejectionCriteria'
+import { ServiceNowApprovalChangeWindow } from './ServiceNowApprovalChangeWindow'
 import css from '@pipeline/components/PipelineSteps/Steps/ServiceNowApproval/ServiceNowApproval.module.scss'
 import stepCss from '@pipeline/components/PipelineSteps/Steps/Steps.module.scss'
 
@@ -323,16 +325,25 @@ function FormContent({
           id="optional-config"
           summary={getString('common.optionalConfig')}
           details={
-            <ServiceNowApprovalRejectionCriteria
-              fieldList={ticketFieldList}
-              title={getString('pipeline.approvalCriteria.rejectionCriteria')}
-              isFetchingFields={false}
-              mode="rejectionCriteria"
-              values={formik.values.spec.rejectionCriteria}
-              onChange={values => formik.setFieldValue('spec.rejectionCriteria', values)}
-              formik={formik}
-              readonly={readonly}
-            />
+            <Layout.Vertical spacing="medium">
+              <ServiceNowApprovalRejectionCriteria
+                fieldList={ticketFieldList}
+                title={getString('pipeline.approvalCriteria.rejectionCriteria')}
+                isFetchingFields={false}
+                mode="rejectionCriteria"
+                values={formik.values.spec.rejectionCriteria}
+                onChange={values => formik.setFieldValue('spec.rejectionCriteria', values)}
+                formik={formik}
+                readonly={readonly}
+              />
+              <ServiceNowApprovalChangeWindow
+                formik={formik}
+                fetchingServiceNowTicketTypes={fetchingServiceNowTicketTypes}
+                serviceNowTicketTypesFetchErrorMessage={serviceNowTicketTypesFetchError?.message}
+                readonly={!!readonly}
+                serviceNowTicketTypesOptions={serviceNowTicketTypesOptions}
+              />
+            </Layout.Vertical>
           }
         />
       </Accordion>
@@ -408,6 +419,14 @@ function ServiceNowApprovalStepMode(
               otherwise: Yup.object().shape({
                 expression: Yup.string().trim().required(getString('pipeline.approvalCriteria.validations.expression'))
               })
+            })
+          }),
+          enableChangeWindow: Yup.boolean(),
+          changeWindow: Yup.object().when('enableChangeWindow', {
+            is: true,
+            then: Yup.object().shape({
+              startField: Yup.string().required(getString('pipeline.serviceNowApprovalStep.validations.windowStart')),
+              endField: Yup.string().required(getString('pipeline.serviceNowApprovalStep.validations.windowEnd'))
             })
           })
         })

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/__test__/ServiceNowApproval.test.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/__test__/ServiceNowApproval.test.tsx
@@ -6,7 +6,8 @@
  */
 
 import React from 'react'
-import { render, act, fireEvent, queryByAttribute, waitFor } from '@testing-library/react'
+import { render, act, fireEvent, queryByAttribute, waitFor, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { StepType } from '@pipeline/components/PipelineSteps/PipelineStepInterface'
 import { StepFormikRef, StepViewType } from '@pipeline/components/AbstractSteps/Step'
 import type { CompletionItemInterface } from '@common/interfaces/YAMLBuilderProps'
@@ -195,9 +196,16 @@ describe('ServiceNow Approval tests', () => {
     expect(queryByDisplayValue('itd1')).toBeTruthy()
 
     expect(queryByDisplayValue('somevalue for f1')).toBeTruthy()
-
-    fireEvent.click(getByText('common.optionalConfig'))
+    userEvent.click(getByText('common.optionalConfig'))
     expect(queryByDisplayValue("<+state> == 'Blocked'")).toBeTruthy()
+
+    const enableApprovalChangeWindow = await screen.findByRole('checkbox', {
+      name: 'enable'
+    })
+    expect(enableApprovalChangeWindow).toBeChecked()
+    userEvent.click(enableApprovalChangeWindow)
+    expect(enableApprovalChangeWindow).not.toBeChecked()
+    userEvent.click(enableApprovalChangeWindow)
 
     await act(() => ref.current?.submitForm()!)
     expect(props.onUpdate).toBeCalledWith({
@@ -231,6 +239,10 @@ describe('ServiceNow Approval tests', () => {
           spec: {
             expression: "<+state> == 'Blocked'"
           }
+        },
+        changeWindow: {
+          endField: 'INCIDENT',
+          startField: 'PROBLEM'
         }
       },
       name: 'serviceNow approval step'

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/__test__/ServiceNowApproval.test.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/__test__/ServiceNowApproval.test.tsx
@@ -30,7 +30,7 @@ jest.mock('@common/components/YAMLBuilder/YamlBuilder')
 jest.mock('services/cd-ng', () => ({
   useGetConnector: () => mockConnectorResponse,
   useGetServiceNowTicketTypes: () => mockTicketTypesResponse,
-  useGetServiceNowIssueCreateMetadata: () => mockServiceNowCreateMetadataResponse,
+  useGetServiceNowIssueCreateMetadataV2: () => mockServiceNowCreateMetadataResponse,
   getConnectorListV2Promise: jest.fn(() => Promise.resolve(ConnectorsResponse.data)),
   getServiceNowTicketTypesPromise: jest.fn(() => Promise.resolve(mockTicketTypesResponse.data))
 }))
@@ -241,8 +241,8 @@ describe('ServiceNow Approval tests', () => {
           }
         },
         changeWindow: {
-          endField: 'INCIDENT',
-          startField: 'PROBLEM'
+          endField: 'due_date',
+          startField: 'sys_updated_on'
         }
       },
       name: 'serviceNow approval step'

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/__test__/ServiceNowApprovalTestHelper.ts
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/__test__/ServiceNowApprovalTestHelper.ts
@@ -71,6 +71,10 @@ export const getServiceNowApprovalEditModePropsWithValues = (): ServiceNowApprov
         spec: {
           expression: "<+state> == 'Blocked'"
         }
+      },
+      changeWindow: {
+        startField: 'PROBLEM',
+        endField: 'INCIDENT'
       }
     }
   },

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/__test__/ServiceNowApprovalTestHelper.ts
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/__test__/ServiceNowApprovalTestHelper.ts
@@ -11,7 +11,7 @@ import { StepType } from '@pipeline/components/PipelineSteps/PipelineStepInterfa
 import { StepViewType } from '@pipeline/components/AbstractSteps/Step'
 import type {
   ResponseConnectorResponse,
-  ResponseListServiceNowFieldNG,
+  ResponseServiceNowFieldListDTO,
   ResponsePageConnectorResponse,
   ResponseListServiceNowTicketTypeDTO
 } from 'services/cd-ng'
@@ -73,8 +73,8 @@ export const getServiceNowApprovalEditModePropsWithValues = (): ServiceNowApprov
         }
       },
       changeWindow: {
-        startField: 'PROBLEM',
-        endField: 'INCIDENT'
+        startField: 'sys_updated_on',
+        endField: 'due_date'
       }
     }
   },
@@ -224,7 +224,7 @@ export const mockTicketTypesResponse: UseGetMockData<ResponseListServiceNowTicke
     ]
   }
 }
-export const mockServiceNowCreateMetadataResponse: UseGetMockData<ResponseListServiceNowFieldNG> = {
+export const mockServiceNowCreateMetadataResponse: UseGetMockData<ResponseServiceNowFieldListDTO> = {
   loading: false,
   // eslint-disable-next-line
   // @ts-ignore
@@ -234,56 +234,98 @@ export const mockServiceNowCreateMetadataResponse: UseGetMockData<ResponseListSe
     correlationId: '',
     status: 'SUCCESS',
     metaData: null as unknown as undefined,
-    data: [
-      {
-        key: 'parent',
-        name: 'Parent',
-        required: false,
-        schema: { array: undefined, customType: undefined, type: 'string', typeStr: '' },
-        allowedValues: [],
-        custom: false
-      },
-      {
-        key: 'made_sla',
-        name: 'Made SLA',
-        required: false,
-        schema: { array: undefined, customType: undefined, type: 'string', typeStr: '' },
-        allowedValues: [],
-        custom: false
-      },
-      {
-        key: 'caused_by',
-        name: 'Caused by Change',
-        required: false,
-        schema: { array: undefined, customType: undefined, type: 'string', typeStr: '' },
-        allowedValues: [],
-        custom: false
-      },
-      {
-        key: 'watch_list',
-        name: 'Watch list',
-        required: false,
-        schema: { array: undefined, customType: undefined, type: 'string', typeStr: '' },
-        allowedValues: [],
-        custom: false
-      },
-      {
-        key: 'upon_reject',
-        name: 'Upon reject',
-        required: false,
-        schema: { array: undefined, customType: undefined, type: 'string', typeStr: '' },
-        allowedValues: [],
-        custom: false
-      },
-      {
-        key: 'sys_updated_on',
-        name: 'updated',
-        required: false,
-        schema: { array: undefined, customType: undefined, type: 'string', typeStr: '' },
-        allowedValues: [],
-        custom: false
+    data: {
+      fields: [
+        {
+          key: 'parent',
+          name: 'Parent',
+          required: false,
+          schema: { array: undefined, customType: undefined, type: 'string', typeStr: '' },
+          internalType: 'reference',
+          allowedValues: [],
+          custom: false
+        },
+        {
+          key: 'made_sla',
+          name: 'Made SLA',
+          required: false,
+          schema: { array: undefined, customType: undefined, type: 'string', typeStr: '' },
+          internalType: 'boolean',
+          allowedValues: [],
+          custom: false
+        },
+        {
+          key: 'caused_by',
+          name: 'Caused by Change',
+          required: false,
+          schema: { array: undefined, customType: undefined, type: 'string', typeStr: '' },
+          internalType: 'reference',
+          allowedValues: [],
+          custom: false
+        },
+        {
+          key: 'watch_list',
+          name: 'Watch list',
+          required: false,
+          schema: { array: undefined, customType: undefined, type: 'string', typeStr: '' },
+          internalType: 'glide_list',
+          allowedValues: [],
+          custom: false
+        },
+        {
+          key: 'upon_reject',
+          name: 'Upon reject',
+          required: false,
+          schema: { array: undefined, customType: undefined, type: 'string', typeStr: '' },
+          internalType: 'string',
+          allowedValues: [],
+          custom: false
+        },
+        {
+          key: 'sys_updated_on',
+          name: 'updated',
+          required: false,
+          schema: { array: undefined, customType: undefined, type: 'string', typeStr: '' },
+          internalType: 'glide_date_time',
+          allowedValues: [],
+          custom: false
+        },
+        {
+          key: 'work_start',
+          name: 'Actual start',
+          required: false,
+          schema: { array: undefined, customType: undefined, type: 'string', typeStr: '' },
+          internalType: 'glide_date',
+          allowedValues: [],
+          custom: false
+        },
+        {
+          key: 'follow_up',
+          name: 'Follow up',
+          required: false,
+          schema: { array: undefined, customType: undefined, type: 'string', typeStr: '' },
+          internalType: 'glide_time',
+          allowedValues: [],
+          custom: false
+        },
+        {
+          key: 'due_date',
+          name: 'Due Date',
+          required: false,
+          schema: { array: undefined, customType: undefined, type: 'string', typeStr: '' },
+          internalType: 'due_date',
+          allowedValues: [],
+          custom: false
+        }
+      ],
+      fieldInternalTypeMap: {
+        OPTION: ['option'],
+        STRING: ['string'],
+        DATE_TIME: ['glide_date_time', 'due_date', 'glide_date', 'glide_time'],
+        BOOLEAN: ['boolean'],
+        INTEGER: ['integer']
       }
-    ]
+    }
   }
 }
 

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/helper.ts
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/helper.ts
@@ -26,19 +26,22 @@ export const processInitialValues = (values: ServiceNowApprovalData): ServiceNow
     spec: {
       ...values.spec,
       approvalCriteria: getApprovalRejectionCriteriaForInitialValues(values.spec.approvalCriteria),
-      rejectionCriteria: getApprovalRejectionCriteriaForInitialValues(values.spec.rejectionCriteria)
+      rejectionCriteria: getApprovalRejectionCriteriaForInitialValues(values.spec.rejectionCriteria),
+      enableChangeWindow: !!values.spec.changeWindow
     }
   }
 }
 
 export const processFormData = (values: ServiceNowApprovalData): ServiceNowApprovalData => {
+  const { enableChangeWindow, changeWindow, ...restOfSpec } = values.spec
   return {
     ...values,
     spec: {
-      ...values.spec,
+      ...restOfSpec,
       connectorRef: values.spec.connectorRef,
       approvalCriteria: getApprovalRejectionCriteriaForSubmit(values.spec.approvalCriteria),
-      rejectionCriteria: getApprovalRejectionCriteriaForSubmit(values.spec.rejectionCriteria)
+      rejectionCriteria: getApprovalRejectionCriteriaForSubmit(values.spec.rejectionCriteria),
+      ...(enableChangeWindow ? { changeWindow } : undefined)
     }
   }
 }

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/helper.ts
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/helper.ts
@@ -41,7 +41,7 @@ export const processFormData = (values: ServiceNowApprovalData): ServiceNowAppro
       connectorRef: values.spec.connectorRef,
       approvalCriteria: getApprovalRejectionCriteriaForSubmit(values.spec.approvalCriteria),
       rejectionCriteria: getApprovalRejectionCriteriaForSubmit(values.spec.rejectionCriteria),
-      ...(enableChangeWindow ? { changeWindow } : undefined)
+      ...(enableChangeWindow && { changeWindow })
     }
   }
 }

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/types.ts
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/types.ts
@@ -29,6 +29,11 @@ export interface ServiceNowApprovalData extends StepElementConfig {
     ticketNumber: string
     approvalCriteria: ApprovalRejectionCriteria
     rejectionCriteria: ApprovalRejectionCriteria
+    enableChangeWindow?: boolean
+    changeWindow?: {
+      startField: string
+      endField: string
+    }
   }
 }
 export interface ServiceNowTicketTypeSelectOption extends SelectOption {

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/types.ts
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/types.ts
@@ -12,10 +12,10 @@ import type { GetDataError } from 'restful-react'
 import type {
   ResponseListServiceNowTicketTypeDTO,
   StepElementConfig,
-  UseGetServiceNowIssueCreateMetadataProps,
   UseGetServiceNowTicketTypesProps,
   Failure,
-  ResponseListServiceNowFieldNG
+  ResponseServiceNowFieldListDTO,
+  UseGetServiceNowIssueCreateMetadataV2Props
 } from 'services/cd-ng'
 import type { InputSetData, StepViewType } from '@pipeline/components/AbstractSteps/Step'
 import { getDefaultCriterias } from '@pipeline/components/PipelineSteps/Steps/JiraApproval/helper'
@@ -36,6 +36,7 @@ export interface ServiceNowApprovalData extends StepElementConfig {
     }
   }
 }
+
 export interface ServiceNowTicketTypeSelectOption extends SelectOption {
   key: string
 }
@@ -76,10 +77,10 @@ export interface ServiceNowFormContentInterface {
   serviceNowTicketTypesFetchError?: GetDataError<Failure | Error> | null
   fetchingServiceNowTicketTypes: boolean
   serviceNowTicketTypesResponse: ResponseListServiceNowTicketTypeDTO | null
-  refetchServiceNowMetadata: (props: UseGetServiceNowIssueCreateMetadataProps) => Promise<void>
-  serviceNowMetadataFetchError?: GetDataError<Failure | Error> | null
-  fetchingServiceNowMetadata: boolean
-  serviceNowMetadataResponse: ResponseListServiceNowFieldNG | null
+  refetchServiceNowIssueCreateMetadata: (props: UseGetServiceNowIssueCreateMetadataV2Props) => Promise<void>
+  serviceNowIssueCreateMetadataFetchError?: GetDataError<Failure | Error> | null
+  fetchingServiceNowIssueCreateMetadata: boolean
+  serviceNowIssueCreateMetadataResponse: ResponseServiceNowFieldListDTO | null
 }
 export const resetForm = (formik: FormikProps<ServiceNowApprovalData>, parent: string) => {
   if (parent === 'connectorRef') {

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowCreate/ServiceNowCreateDeploymentMode.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowCreate/ServiceNowCreateDeploymentMode.tsx
@@ -25,7 +25,11 @@ import type {
   ServiceNowCreateDeploymentModeProps
 } from '@pipeline/components/PipelineSteps/Steps/ServiceNowCreate/types'
 import type { ServiceNowTicketTypeSelectOption } from '@pipeline/components/PipelineSteps/Steps/ServiceNowApproval/types'
-import { ServiceNowTicketTypeDTO, useGetServiceNowIssueMetadata, useGetServiceNowTicketTypes } from 'services/cd-ng'
+import {
+  ServiceNowTicketTypeDTO,
+  useGetServiceNowIssueCreateMetadataV2,
+  useGetServiceNowTicketTypes
+} from 'services/cd-ng'
 import { FormMultiTypeTextAreaField } from '@common/components'
 import {
   ServiceNowCreateFieldType,
@@ -51,9 +55,9 @@ function FormContent(formContentProps: ServiceNowCreateDeploymentModeFormContent
     fetchingServiceNowTicketTypes,
     serviceNowTicketTypesFetchError,
     serviceNowTicketTypesResponse,
-    refetchServiceNowMetadata,
-    fetchingServiceNowMetadata,
-    serviceNowMetadataResponse
+    refetchServiceNowIssueCreateMetadata,
+    fetchingServiceNowIssueCreateMetadata,
+    serviceNowIssueCreateMetadataResponse
   } = formContentProps
   const template = inputSetData?.template
   const path = inputSetData?.path
@@ -119,7 +123,7 @@ function FormContent(formContentProps: ServiceNowCreateDeploymentModeFormContent
   }, [serviceNowTicketTypesResponse?.data])
   useDeepCompareEffect(() => {
     if (connectorRefFixedValue && ticketTypeKeyFixedValue && fetchMetadataRequired) {
-      refetchServiceNowMetadata({
+      refetchServiceNowIssueCreateMetadata({
         queryParams: {
           ...commonParams,
           connectorRef: connectorRefFixedValue.toString(),
@@ -131,8 +135,8 @@ function FormContent(formContentProps: ServiceNowCreateDeploymentModeFormContent
   useEffect(() => {
     const selectedFields: ServiceNowFieldNGWithValue[] = []
     if (ticketTypeKeyFixedValue) {
-      if (template?.spec?.fields && serviceNowMetadataResponse?.data) {
-        serviceNowMetadataResponse?.data.forEach(field => {
+      if (template?.spec?.fields && serviceNowIssueCreateMetadataResponse?.data) {
+        serviceNowIssueCreateMetadataResponse?.data?.fields.forEach(field => {
           if (
             field &&
             field.key !== ServiceNowStaticFields.short_description &&
@@ -149,7 +153,7 @@ function FormContent(formContentProps: ServiceNowCreateDeploymentModeFormContent
         setCustomFields([])
       }
     }
-  }, [serviceNowMetadataResponse?.data])
+  }, [serviceNowIssueCreateMetadataResponse?.data])
   return (
     <React.Fragment>
       {getMultiTypeFromValue(template?.timeout) === MultiTypeInputType.RUNTIME ? (
@@ -263,7 +267,7 @@ function FormContent(formContentProps: ServiceNowCreateDeploymentModeFormContent
           className={css.deploymentViewMedium}
         />
       )}
-      {fetchingServiceNowMetadata ? (
+      {fetchingServiceNowIssueCreateMetadata ? (
         <PageSpinner message={getString('pipeline.serviceNowCreateStep.fetchingFields')} className={css.fetching} />
       ) : fetchMetadataRequired && customFields?.length === 0 ? (
         // Metadata fetch failed, so display as key value pair
@@ -369,15 +373,16 @@ export default function ServiceNowCreateDeploymentMode(props: ServiceNowCreateDe
     }
   })
   const {
-    refetch: refetchServiceNowMetadata,
-    data: serviceNowMetadataResponse,
-    error: serviceNowMetadataFetchError,
-    loading: fetchingServiceNowMetadata
-  } = useGetServiceNowIssueMetadata({
+    refetch: refetchServiceNowIssueCreateMetadata,
+    data: serviceNowIssueCreateMetadataResponse,
+    error: serviceNowIssueCreateMetadataFetchError,
+    loading: fetchingServiceNowIssueCreateMetadata
+  } = useGetServiceNowIssueCreateMetadataV2({
     lazy: true,
     queryParams: {
       ...commonParams,
-      connectorRef: ''
+      connectorRef: '',
+      ticketType: ''
     }
   })
   return (
@@ -387,10 +392,10 @@ export default function ServiceNowCreateDeploymentMode(props: ServiceNowCreateDe
       fetchingServiceNowTicketTypes={fetchingServiceNowTicketTypes}
       serviceNowTicketTypesResponse={serviceNowTicketTypesResponse}
       serviceNowTicketTypesFetchError={serviceNowTicketTypesFetchError}
-      refetchServiceNowMetadata={refetchServiceNowMetadata}
-      fetchingServiceNowMetadata={fetchingServiceNowMetadata}
-      serviceNowMetadataResponse={serviceNowMetadataResponse}
-      serviceNowMetadataFetchError={serviceNowMetadataFetchError}
+      refetchServiceNowIssueCreateMetadata={refetchServiceNowIssueCreateMetadata}
+      fetchingServiceNowIssueCreateMetadata={fetchingServiceNowIssueCreateMetadata}
+      serviceNowIssueCreateMetadataResponse={serviceNowIssueCreateMetadataResponse}
+      serviceNowIssueCreateMetadataFetchError={serviceNowIssueCreateMetadataFetchError}
     />
   )
 }

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowCreate/ServiceNowCreateStepMode.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowCreate/ServiceNowCreateStepMode.tsx
@@ -34,7 +34,7 @@ import { useVariablesExpression } from '@pipeline/components/PipelineStudio/Pipl
 import {
   ServiceNowFieldNG,
   ServiceNowTicketTypeDTO,
-  useGetServiceNowIssueMetadata,
+  useGetServiceNowIssueCreateMetadataV2,
   useGetServiceNowTemplateMetadata,
   useGetServiceNowTicketTypes
 } from 'services/cd-ng'
@@ -87,10 +87,10 @@ function FormContent({
   refetchServiceNowTicketTypes,
   fetchingServiceNowTicketTypes,
   serviceNowTicketTypesResponse,
-  serviceNowMetadataResponse,
+  serviceNowIssueCreateMetadataResponse,
   serviceNowTicketTypesFetchError,
-  refetchServiceNowMetadata,
-  fetchingServiceNowMetadata,
+  refetchServiceNowIssueCreateMetadata,
+  fetchingServiceNowIssueCreateMetadata,
   refetchServiceNowTemplate,
   serviceNowTemplateResponse,
   fetchingServiceNowTemplate
@@ -174,7 +174,7 @@ function FormContent({
   }, [connectorRefFixedValue, ticketTypeKeyFixedValue, templateName])
   useDeepCompareEffect(() => {
     if (connectorRefFixedValue && ticketTypeKeyFixedValue && ticketValueType === MultiTypeInputType.FIXED) {
-      refetchServiceNowMetadata({
+      refetchServiceNowIssueCreateMetadata({
         queryParams: {
           ...commonParams,
           connectorRef: connectorRefFixedValue.toString(),
@@ -186,9 +186,9 @@ function FormContent({
   useEffect(() => {
     const formikSelectedFields: ServiceNowFieldNGWithValue[] = []
     if (ticketTypeKeyFixedValue) {
-      setTicketFieldList(serviceNowMetadataResponse?.data || [])
-      if (formik.values.spec.fields && serviceNowMetadataResponse?.data) {
-        serviceNowMetadataResponse?.data.forEach(field => {
+      setTicketFieldList(serviceNowIssueCreateMetadataResponse?.data?.fields || [])
+      if (formik.values.spec.fields && serviceNowIssueCreateMetadataResponse?.data) {
+        serviceNowIssueCreateMetadataResponse?.data?.fields.forEach(field => {
           if (
             field &&
             field.key !== ServiceNowStaticFields.short_description &&
@@ -215,7 +215,7 @@ function FormContent({
         setTicketFieldList([])
       }
     }
-  }, [serviceNowMetadataResponse?.data])
+  }, [serviceNowIssueCreateMetadataResponse?.data])
 
   useEffect(() => {
     if (serviceNowTemplateResponse && serviceNowTemplateResponse.data) {
@@ -460,7 +460,7 @@ function FormContent({
         />
         {formik.values.spec.fieldType === FieldType.ConfigureFields && (
           <div>
-            {fetchingServiceNowMetadata ? (
+            {fetchingServiceNowIssueCreateMetadata ? (
               <PageSpinner
                 message={getString('pipeline.serviceNowCreateStep.fetchingFields')}
                 className={css.fetching}
@@ -656,15 +656,16 @@ function ServiceNowCreateStepMode(
   })
 
   const {
-    refetch: refetchServiceNowMetadata,
-    data: serviceNowMetadataResponse,
-    error: serviceNowMetadataFetchError,
-    loading: fetchingServiceNowMetadata
-  } = useGetServiceNowIssueMetadata({
+    refetch: refetchServiceNowIssueCreateMetadata,
+    data: serviceNowIssueCreateMetadataResponse,
+    error: serviceNowIssueCreateMetadataFetchError,
+    loading: fetchingServiceNowIssueCreateMetadata
+  } = useGetServiceNowIssueCreateMetadataV2({
     lazy: true,
     queryParams: {
       ...commonParams,
-      connectorRef: ''
+      connectorRef: '',
+      ticketType: ''
     }
   })
   const {
@@ -747,10 +748,10 @@ function ServiceNowCreateStepMode(
               fetchingServiceNowTicketTypes={fetchingServiceNowTicketTypes}
               serviceNowTicketTypesResponse={serviceNowTicketTypesResponse}
               serviceNowTicketTypesFetchError={serviceNowTicketTypesFetchError}
-              refetchServiceNowMetadata={refetchServiceNowMetadata}
-              fetchingServiceNowMetadata={fetchingServiceNowMetadata}
-              serviceNowMetadataResponse={serviceNowMetadataResponse}
-              serviceNowMetadataFetchError={serviceNowMetadataFetchError}
+              refetchServiceNowIssueCreateMetadata={refetchServiceNowIssueCreateMetadata}
+              fetchingServiceNowIssueCreateMetadata={fetchingServiceNowIssueCreateMetadata}
+              serviceNowIssueCreateMetadataResponse={serviceNowIssueCreateMetadataResponse}
+              serviceNowIssueCreateMetadataFetchError={serviceNowIssueCreateMetadataFetchError}
               refetchServiceNowTemplate={refetchServiceNowTemplate}
               serviceNowTemplateResponse={serviceNowTemplateResponse}
               serviceNowTemplateFetchError={serviceNowTemplateFetchError}

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowCreate/__tests__/ServiceNowCreate.test.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowCreate/__tests__/ServiceNowCreate.test.tsx
@@ -34,7 +34,7 @@ jest.mock('@common/components/YAMLBuilder/YamlBuilder')
 jest.mock('services/cd-ng', () => ({
   useGetConnector: () => mockConnectorResponse,
   useGetServiceNowTicketTypes: () => mockTicketTypesResponse,
-  useGetServiceNowIssueMetadata: () => mockServiceNowMetadataResponse,
+  useGetServiceNowIssueCreateMetadataV2: () => mockServiceNowMetadataResponse,
   useGetServiceNowTemplateMetadata: () => mockServiceNowTemplateResponse
 }))
 

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowCreate/__tests__/ServiceNowCreateTestHelper.ts
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowCreate/__tests__/ServiceNowCreateTestHelper.ts
@@ -11,7 +11,7 @@ import { StepType } from '@pipeline/components/PipelineSteps/PipelineStepInterfa
 import { StepViewType } from '@pipeline/components/AbstractSteps/Step'
 import type {
   ResponseConnectorResponse,
-  ResponseListServiceNowFieldNG,
+  ResponseServiceNowFieldListDTO,
   ResponseListServiceNowTemplate,
   ResponseListServiceNowTicketTypeDTO,
   ResponsePageConnectorResponse,
@@ -296,7 +296,7 @@ export const mockConnectorsResponse: ResponsePageConnectorResponse = {
   }
 }
 
-export const mockServiceNowMetadataResponse: UseGetMockData<ResponseListServiceNowFieldNG> = {
+export const mockServiceNowMetadataResponse: UseGetMockData<ResponseServiceNowFieldListDTO> = {
   loading: false,
   // eslint-disable-next-line
   // @ts-ignore
@@ -305,36 +305,39 @@ export const mockServiceNowMetadataResponse: UseGetMockData<ResponseListServiceN
     correlationId: '',
     status: 'SUCCESS',
     metaData: null as unknown as undefined,
-    data: [
-      {
-        key: 'f1',
-        name: 'f1',
-        allowedValues: [],
-        schema: {
-          type: 'string' as ServiceNowFieldSchemaNG['type'],
-          typeStr: ''
-        }
-      },
-      {
-        key: 'f2',
-        name: 'f2',
-        allowedValues: [
-          {
-            id: 'av1',
-            name: 'av1',
-            value: 'av1'
-          },
-          {
-            id: 'av2',
-            name: 'av2'
+    data: {
+      fields: [
+        {
+          key: 'f1',
+          name: 'f1',
+          allowedValues: [],
+          schema: {
+            type: 'string' as ServiceNowFieldSchemaNG['type'],
+            typeStr: ''
           }
-        ],
-        schema: {
-          type: 'string' as ServiceNowFieldSchemaNG['type'],
-          typeStr: ''
+        },
+        {
+          key: 'f2',
+          name: 'f2',
+          allowedValues: [
+            {
+              id: 'av1',
+              name: 'av1',
+              value: 'av1'
+            },
+            {
+              id: 'av2',
+              name: 'av2'
+            }
+          ],
+          schema: {
+            type: 'string' as ServiceNowFieldSchemaNG['type'],
+            typeStr: ''
+          }
         }
-      }
-    ]
+      ],
+      fieldInternalTypeMap: {}
+    }
   }
 }
 export const getServiceNowFieldRendererProps = (): ServiceNowFieldsRendererProps => ({

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowCreate/types.ts
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowCreate/types.ts
@@ -13,12 +13,11 @@ import type {
   Failure,
   ServiceNowFieldNG,
   StepElementConfig,
-  ResponseListServiceNowFieldNG,
+  ResponseServiceNowFieldListDTO,
   ResponseListServiceNowTicketTypeDTO,
   UseGetServiceNowTicketTypesProps,
-  UseGetServiceNowIssueMetadataProps,
+  UseGetServiceNowIssueCreateMetadataV2Props,
   UseGetServiceNowTemplateMetadataProps,
-  UseGetServiceNowIssueCreateMetadataProps,
   ResponseListServiceNowTemplate,
   ServiceNowFieldValueNG
 } from 'services/cd-ng'
@@ -79,10 +78,10 @@ export interface ServiceNowCreateFormContentInterface {
   serviceNowTicketTypesFetchError?: GetDataError<Failure | Error> | null
   fetchingServiceNowTicketTypes: boolean
   serviceNowTicketTypesResponse: ResponseListServiceNowTicketTypeDTO | null
-  refetchServiceNowMetadata: (props: UseGetServiceNowIssueMetadataProps) => Promise<void>
-  serviceNowMetadataFetchError?: GetDataError<Failure | Error> | null
-  fetchingServiceNowMetadata: boolean
-  serviceNowMetadataResponse: ResponseListServiceNowFieldNG | null
+  refetchServiceNowIssueCreateMetadata: (props: UseGetServiceNowIssueCreateMetadataV2Props) => Promise<void>
+  serviceNowIssueCreateMetadataFetchError?: GetDataError<Failure | Error> | null
+  fetchingServiceNowIssueCreateMetadata: boolean
+  serviceNowIssueCreateMetadataResponse: ResponseServiceNowFieldListDTO | null
   refetchServiceNowTemplate: (props: UseGetServiceNowTemplateMetadataProps) => Promise<void>
   serviceNowTemplateResponse: ResponseListServiceNowTemplate | null
   fetchingServiceNowTemplate: boolean
@@ -126,10 +125,10 @@ export interface ServiceNowCreateDeploymentModeFormContentInterface extends Serv
   serviceNowTicketTypesFetchError?: GetDataError<Failure | Error> | null
   fetchingServiceNowTicketTypes: boolean
   serviceNowTicketTypesResponse: ResponseListServiceNowTicketTypeDTO | null
-  refetchServiceNowMetadata: (props: UseGetServiceNowIssueCreateMetadataProps) => Promise<void>
-  serviceNowMetadataFetchError?: GetDataError<Failure | Error> | null
-  fetchingServiceNowMetadata: boolean
-  serviceNowMetadataResponse: ResponseListServiceNowFieldNG | null
+  refetchServiceNowIssueCreateMetadata: (props: UseGetServiceNowIssueCreateMetadataV2Props) => Promise<void>
+  serviceNowIssueCreateMetadataFetchError?: GetDataError<Failure | Error> | null
+  fetchingServiceNowIssueCreateMetadata: boolean
+  serviceNowIssueCreateMetadataResponse: ResponseServiceNowFieldListDTO | null
 }
 
 export enum ServiceNowStaticFields {

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowUpdate/ServiceNowUpdateDeploymentMode.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowUpdate/ServiceNowUpdateDeploymentMode.tsx
@@ -22,7 +22,7 @@ import { useVariablesExpression } from '@pipeline/components/PipelineStudio/Pipl
 import { FormMultiTypeTextAreaField } from '@common/components'
 import { FormMultiTypeConnectorField } from '@connectors/components/ConnectorReferenceField/FormMultiTypeConnectorField'
 import type { ServiceNowTicketTypeDTO } from 'services/cd-ng'
-import { useGetServiceNowIssueMetadata, useGetServiceNowTicketTypes } from 'services/cd-ng'
+import { useGetServiceNowIssueCreateMetadataV2, useGetServiceNowTicketTypes } from 'services/cd-ng'
 import {
   ServiceNowCreateFieldType,
   ServiceNowFieldNGWithValue,
@@ -53,9 +53,9 @@ function FormContent(formContentProps: ServiceNowUpdateDeploymentModeFormContent
     fetchingServiceNowTicketTypes,
     serviceNowTicketTypesFetchError,
     serviceNowTicketTypesResponse,
-    refetchServiceNowMetadata,
-    fetchingServiceNowMetadata,
-    serviceNowMetadataResponse
+    refetchServiceNowIssueCreateMetadata,
+    fetchingServiceNowIssueCreateMetadata,
+    serviceNowIssueCreateMetadataResponse
   } = formContentProps
   const template = inputSetData?.template
   const path = inputSetData?.path
@@ -122,7 +122,7 @@ function FormContent(formContentProps: ServiceNowUpdateDeploymentModeFormContent
   }, [serviceNowTicketTypesResponse?.data])
   useDeepCompareEffect(() => {
     if (connectorRefFixedValue && ticketTypeKeyFixedValue && fetchMetadataRequired) {
-      refetchServiceNowMetadata({
+      refetchServiceNowIssueCreateMetadata({
         queryParams: {
           ...commonParams,
           connectorRef: connectorRefFixedValue.toString(),
@@ -134,8 +134,8 @@ function FormContent(formContentProps: ServiceNowUpdateDeploymentModeFormContent
   useEffect(() => {
     const selectedFields: ServiceNowFieldNGWithValue[] = []
     if (ticketTypeKeyFixedValue) {
-      if (template?.spec?.fields && serviceNowMetadataResponse?.data) {
-        serviceNowMetadataResponse?.data.forEach(field => {
+      if (template?.spec?.fields && serviceNowIssueCreateMetadataResponse?.data) {
+        serviceNowIssueCreateMetadataResponse?.data?.fields.forEach(field => {
           if (
             field &&
             field.key !== ServiceNowStaticFields.short_description &&
@@ -152,7 +152,7 @@ function FormContent(formContentProps: ServiceNowUpdateDeploymentModeFormContent
         setCustomFields([])
       }
     }
-  }, [serviceNowMetadataResponse?.data])
+  }, [serviceNowIssueCreateMetadataResponse?.data])
   return (
     <React.Fragment>
       {getMultiTypeFromValue(template?.timeout) === MultiTypeInputType.RUNTIME ? (
@@ -279,7 +279,7 @@ function FormContent(formContentProps: ServiceNowUpdateDeploymentModeFormContent
           className={css.deploymentViewMedium}
         />
       )}
-      {fetchingServiceNowMetadata ? (
+      {fetchingServiceNowIssueCreateMetadata ? (
         <PageSpinner message={getString('pipeline.serviceNowCreateStep.fetchingFields')} className={css.fetching} />
       ) : fetchMetadataRequired && customFields?.length === 0 ? (
         // Metadata fetch failed, so display as key value pair
@@ -385,15 +385,16 @@ export default function ServiceNowUpdateDeploymentMode(props: ServiceNowUpdateDe
     }
   })
   const {
-    refetch: refetchServiceNowMetadata,
-    data: serviceNowMetadataResponse,
-    error: serviceNowMetadataFetchError,
-    loading: fetchingServiceNowMetadata
-  } = useGetServiceNowIssueMetadata({
+    refetch: refetchServiceNowIssueCreateMetadata,
+    data: serviceNowIssueCreateMetadataResponse,
+    error: serviceNowIssueCreateMetadataFetchError,
+    loading: fetchingServiceNowIssueCreateMetadata
+  } = useGetServiceNowIssueCreateMetadataV2({
     lazy: true,
     queryParams: {
       ...commonParams,
-      connectorRef: ''
+      connectorRef: '',
+      ticketType: ''
     }
   })
 
@@ -404,10 +405,10 @@ export default function ServiceNowUpdateDeploymentMode(props: ServiceNowUpdateDe
       fetchingServiceNowTicketTypes={fetchingServiceNowTicketTypes}
       serviceNowTicketTypesResponse={serviceNowTicketTypesResponse}
       serviceNowTicketTypesFetchError={serviceNowTicketTypesFetchError}
-      refetchServiceNowMetadata={refetchServiceNowMetadata}
-      fetchingServiceNowMetadata={fetchingServiceNowMetadata}
-      serviceNowMetadataResponse={serviceNowMetadataResponse}
-      serviceNowMetadataFetchError={serviceNowMetadataFetchError}
+      refetchServiceNowIssueCreateMetadata={refetchServiceNowIssueCreateMetadata}
+      fetchingServiceNowIssueCreateMetadata={fetchingServiceNowIssueCreateMetadata}
+      serviceNowIssueCreateMetadataResponse={serviceNowIssueCreateMetadataResponse}
+      serviceNowIssueCreateMetadataFetchError={serviceNowIssueCreateMetadataFetchError}
     />
   )
 }

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowUpdate/ServiceNowUpdateStepMode.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowUpdate/ServiceNowUpdateStepMode.tsx
@@ -34,7 +34,7 @@ import { useVariablesExpression } from '@pipeline/components/PipelineStudio/Pipl
 import {
   ServiceNowFieldNG,
   ServiceNowTicketTypeDTO,
-  useGetServiceNowIssueMetadata,
+  useGetServiceNowIssueCreateMetadataV2,
   useGetServiceNowTemplateMetadata,
   useGetServiceNowTicketTypes
 } from 'services/cd-ng'
@@ -84,10 +84,10 @@ function FormContent({
   refetchServiceNowTicketTypes,
   fetchingServiceNowTicketTypes,
   serviceNowTicketTypesResponse,
-  serviceNowMetadataResponse,
   serviceNowTicketTypesFetchError,
-  refetchServiceNowMetadata,
-  fetchingServiceNowMetadata,
+  serviceNowIssueCreateMetadataResponse,
+  refetchServiceNowIssueCreateMetadata,
+  fetchingServiceNowIssueCreateMetadata,
   refetchServiceNowTemplate,
   serviceNowTemplateResponse,
   fetchingServiceNowTemplate
@@ -168,7 +168,7 @@ function FormContent({
   }, [connectorRefFixedValue, ticketTypeKeyFixedValue, templateName])
   useDeepCompareEffect(() => {
     if (connectorRefFixedValue && ticketTypeKeyFixedValue && ticketValueType === MultiTypeInputType.FIXED) {
-      refetchServiceNowMetadata({
+      refetchServiceNowIssueCreateMetadata({
         queryParams: {
           ...commonParams,
           connectorRef: connectorRefFixedValue.toString(),
@@ -180,9 +180,9 @@ function FormContent({
   useEffect(() => {
     const formikSelectedFields: ServiceNowFieldNGWithValue[] = []
     if (ticketTypeKeyFixedValue) {
-      setTicketFieldList(serviceNowMetadataResponse?.data || [])
-      if (formik.values.spec.fields && serviceNowMetadataResponse?.data) {
-        serviceNowMetadataResponse?.data.forEach(field => {
+      setTicketFieldList(serviceNowIssueCreateMetadataResponse?.data?.fields || [])
+      if (formik.values.spec.fields && serviceNowIssueCreateMetadataResponse?.data) {
+        serviceNowIssueCreateMetadataResponse?.data?.fields.forEach(field => {
           if (
             field &&
             field.key !== ServiceNowStaticFields.short_description &&
@@ -209,7 +209,7 @@ function FormContent({
         setTicketFieldList([])
       }
     }
-  }, [serviceNowMetadataResponse?.data])
+  }, [serviceNowIssueCreateMetadataResponse?.data])
   useEffect(() => {
     if (serviceNowTemplateResponse && serviceNowTemplateResponse.data) {
       setIsTemplateSectionAvailable(true)
@@ -481,7 +481,7 @@ function FormContent({
         />
         {formik.values.spec.fieldType === FieldType.ConfigureFields && (
           <div>
-            {fetchingServiceNowMetadata ? (
+            {fetchingServiceNowIssueCreateMetadata ? (
               <PageSpinner
                 message={getString('pipeline.serviceNowCreateStep.fetchingFields')}
                 className={css.fetching}
@@ -677,15 +677,16 @@ function ServiceNowUpdateStepMode(
   })
 
   const {
-    refetch: refetchServiceNowMetadata,
-    data: serviceNowMetadataResponse,
-    error: serviceNowMetadataFetchError,
-    loading: fetchingServiceNowMetadata
-  } = useGetServiceNowIssueMetadata({
+    refetch: refetchServiceNowIssueCreateMetadata,
+    data: serviceNowIssueCreateMetadataResponse,
+    error: serviceNowIssueCreateMetadataFetchError,
+    loading: fetchingServiceNowIssueCreateMetadata
+  } = useGetServiceNowIssueCreateMetadataV2({
     lazy: true,
     queryParams: {
       ...commonParams,
-      connectorRef: ''
+      connectorRef: '',
+      ticketType: ''
     }
   })
   const {
@@ -770,10 +771,10 @@ function ServiceNowUpdateStepMode(
               fetchingServiceNowTicketTypes={fetchingServiceNowTicketTypes}
               serviceNowTicketTypesResponse={serviceNowTicketTypesResponse}
               serviceNowTicketTypesFetchError={serviceNowTicketTypesFetchError}
-              refetchServiceNowMetadata={refetchServiceNowMetadata}
-              fetchingServiceNowMetadata={fetchingServiceNowMetadata}
-              serviceNowMetadataResponse={serviceNowMetadataResponse}
-              serviceNowMetadataFetchError={serviceNowMetadataFetchError}
+              refetchServiceNowIssueCreateMetadata={refetchServiceNowIssueCreateMetadata}
+              fetchingServiceNowIssueCreateMetadata={fetchingServiceNowIssueCreateMetadata}
+              serviceNowIssueCreateMetadataResponse={serviceNowIssueCreateMetadataResponse}
+              serviceNowIssueCreateMetadataFetchError={serviceNowIssueCreateMetadataFetchError}
               refetchServiceNowTemplate={refetchServiceNowTemplate}
               serviceNowTemplateResponse={serviceNowTemplateResponse}
               serviceNowTemplateFetchError={serviceNowTemplateFetchError}

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowUpdate/__tests__/ServiceNowUpdate.test.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowUpdate/__tests__/ServiceNowUpdate.test.tsx
@@ -34,7 +34,7 @@ jest.mock('@common/components/YAMLBuilder/YamlBuilder')
 jest.mock('services/cd-ng', () => ({
   useGetConnector: () => mockConnectorResponse,
   useGetServiceNowTicketTypes: () => mockTicketTypesResponse,
-  useGetServiceNowIssueMetadata: () => mockServiceNowMetadataResponse,
+  useGetServiceNowIssueCreateMetadataV2: () => mockServiceNowMetadataResponse,
   useGetServiceNowTemplateMetadata: () => mockServiceNowTemplateResponse
 }))
 

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowUpdate/__tests__/ServiceNowUpdateTestHelper.ts
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowUpdate/__tests__/ServiceNowUpdateTestHelper.ts
@@ -11,7 +11,7 @@ import { StepType } from '@pipeline/components/PipelineSteps/PipelineStepInterfa
 import { StepViewType } from '@pipeline/components/AbstractSteps/Step'
 import type {
   ResponseConnectorResponse,
-  ResponseListServiceNowFieldNG,
+  ResponseServiceNowFieldListDTO,
   ResponsePageConnectorResponse,
   ServiceNowFieldSchemaNG,
   ResponseListServiceNowTicketTypeDTO
@@ -312,7 +312,7 @@ export const mockConnectorsResponse: ResponsePageConnectorResponse = {
   }
 }
 
-export const mockServiceNowMetadataResponse: UseGetMockData<ResponseListServiceNowFieldNG> = {
+export const mockServiceNowMetadataResponse: UseGetMockData<ResponseServiceNowFieldListDTO> = {
   loading: false,
   // eslint-disable-next-line
   // @ts-ignore
@@ -321,36 +321,39 @@ export const mockServiceNowMetadataResponse: UseGetMockData<ResponseListServiceN
     correlationId: '',
     status: 'SUCCESS',
     metaData: null as unknown as undefined,
-    data: [
-      {
-        key: 'f1',
-        name: 'f1',
-        allowedValues: [],
-        schema: {
-          type: 'string' as ServiceNowFieldSchemaNG['type'],
-          typeStr: ''
-        }
-      },
-      {
-        key: 'f2',
-        name: 'f2',
-        allowedValues: [
-          {
-            id: 'av1',
-            name: 'av1',
-            value: 'av1'
-          },
-          {
-            id: 'av2',
-            name: 'av2'
+    data: {
+      fields: [
+        {
+          key: 'f1',
+          name: 'f1',
+          allowedValues: [],
+          schema: {
+            type: 'string' as ServiceNowFieldSchemaNG['type'],
+            typeStr: ''
           }
-        ],
-        schema: {
-          type: 'string' as ServiceNowFieldSchemaNG['type'],
-          typeStr: ''
+        },
+        {
+          key: 'f2',
+          name: 'f2',
+          allowedValues: [
+            {
+              id: 'av1',
+              name: 'av1',
+              value: 'av1'
+            },
+            {
+              id: 'av2',
+              name: 'av2'
+            }
+          ],
+          schema: {
+            type: 'string' as ServiceNowFieldSchemaNG['type'],
+            typeStr: ''
+          }
         }
-      }
-    ]
+      ],
+      fieldInternalTypeMap: {}
+    }
   }
 }
 

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowUpdate/types.ts
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowUpdate/types.ts
@@ -12,13 +12,13 @@ import type { InputSetData, StepViewType } from '@pipeline/components/AbstractSt
 import type {
   Failure,
   StepElementConfig,
-  UseGetServiceNowIssueCreateMetadataProps,
-  ResponseListServiceNowFieldNG,
+  ResponseServiceNowFieldListDTO,
   ResponseListServiceNowTicketTypeDTO,
   UseGetServiceNowTicketTypesProps,
   ResponseListServiceNowTemplate,
   ServiceNowFieldValueNG,
-  UseGetServiceNowTemplateMetadataProps
+  UseGetServiceNowTemplateMetadataProps,
+  UseGetServiceNowIssueCreateMetadataV2Props
 } from 'services/cd-ng'
 import type { VariableMergeServiceResponse } from 'services/pipeline-ng'
 import type { ServiceNowTicketTypeSelectOption } from '@pipeline/components/PipelineSteps/Steps/ServiceNowApproval/types'
@@ -72,10 +72,10 @@ export interface ServiceNowUpdateFormContentInterface {
   serviceNowTicketTypesFetchError?: GetDataError<Failure | Error> | null
   fetchingServiceNowTicketTypes: boolean
   serviceNowTicketTypesResponse: ResponseListServiceNowTicketTypeDTO | null
-  refetchServiceNowMetadata: (props: UseGetServiceNowIssueCreateMetadataProps) => Promise<void>
-  serviceNowMetadataFetchError?: GetDataError<Failure | Error> | null
-  fetchingServiceNowMetadata: boolean
-  serviceNowMetadataResponse: ResponseListServiceNowFieldNG | null
+  refetchServiceNowIssueCreateMetadata: (props: UseGetServiceNowIssueCreateMetadataV2Props) => Promise<void>
+  serviceNowIssueCreateMetadataFetchError?: GetDataError<Failure | Error> | null
+  fetchingServiceNowIssueCreateMetadata: boolean
+  serviceNowIssueCreateMetadataResponse: ResponseServiceNowFieldListDTO | null
   refetchServiceNowTemplate: (props: UseGetServiceNowTemplateMetadataProps) => Promise<void>
   serviceNowTemplateResponse: ResponseListServiceNowTemplate | null
   fetchingServiceNowTemplate: boolean
@@ -96,8 +96,8 @@ export interface ServiceNowUpdateDeploymentModeFormContentInterface extends Serv
   serviceNowTicketTypesFetchError?: GetDataError<Failure | Error> | null
   fetchingServiceNowTicketTypes: boolean
   serviceNowTicketTypesResponse: ResponseListServiceNowTicketTypeDTO | null
-  refetchServiceNowMetadata: (props: UseGetServiceNowIssueCreateMetadataProps) => Promise<void>
-  serviceNowMetadataFetchError?: GetDataError<Failure | Error> | null
-  fetchingServiceNowMetadata: boolean
-  serviceNowMetadataResponse: ResponseListServiceNowFieldNG | null
+  refetchServiceNowIssueCreateMetadata: (props: UseGetServiceNowIssueCreateMetadataV2Props) => Promise<void>
+  serviceNowIssueCreateMetadataFetchError?: GetDataError<Failure | Error> | null
+  fetchingServiceNowIssueCreateMetadata: boolean
+  serviceNowIssueCreateMetadataResponse: ResponseServiceNowFieldListDTO | null
 }

--- a/src/modules/70-pipeline/strings/strings.en.yaml
+++ b/src/modules/70-pipeline/strings/strings.en.yaml
@@ -220,6 +220,9 @@ serviceNowApprovalStep:
   jexlExpressionPlaceholder: |
     Example: <+ticket.state.value> == "Done"
   serviceNowField: Service Now Field
+  approvalChangeWindow: Approval Change Window
+  windowStart: Window Start
+  windowEnd: Window End
   execution:
     wasApproved: 'Approval Criteria was met for ServiceNow Ticket:'
     wasRejected: 'Rejection Criteria was met for ServiceNow Ticket:'
@@ -234,6 +237,8 @@ serviceNowApprovalStep:
     connectorRef: ServiceNow Connector is required
     ticketType: Ticket Type is required
     issueNumber: Ticket Number is required
+    windowStart: Window start is required
+    windowEnd: Window end is required
 serviceNowCreateStep:
   fieldType:
     configureFields: Configure Fields

--- a/src/services/cd-ng/index.tsx
+++ b/src/services/cd-ng/index.tsx
@@ -394,6 +394,7 @@ export interface Account {
   nextGenEnabled?: boolean
   oauthEnabled?: boolean
   povAccount?: boolean
+  productLed?: boolean
   ringName?: string
   serviceAccountConfig?: ServiceAccountConfig
   serviceGuardLimit?: number
@@ -413,6 +414,7 @@ export interface AccountDTO {
   identifier?: string
   name?: string
   nextGenEnabled?: boolean
+  productLed?: boolean
   serviceAccountConfig?: ServiceAccountConfig
 }
 
@@ -1435,6 +1437,7 @@ export interface CDPipelineModuleInfo {
   envIdentifiers?: string[]
   environmentTypes?: ('PreProduction' | 'Production')[]
   infrastructureIdentifiers?: string[]
+  infrastructureNames?: string[]
   infrastructureTypes?: string[]
   serviceDefinitionTypes?: string[]
   serviceIdentifiers?: string[]
@@ -1650,6 +1653,7 @@ export type CommandStepInfo = StepSpecType & {
   commandUnits?: CommandUnitWrapper[]
   delegateSelectors?: string[]
   environmentVariables?: NGVariable[]
+  host?: string
   metadata?: string
   onDelegate: boolean
   outputVariables?: NGVariable[]
@@ -2818,7 +2822,7 @@ export interface EnvironmentDeploymentsInfo {
   envId?: string
   envName?: string
   envType?: string
-  infrastructureIdentifiers?: string[]
+  infrastructureDetails?: InfrastructureInfo[]
 }
 
 export interface EnvironmentFilterProperties {
@@ -4753,7 +4757,12 @@ export interface GitOpsInstanceRequest {
   envIdentifier?: string
   instanceInfo: K8sBasicInfo
   lastDeployedAt: number
+  lastDeployedById?: string
+  lastDeployedByName?: string
+  lastExecutedAt?: number
   orgIdentifier?: string
+  pipelineExecutionId?: string
+  pipelineName?: string
   projectIdentifier?: string
   serviceIdentifier?: string
 }
@@ -5519,6 +5528,7 @@ export type IgnoreFailureActionConfig = FailureStrategyActionConfig & {
 export interface InfraExecutionSummary {
   identifier?: string
   infrastructureIdentifier?: string
+  infrastructureName?: string
   name?: string
   type?: string
 }
@@ -5586,6 +5596,11 @@ export interface InfrastructureDefinitionConfig {
 
 export interface InfrastructureDetails {
   [key: string]: any
+}
+
+export interface InfrastructureInfo {
+  infrastructureIdentifier?: string
+  infrastructureName?: string
 }
 
 export interface InfrastructureRequestDTO {
@@ -9747,6 +9762,13 @@ export interface ResponseServiceInstanceUsageDTO {
   status?: 'SUCCESS' | 'FAILURE' | 'ERROR'
 }
 
+export interface ResponseServiceNowFieldListDTO {
+  correlationId?: string
+  data?: ServiceNowFieldListDTO
+  metaData?: { [key: string]: any }
+  status?: 'SUCCESS' | 'FAILURE' | 'ERROR'
+}
+
 export interface ResponseServiceOverrideResponseDTO {
   correlationId?: string
   data?: ServiceOverrideResponseDTO
@@ -10921,9 +10943,17 @@ export interface ServiceNowFieldAllowedValueNG {
   value?: string
 }
 
+export interface ServiceNowFieldListDTO {
+  fieldInternalTypeMap: {
+    [key: string]: string[]
+  }
+  fields: ServiceNowFieldNG[]
+}
+
 export interface ServiceNowFieldNG {
   allowedValues: ServiceNowFieldAllowedValueNG[]
   custom?: boolean
+  internalType?: string
   key: string
   name: string
   required?: boolean
@@ -10978,6 +11008,8 @@ export interface ServiceOverrides {
 }
 
 export interface ServicePipelineInfo {
+  deployedById?: string
+  deployedByName?: string
   identifier?: string
   lastExecutedAt?: number
   name?: string
@@ -15121,11 +15153,13 @@ export const getLastSuccessfulBuildForArtifactoryArtifactPromise = (
   >('POST', getConfig('ng/api'), `/artifacts/artifactory/getLastSuccessfulBuild`, props, signal)
 
 export interface GetRepositoriesDetailsForArtifactoryQueryParams {
-  connectorRef: string
+  connectorRef?: string
   repositoryType?: string
   accountIdentifier: string
   orgIdentifier: string
   projectIdentifier: string
+  fqnPath?: string
+  serviceId?: string
 }
 
 export type GetRepositoriesDetailsForArtifactoryProps = Omit<
@@ -36330,6 +36364,7 @@ export interface GetServiceNowIssueCreateMetadataQueryParams {
   orgIdentifier?: string
   projectIdentifier?: string
   ticketType?: string
+  fieldType?: 'glide_date_time' | 'integer' | 'boolean' | 'string' | 'option'
   branch?: string
   repoIdentifier?: string
   getDefaultFromOtherRepo?: boolean
@@ -36380,6 +36415,66 @@ export const getServiceNowIssueCreateMetadataPromise = (
   getUsingFetch<ResponseListServiceNowFieldNG, Failure | Error, GetServiceNowIssueCreateMetadataQueryParams, void>(
     getConfig('ng/api'),
     `/servicenow/createMetadata`,
+    props,
+    signal
+  )
+
+export interface GetServiceNowIssueCreateMetadataV2QueryParams {
+  connectorRef: string
+  accountIdentifier: string
+  orgIdentifier?: string
+  projectIdentifier?: string
+  ticketType: string
+  branch?: string
+  repoIdentifier?: string
+  getDefaultFromOtherRepo?: boolean
+}
+
+export type GetServiceNowIssueCreateMetadataV2Props = Omit<
+  GetProps<ResponseServiceNowFieldListDTO, Failure | Error, GetServiceNowIssueCreateMetadataV2QueryParams, void>,
+  'path'
+>
+
+/**
+ * Get ServiceNow issue create metadata
+ */
+export const GetServiceNowIssueCreateMetadataV2 = (props: GetServiceNowIssueCreateMetadataV2Props) => (
+  <Get<ResponseServiceNowFieldListDTO, Failure | Error, GetServiceNowIssueCreateMetadataV2QueryParams, void>
+    path={`/servicenow/createMetadataV2`}
+    base={getConfig('ng/api')}
+    {...props}
+  />
+)
+
+export type UseGetServiceNowIssueCreateMetadataV2Props = Omit<
+  UseGetProps<ResponseServiceNowFieldListDTO, Failure | Error, GetServiceNowIssueCreateMetadataV2QueryParams, void>,
+  'path'
+>
+
+/**
+ * Get ServiceNow issue create metadata
+ */
+export const useGetServiceNowIssueCreateMetadataV2 = (props: UseGetServiceNowIssueCreateMetadataV2Props) =>
+  useGet<ResponseServiceNowFieldListDTO, Failure | Error, GetServiceNowIssueCreateMetadataV2QueryParams, void>(
+    `/servicenow/createMetadataV2`,
+    { base: getConfig('ng/api'), ...props }
+  )
+
+/**
+ * Get ServiceNow issue create metadata
+ */
+export const getServiceNowIssueCreateMetadataV2Promise = (
+  props: GetUsingFetchProps<
+    ResponseServiceNowFieldListDTO,
+    Failure | Error,
+    GetServiceNowIssueCreateMetadataV2QueryParams,
+    void
+  >,
+  signal?: RequestInit['signal']
+) =>
+  getUsingFetch<ResponseServiceNowFieldListDTO, Failure | Error, GetServiceNowIssueCreateMetadataV2QueryParams, void>(
+    getConfig('ng/api'),
+    `/servicenow/createMetadataV2`,
     props,
     signal
   )

--- a/src/stringTypes.ts
+++ b/src/stringTypes.ts
@@ -3465,6 +3465,7 @@ export interface StringsMap {
   'pipeline.serviceDeploymentTypes.serverlessGoogleFunctions': string
   'pipeline.serviceDeploymentTypes.ssh': string
   'pipeline.serviceDeploymentTypes.winrm': string
+  'pipeline.serviceNowApprovalStep.approvalChangeWindow': string
   'pipeline.serviceNowApprovalStep.connectToServiceNow': string
   'pipeline.serviceNowApprovalStep.connectorRef': string
   'pipeline.serviceNowApprovalStep.execution.conditions.equals': string
@@ -3488,6 +3489,10 @@ export interface StringsMap {
   'pipeline.serviceNowApprovalStep.validations.connectorRef': string
   'pipeline.serviceNowApprovalStep.validations.issueNumber': string
   'pipeline.serviceNowApprovalStep.validations.ticketType': string
+  'pipeline.serviceNowApprovalStep.validations.windowEnd': string
+  'pipeline.serviceNowApprovalStep.validations.windowStart': string
+  'pipeline.serviceNowApprovalStep.windowEnd': string
+  'pipeline.serviceNowApprovalStep.windowStart': string
   'pipeline.serviceNowCreateStep.addFields': string
   'pipeline.serviceNowCreateStep.descriptionPlaceholder': string
   'pipeline.serviceNowCreateStep.fetchingFields': string


### PR DESCRIPTION
### Summary

- Change window with optional layout
- Required if the checkbox is enabled
- v2 endpoint - `useGetServiceNowIssueCreateMetadataV2` to avoid calling the same endpoint with various query params.

`data: [] -> data: {fields: [], fieldInternalTypeMap: {}}`

#### Screenshots
![Kapture 2022-07-29 at 09 29 03](https://user-images.githubusercontent.com/20707504/181685966-1ba795a7-dcfb-439e-a7ea-2d3fdd05f465.gif)

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [x] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier: `fix prettier`
</details>
