### PR TITLE
fix: [CDS-42268]: fix harness icons to specifc version

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@emotion/styled": "^10.0.27",
     "@harness/design-system": "1.0.0",
     "@harness/help-panel": "1.12.0",
-    "@harness/icons": "^1.55.0",
+    "@harness/icons": "1.55.0",
     "@harness/monaco-yaml": "^1.0.0",
     "@harness/ng-tooltip": "^1.31.2",
     "@harness/telemetry": "^1.0.42",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1756,10 +1756,10 @@
     "@contentful/rich-text-react-renderer" "^15.12.0"
     contentful "^9.1.20"
 
-"@harness/icons@^1.55.0":
-  version "1.56.0"
-  resolved "https://npm.pkg.github.com/download/@harness/icons/1.56.0/5ee234c3932e86738da03a2392698af052218b04#5ee234c3932e86738da03a2392698af052218b04"
-  integrity sha512-pF1Bh8Sfg8XIa+23CxoFN8Q0F8Na/gzEk/B/Go3gCJCSwOpP3sxpbZNEQjHmyqmVJ+Pbo0L3OT2CyGVAF7An0Q==
+"@harness/icons@1.55.0":
+  version "1.55.0"
+  resolved "https://npm.pkg.github.com/download/@harness/icons/1.55.0/1f968f5a643328ef124322882ca03bc2254a3b42#1f968f5a643328ef124322882ca03bc2254a3b42"
+  integrity sha512-9ODoJGDx2dNLBnBzXTfS8pfNXmchfHUpNjDLbUjnaqgyIx+Oc3EpggVNN1VySwO72PtsMWhRv4zYKVzEy/xjuQ==
 
 "@harness/jarvis@0.16.0":
   version "0.16.0"


### PR DESCRIPTION
### Summary
Set harness icons to specific version, caret (^) seems to have broken unit tests. Removing to fix the issue.
<!-- ✍️ A clear and concise description...-->

#### Screenshots

NA
<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier: `fix prettier`
</details>
