### PR TITLE
fix: formik issue clearing the fields due to batching

### DIFF
--- a/src/modules/75-cd/components/PipelineSteps/AzureWebAppInfrastructureStep/AzureWebAppInfrastructureSpecEditable.tsx
+++ b/src/modules/75-cd/components/PipelineSteps/AzureWebAppInfrastructureStep/AzureWebAppInfrastructureSpecEditable.tsx
@@ -260,10 +260,14 @@ const AzureWebAppInfrastructureSpecEditableNew: React.FC<AzureWebAppInfrastructu
                     /* istanbul ignore next */
                     if (type !== MultiTypeInputType.FIXED) {
                       getMultiTypeFromValue(formik.values?.subscriptionId) !== MultiTypeInputType.RUNTIME &&
+                        formik.values.subscriptionId?.value &&
                         formik.setFieldValue('subscriptionId', '')
                       getMultiTypeFromValue(formik.values?.resourceGroup) !== MultiTypeInputType.RUNTIME &&
+                        formik.values.resourceGroup?.value &&
                         formik.setFieldValue('resourceGroup', '')
                     }
+                    setSubscriptions([])
+                    setResourceGroups([])
                   }}
                 />
                 {getMultiTypeFromValue(formik.values.connectorRef) === MultiTypeInputType.RUNTIME && !readonly && (
@@ -303,6 +307,7 @@ const AzureWebAppInfrastructureSpecEditableNew: React.FC<AzureWebAppInfrastructu
                   multiTypeInputProps={{
                     onChange: /* istanbul ignore next */ () => {
                       getMultiTypeFromValue(formik.values?.resourceGroup) !== MultiTypeInputType.RUNTIME &&
+                        formik.values.resourceGroup?.value &&
                         formik.setFieldValue('resourceGroup', '')
 
                       setResourceGroups([])


### PR DESCRIPTION
### Summary

1. Formik batching update losses state when multiple setFieldValues are triggered.
2. The dropdowns should be cleared on change of dependent parent field

#### Screenshots


https://user-images.githubusercontent.com/106532291/184132416-94b5e660-cfeb-4156-a391-da4b19cc1c6d.mov


#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier: `fix prettier`
</details>
