### PR TITLE
fix: [CDS-43309]: UI Fixes for Win-Rm and SSH Secrets

### DIFF
--- a/src/modules/30-secrets/modals/CreateSSHCredModal/__test__/CreateSSHCredWizard.test.tsx
+++ b/src/modules/30-secrets/modals/CreateSSHCredModal/__test__/CreateSSHCredWizard.test.tsx
@@ -134,6 +134,6 @@ describe('Create SSH Cred Wizard', () => {
       clickSubmit(container)
     })
     //Verification of delegate service
-    expect(getAllByText('secrets.createSSHCredWizard.verifyRetest')[0]).toBeDefined()
+    expect(getAllByText('retry')[0]).toBeDefined()
   })
 })

--- a/src/modules/30-secrets/modals/CreateSSHCredModal/__test__/__snapshots__/CreateSSHCredWizard.test.tsx.snap
+++ b/src/modules/30-secrets/modals/CreateSSHCredModal/__test__/__snapshots__/CreateSSHCredWizard.test.tsx.snap
@@ -1065,70 +1065,74 @@ exports[`Create SSH Cred Wizard should render form 3`] = `
           secrets.stepTitleVerify
         </p>
         <div
-          class="StyledProps--font StyledProps--main"
-          style="width: 300px;"
+          class="StyledProps--font StyledProps--main formData"
         >
           <div
-            class="OverlaySpinner--overlaySpinner"
+            class="StyledProps--font StyledProps--main"
+            style="width: 300px;"
           >
-            <form
-              action="#"
-              class="FormikForm--main"
+            <div
+              class="OverlaySpinner--overlaySpinner"
             >
-              <div>
-                <div
-                  class="bp3-form-group"
-                  data-id="host-0"
-                >
-                  <label
-                    class="bp3-label"
-                    for="host"
-                  >
-                    <span
-                      class="Tooltip--acenter"
-                      data-tooltip-id="sshVerifyConnectionForm_host"
-                    >
-                      secrets.createSSHCredWizard.labelHostname
-                    </span>
-                     
-                    <span
-                      class="bp3-text-muted"
-                    />
-                  </label>
+              <form
+                action="#"
+                class="FormikForm--main"
+              >
+                <div>
                   <div
-                    class="bp3-form-content"
+                    class="bp3-form-group"
+                    data-id="host-0"
                   >
-                    <div
-                      class="bp3-input-group"
+                    <label
+                      class="bp3-label"
+                      for="host"
                     >
-                      <input
-                        autocomplete="off"
-                        class="bp3-input"
-                        name="host"
-                        type="text"
-                        value=""
+                      <span
+                        class="Tooltip--acenter"
+                        data-tooltip-id="sshVerifyConnectionForm_host"
+                      >
+                        secrets.createSSHCredWizard.labelHostname
+                      </span>
+                       
+                      <span
+                        class="bp3-text-muted"
                       />
+                    </label>
+                    <div
+                      class="bp3-form-content"
+                    >
+                      <div
+                        class="bp3-input-group"
+                      >
+                        <input
+                          autocomplete="off"
+                          class="bp3-input"
+                          name="host"
+                          type="text"
+                          value=""
+                        />
+                      </div>
                     </div>
                   </div>
-                </div>
-                <p
-                  class="StyledProps--font StyledProps--main StyledProps--font-size-xsmall StyledProps--font-weight-bold"
-                >
-                  secrets.createSSHCredWizard.hostnameInfo
-                </p>
-                <button
-                  class="bp3-button Button--button StyledProps--font StyledProps--main StyledProps--margin-top-medium Button--with-current-color Button--variation Button--variation-secondary Button--size Button--small"
-                  style="font-size: smaller;"
-                  type="submit"
-                >
-                  <span
-                    class="bp3-button-text"
+                  <p
+                    class="StyledProps--font StyledProps--main StyledProps--font-size-xsmall StyledProps--font-weight-bold"
                   >
-                    common.smtp.testConnection
-                  </span>
-                </button>
-              </div>
-            </form>
+                    secrets.createSSHCredWizard.hostnameInfo
+                  </p>
+                  <button
+                    class="bp3-button Button--button StyledProps--font StyledProps--main StyledProps--margin-top-medium Button--with-current-color Button--variation Button--variation-secondary Button--size Button--small"
+                    style="font-size: smaller;"
+                    type="submit"
+                  >
+                    <span
+                      class="bp3-button-text"
+                    >
+                      common.smtp.testConnection
+                    </span>
+                  </button>
+                </div>
+              </form>
+            </div>
           </div>
         </div>
       </div>

--- a/src/modules/30-secrets/modals/CreateSSHCredModal/__test__/__snapshots__/CreateSSHCredWizard.test.tsx.snap
+++ b/src/modules/30-secrets/modals/CreateSSHCredModal/__test__/__snapshots__/CreateSSHCredWizard.test.tsx.snap
@@ -1114,7 +1114,7 @@ exports[`Create SSH Cred Wizard should render form 3`] = `
                 <p
                   class="StyledProps--font StyledProps--main StyledProps--font-size-xsmall StyledProps--font-weight-bold"
                 >
-                  SECRETS.CREATESSHCREDWIZARD.HOSTNAMEINFO
+                  secrets.createSSHCredWizard.hostnameInfo
                 </p>
                 <button
                   class="bp3-button Button--button StyledProps--font StyledProps--main StyledProps--margin-top-medium Button--with-current-color Button--variation Button--variation-secondary Button--size Button--small"
@@ -1124,7 +1124,7 @@ exports[`Create SSH Cred Wizard should render form 3`] = `
                   <span
                     class="bp3-button-text"
                   >
-                    secrets.createSSHCredWizard.btnVerifyConnection
+                    common.smtp.testConnection
                   </span>
                 </button>
               </div>

--- a/src/modules/30-secrets/modals/CreateSSHCredModal/views/VerifyConnection.tsx
+++ b/src/modules/30-secrets/modals/CreateSSHCredModal/views/VerifyConnection.tsx
@@ -22,6 +22,7 @@ import { useStrings } from 'framework/strings'
 import { useTelemetry } from '@common/hooks/useTelemetry'
 import { Category, SecretActions } from '@common/constants/TrackingConstants'
 import VerifySecret, { Status } from './VerifySecret'
+import css from './StepDetails.module.scss'
 
 interface VerifyConnectionProps {
   identifier: string
@@ -35,86 +36,90 @@ const VerifyConnection: React.FC<VerifyConnectionProps> = ({ identifier, closeMo
   const { trackEvent } = useTelemetry()
   return (
     <>
-      <Container width={300}>
-        <Formik<ValidationMetadata>
-          onSubmit={formData => {
-            setValidationMetadata({
-              type: 'SSHKey',
-              host: formData.host
-            })
-          }}
-          formName="sshVerifyConnectionForm"
-          initialValues={{
-            type: 'SSHKey',
-            host: ''
-          }}
-          validationSchema={Yup.object().shape({
-            host: Yup.string().trim().required()
-          })}
-        >
-          {() => {
-            return (
-              <FormikForm>
-                <FormInput.Text
-                  name="host"
-                  label={getString('secrets.createSSHCredWizard.labelHostname')}
-                  disabled={!!validationMetadata}
-                />
-                <Text font={{ size: 'xsmall', weight: 'bold' }}>
-                  {getString('secrets.createSSHCredWizard.hostnameInfo')}
-                </Text>
-                {validationMetadata ? null : (
-                  <Button
-                    type="submit"
-                    text={getString('common.smtp.testConnection')}
-                    style={{ fontSize: 'smaller' }}
-                    margin={{ top: 'medium' }}
-                    variation={ButtonVariation.SECONDARY}
-                    size={ButtonSize.SMALL}
-                  />
-                )}
-              </FormikForm>
-            )
-          }}
-        </Formik>
-      </Container>
-      {validationMetadata ? (
-        <Container margin={{ top: 'xxlarge' }}>
-          <VerifySecret
-            identifier={identifier as string}
-            validationMetadata={validationMetadata}
-            onFinish={status => {
-              setFinishStatus(status)
+      <Container className={css.formData}>
+        <Container width={300}>
+          <Formik<ValidationMetadata>
+            onSubmit={formData => {
+              setValidationMetadata({
+                type: 'SSHKey',
+                host: formData.host
+              })
             }}
-          />
-          {finishStatus && (
-            <>
-              <Button
-                text={getString('retry')}
-                variation={ButtonVariation.SECONDARY}
-                size={ButtonSize.SMALL}
-                margin={{ top: 'medium' }}
-                onClick={() => {
-                  setValidationMetadata(undefined)
-                }}
-              />
-            </>
-          )}
-          <Container margin={{ top: 'large' }}>
-            <Button
-              text={getString('finish')}
-              variation={ButtonVariation.SECONDARY}
-              size={ButtonSize.SMALL}
-              onClick={() => {
-                trackEvent(SecretActions.SaveCreateSecret, {
-                  category: Category.SECRET,
-                  finishStatus,
-                  validationMetadata
-                })
-                closeModal?.()
+            formName="sshVerifyConnectionForm"
+            initialValues={{
+              type: 'SSHKey',
+              host: ''
+            }}
+            validationSchema={Yup.object().shape({
+              host: Yup.string().trim().required()
+            })}
+          >
+            {() => {
+              return (
+                <FormikForm>
+                  <FormInput.Text
+                    name="host"
+                    label={getString('secrets.createSSHCredWizard.labelHostname')}
+                    disabled={!!validationMetadata}
+                  />
+                  <Text font={{ size: 'xsmall', weight: 'bold' }}>
+                    {getString('secrets.createSSHCredWizard.hostnameInfo')}
+                  </Text>
+                  {validationMetadata ? null : (
+                    <Button
+                      type="submit"
+                      text={getString('common.smtp.testConnection')}
+                      style={{ fontSize: 'smaller' }}
+                      margin={{ top: 'medium' }}
+                      variation={ButtonVariation.SECONDARY}
+                      size={ButtonSize.SMALL}
+                    />
+                  )}
+                </FormikForm>
+              )
+            }}
+          </Formik>
+        </Container>
+        {validationMetadata ? (
+          <Container margin={{ top: 'xxlarge' }}>
+            <VerifySecret
+              identifier={identifier as string}
+              validationMetadata={validationMetadata}
+              onFinish={status => {
+                setFinishStatus(status)
               }}
             />
+            {finishStatus && (
+              <>
+                <Button
+                  text={getString('retry')}
+                  variation={ButtonVariation.SECONDARY}
+                  size={ButtonSize.SMALL}
+                  margin={{ top: 'medium' }}
+                  onClick={() => {
+                    setValidationMetadata(undefined)
+                  }}
+                />
+              </>
+            )}
           </Container>
+        ) : null}
+      </Container>
+      {validationMetadata ? (
+        <Container>
+          <Button
+            text={getString('finish')}
+            variation={ButtonVariation.SECONDARY}
+            size={ButtonSize.SMALL}
+            onClick={() => {
+              trackEvent(SecretActions.SaveCreateSecret, {
+                category: Category.SECRET,
+                finishStatus,
+                validationMetadata
+              })
+              closeModal?.()
+            }}
+          />
         </Container>
       ) : null}
     </>

--- a/src/modules/30-secrets/modals/CreateSSHCredModal/views/VerifyConnection.tsx
+++ b/src/modules/30-secrets/modals/CreateSSHCredModal/views/VerifyConnection.tsx
@@ -61,12 +61,12 @@ const VerifyConnection: React.FC<VerifyConnectionProps> = ({ identifier, closeMo
                   disabled={!!validationMetadata}
                 />
                 <Text font={{ size: 'xsmall', weight: 'bold' }}>
-                  {getString('secrets.createSSHCredWizard.hostnameInfo').toUpperCase()}
+                  {getString('secrets.createSSHCredWizard.hostnameInfo')}
                 </Text>
                 {validationMetadata ? null : (
                   <Button
                     type="submit"
-                    text={getString('secrets.createSSHCredWizard.btnVerifyConnection')}
+                    text={getString('common.smtp.testConnection')}
                     style={{ fontSize: 'smaller' }}
                     margin={{ top: 'medium' }}
                     variation={ButtonVariation.SECONDARY}
@@ -90,7 +90,7 @@ const VerifyConnection: React.FC<VerifyConnectionProps> = ({ identifier, closeMo
           {finishStatus && (
             <>
               <Button
-                text={getString('secrets.createSSHCredWizard.verifyRetest')}
+                text={getString('retry')}
                 variation={ButtonVariation.SECONDARY}
                 size={ButtonSize.SMALL}
                 margin={{ top: 'medium' }}
@@ -98,23 +98,23 @@ const VerifyConnection: React.FC<VerifyConnectionProps> = ({ identifier, closeMo
                   setValidationMetadata(undefined)
                 }}
               />
-              <Container margin={{ top: 'large' }}>
-                <Button
-                  text={getString('finish').toUpperCase()}
-                  variation={ButtonVariation.SECONDARY}
-                  size={ButtonSize.SMALL}
-                  onClick={() => {
-                    trackEvent(SecretActions.SaveCreateSecret, {
-                      category: Category.SECRET,
-                      finishStatus,
-                      validationMetadata
-                    })
-                    closeModal?.()
-                  }}
-                />
-              </Container>
             </>
           )}
+          <Container margin={{ top: 'large' }}>
+            <Button
+              text={getString('finish')}
+              variation={ButtonVariation.SECONDARY}
+              size={ButtonSize.SMALL}
+              onClick={() => {
+                trackEvent(SecretActions.SaveCreateSecret, {
+                  category: Category.SECRET,
+                  finishStatus,
+                  validationMetadata
+                })
+                closeModal?.()
+              }}
+            />
+          </Container>
         </Container>
       ) : null}
     </>

--- a/src/modules/30-secrets/modals/CreateWinRmCredModal/__test__/CreateWinRmCredWizard.test.tsx
+++ b/src/modules/30-secrets/modals/CreateWinRmCredModal/__test__/CreateWinRmCredWizard.test.tsx
@@ -137,6 +137,6 @@ describe('Create WinRm Cred Wizard', () => {
       clickSubmit(container)
     })
     //Verification of delegate service
-    expect(getAllByText('secrets.createSSHCredWizard.verifyRetest')[0]).toBeDefined()
+    expect(getAllByText('retry')[0]).toBeDefined()
   })
 })

--- a/src/modules/30-secrets/modals/CreateWinRmCredModal/__test__/__snapshots__/CreateWinRmCredWizard.test.tsx.snap
+++ b/src/modules/30-secrets/modals/CreateWinRmCredModal/__test__/__snapshots__/CreateWinRmCredWizard.test.tsx.snap
@@ -979,70 +979,74 @@ exports[`Create WinRm Cred Wizard should render form 3`] = `
           secrets.stepTitleVerify
         </p>
         <div
-          class="StyledProps--font StyledProps--main"
-          style="width: 300px;"
+          class="StyledProps--font StyledProps--main formData"
         >
           <div
-            class="OverlaySpinner--overlaySpinner"
+            class="StyledProps--font StyledProps--main"
+            style="width: 300px;"
           >
-            <form
-              action="#"
-              class="FormikForm--main"
+            <div
+              class="OverlaySpinner--overlaySpinner"
             >
-              <div>
-                <div
-                  class="bp3-form-group"
-                  data-id="host-0"
-                >
-                  <label
-                    class="bp3-label"
-                    for="host"
-                  >
-                    <span
-                      class="Tooltip--acenter"
-                      data-tooltip-id="sshVerifyConnectionForm_host"
-                    >
-                      secrets.createSSHCredWizard.labelHostname
-                    </span>
-                     
-                    <span
-                      class="bp3-text-muted"
-                    />
-                  </label>
+              <form
+                action="#"
+                class="FormikForm--main"
+              >
+                <div>
                   <div
-                    class="bp3-form-content"
+                    class="bp3-form-group"
+                    data-id="host-0"
                   >
-                    <div
-                      class="bp3-input-group"
+                    <label
+                      class="bp3-label"
+                      for="host"
                     >
-                      <input
-                        autocomplete="off"
-                        class="bp3-input"
-                        name="host"
-                        type="text"
-                        value=""
+                      <span
+                        class="Tooltip--acenter"
+                        data-tooltip-id="sshVerifyConnectionForm_host"
+                      >
+                        secrets.createSSHCredWizard.labelHostname
+                      </span>
+                       
+                      <span
+                        class="bp3-text-muted"
                       />
+                    </label>
+                    <div
+                      class="bp3-form-content"
+                    >
+                      <div
+                        class="bp3-input-group"
+                      >
+                        <input
+                          autocomplete="off"
+                          class="bp3-input"
+                          name="host"
+                          type="text"
+                          value=""
+                        />
+                      </div>
                     </div>
                   </div>
-                </div>
-                <p
-                  class="StyledProps--font StyledProps--main StyledProps--font-size-xsmall StyledProps--font-weight-bold"
-                >
-                  secrets.createSSHCredWizard.hostnameInfo
-                </p>
-                <button
-                  class="bp3-button Button--button StyledProps--font StyledProps--main StyledProps--margin-top-medium Button--with-current-color Button--variation Button--variation-secondary Button--size Button--small"
-                  style="font-size: smaller;"
-                  type="submit"
-                >
-                  <span
-                    class="bp3-button-text"
+                  <p
+                    class="StyledProps--font StyledProps--main StyledProps--font-size-xsmall StyledProps--font-weight-bold"
                   >
-                    common.smtp.testConnection
-                  </span>
-                </button>
-              </div>
-            </form>
+                    secrets.createSSHCredWizard.hostnameInfo
+                  </p>
+                  <button
+                    class="bp3-button Button--button StyledProps--font StyledProps--main StyledProps--margin-top-medium Button--with-current-color Button--variation Button--variation-secondary Button--size Button--small"
+                    style="font-size: smaller;"
+                    type="submit"
+                  >
+                    <span
+                      class="bp3-button-text"
+                    >
+                      common.smtp.testConnection
+                    </span>
+                  </button>
+                </div>
+              </form>
+            </div>
           </div>
         </div>
       </div>

--- a/src/modules/30-secrets/modals/CreateWinRmCredModal/__test__/__snapshots__/CreateWinRmCredWizard.test.tsx.snap
+++ b/src/modules/30-secrets/modals/CreateWinRmCredModal/__test__/__snapshots__/CreateWinRmCredWizard.test.tsx.snap
@@ -1028,7 +1028,7 @@ exports[`Create WinRm Cred Wizard should render form 3`] = `
                 <p
                   class="StyledProps--font StyledProps--main StyledProps--font-size-xsmall StyledProps--font-weight-bold"
                 >
-                  SECRETS.CREATESSHCREDWIZARD.HOSTNAMEINFO
+                  secrets.createSSHCredWizard.hostnameInfo
                 </p>
                 <button
                   class="bp3-button Button--button StyledProps--font StyledProps--main StyledProps--margin-top-medium Button--with-current-color Button--variation Button--variation-secondary Button--size Button--small"
@@ -1038,7 +1038,7 @@ exports[`Create WinRm Cred Wizard should render form 3`] = `
                   <span
                     class="bp3-button-text"
                   >
-                    secrets.createSSHCredWizard.btnVerifyConnection
+                    common.smtp.testConnection
                   </span>
                 </button>
               </div>

--- a/src/modules/30-secrets/modals/CreateWinRmCredModal/views/VerifyConnection.tsx
+++ b/src/modules/30-secrets/modals/CreateWinRmCredModal/views/VerifyConnection.tsx
@@ -22,6 +22,7 @@ import { useStrings } from 'framework/strings'
 import { useTelemetry } from '@common/hooks/useTelemetry'
 import { Category, SecretActions } from '@common/constants/TrackingConstants'
 import VerifySecret, { Status } from './VerifySecret'
+import css from './StepDetails.module.scss'
 
 interface VerifyConnectionProps {
   identifier: string
@@ -35,87 +36,92 @@ const VerifyConnection: React.FC<VerifyConnectionProps> = ({ identifier, closeMo
   const { trackEvent } = useTelemetry()
   return (
     <>
-      <Container width={300}>
-        <Formik<WinRmCredentialsValidationMetadata>
-          onSubmit={formData => {
-            setValidationMetadata({
-              type: 'WinRmCredentials',
-              host: formData.host
-            })
-          }}
-          formName="sshVerifyConnectionForm"
-          initialValues={{
-            type: 'WinRmCredentials',
-            host: ''
-          }}
-          validationSchema={Yup.object().shape({
-            host: Yup.string().trim().required()
-          })}
-        >
-          {() => {
-            return (
-              <FormikForm>
-                <FormInput.Text
-                  name="host"
-                  label={getString('secrets.createSSHCredWizard.labelHostname')}
-                  disabled={!!validationMetadata}
-                />
-                <Text font={{ size: 'xsmall', weight: 'bold' }}>
-                  {getString('secrets.createSSHCredWizard.hostnameInfo')}
-                </Text>
-                {validationMetadata ? null : (
-                  <Button
-                    type="submit"
-                    text={getString('common.smtp.testConnection')}
-                    style={{ fontSize: 'smaller' }}
-                    margin={{ top: 'medium' }}
-                    variation={ButtonVariation.SECONDARY}
-                    size={ButtonSize.SMALL}
-                  />
-                )}
-              </FormikForm>
-            )
-          }}
-        </Formik>
-      </Container>
-      {validationMetadata ? (
-        <Container margin={{ top: 'xxlarge' }}>
-          <VerifySecret
-            identifier={identifier as string}
-            validationMetadata={validationMetadata}
-            onFinish={status => {
-              setFinishStatus(status)
+      <Container className={css.formData}>
+        <Container width={300}>
+          <Formik<WinRmCredentialsValidationMetadata>
+            onSubmit={formData => {
+              setValidationMetadata({
+                type: 'WinRmCredentials',
+                host: formData.host
+              })
             }}
-          />
-          {finishStatus && (
-            <>
-              <Button
-                text={getString('retry')}
-                variation={ButtonVariation.SECONDARY}
-                size={ButtonSize.SMALL}
-                margin={{ top: 'medium' }}
-                onClick={() => {
-                  setValidationMetadata(undefined)
-                }}
-              />
-            </>
-          )}
-          <Container margin={{ top: 'large' }}>
-            <Button
-              text={getString('finish')}
-              variation={ButtonVariation.SECONDARY}
-              size={ButtonSize.SMALL}
-              onClick={() => {
-                trackEvent(SecretActions.SaveCreateSecret, {
-                  category: Category.SECRET,
-                  finishStatus,
-                  validationMetadata
-                })
-                /* istanbul ignore next */
-                closeModal?.()
+            formName="sshVerifyConnectionForm"
+            initialValues={{
+              type: 'WinRmCredentials',
+              host: ''
+            }}
+            validationSchema={Yup.object().shape({
+              host: Yup.string().trim().required()
+            })}
+          >
+            {() => {
+              return (
+                <FormikForm>
+                  <FormInput.Text
+                    name="host"
+                    label={getString('secrets.createSSHCredWizard.labelHostname')}
+                    disabled={!!validationMetadata}
+                  />
+                  <Text font={{ size: 'xsmall', weight: 'bold' }}>
+                    {getString('secrets.createSSHCredWizard.hostnameInfo')}
+                  </Text>
+                  {validationMetadata ? null : (
+                    <Button
+                      type="submit"
+                      text={getString('common.smtp.testConnection')}
+                      style={{ fontSize: 'smaller' }}
+                      margin={{ top: 'medium' }}
+                      variation={ButtonVariation.SECONDARY}
+                      size={ButtonSize.SMALL}
+                    />
+                  )}
+                </FormikForm>
+              )
+            }}
+          </Formik>
+        </Container>
+        {validationMetadata ? (
+          <Container margin={{ top: 'xxlarge' }}>
+            <VerifySecret
+              identifier={identifier as string}
+              validationMetadata={validationMetadata}
+              onFinish={status => {
+                setFinishStatus(status)
               }}
             />
+            {finishStatus && (
+              <>
+                <Button
+                  text={getString('retry')}
+                  variation={ButtonVariation.SECONDARY}
+                  size={ButtonSize.SMALL}
+                  margin={{ top: 'medium' }}
+                  onClick={() => {
+                    setValidationMetadata(undefined)
+                  }}
+                />
+              </>
+            )}
           </Container>
+        ) : null}
+      </Container>
+      {validationMetadata ? (
+        <Container>
+          <Button
+            text={getString('finish')}
+            variation={ButtonVariation.SECONDARY}
+            hidden={!validationMetadata}
+            size={ButtonSize.SMALL}
+            onClick={() => {
+              trackEvent(SecretActions.SaveCreateSecret, {
+                category: Category.SECRET,
+                finishStatus,
+                validationMetadata
+              })
+              /* istanbul ignore next */
+              closeModal?.()
+            }}
+          />
         </Container>
       ) : null}
     </>

--- a/src/modules/30-secrets/modals/CreateWinRmCredModal/views/VerifyConnection.tsx
+++ b/src/modules/30-secrets/modals/CreateWinRmCredModal/views/VerifyConnection.tsx
@@ -61,12 +61,12 @@ const VerifyConnection: React.FC<VerifyConnectionProps> = ({ identifier, closeMo
                   disabled={!!validationMetadata}
                 />
                 <Text font={{ size: 'xsmall', weight: 'bold' }}>
-                  {getString('secrets.createSSHCredWizard.hostnameInfo').toUpperCase()}
+                  {getString('secrets.createSSHCredWizard.hostnameInfo')}
                 </Text>
                 {validationMetadata ? null : (
                   <Button
                     type="submit"
-                    text={getString('secrets.createSSHCredWizard.btnVerifyConnection')}
+                    text={getString('common.smtp.testConnection')}
                     style={{ fontSize: 'smaller' }}
                     margin={{ top: 'medium' }}
                     variation={ButtonVariation.SECONDARY}
@@ -90,7 +90,7 @@ const VerifyConnection: React.FC<VerifyConnectionProps> = ({ identifier, closeMo
           {finishStatus && (
             <>
               <Button
-                text={getString('secrets.createSSHCredWizard.verifyRetest')}
+                text={getString('retry')}
                 variation={ButtonVariation.SECONDARY}
                 size={ButtonSize.SMALL}
                 margin={{ top: 'medium' }}
@@ -98,24 +98,24 @@ const VerifyConnection: React.FC<VerifyConnectionProps> = ({ identifier, closeMo
                   setValidationMetadata(undefined)
                 }}
               />
-              <Container margin={{ top: 'large' }}>
-                <Button
-                  text={getString('finish').toUpperCase()}
-                  variation={ButtonVariation.SECONDARY}
-                  size={ButtonSize.SMALL}
-                  onClick={() => {
-                    trackEvent(SecretActions.SaveCreateSecret, {
-                      category: Category.SECRET,
-                      finishStatus,
-                      validationMetadata
-                    })
-                    /* istanbul ignore next */
-                    closeModal?.()
-                  }}
-                />
-              </Container>
             </>
           )}
+          <Container margin={{ top: 'large' }}>
+            <Button
+              text={getString('finish')}
+              variation={ButtonVariation.SECONDARY}
+              size={ButtonSize.SMALL}
+              onClick={() => {
+                trackEvent(SecretActions.SaveCreateSecret, {
+                  category: Category.SECRET,
+                  finishStatus,
+                  validationMetadata
+                })
+                /* istanbul ignore next */
+                closeModal?.()
+              }}
+            />
+          </Container>
         </Container>
       ) : null}
     </>

--- a/src/modules/30-secrets/pages/secrets/views/SecretsListView/SecretsList.tsx
+++ b/src/modules/30-secrets/pages/secrets/views/SecretsListView/SecretsList.tsx
@@ -114,7 +114,7 @@ const RenderColumnStatus: Renderer<CellProps<SecretResponseWrapper>> = ({ row })
     return (
       <Button
         font="small"
-        text={<String stringID="common.labelTestConnection" />}
+        text={<String stringID="test" />}
         onClick={e => {
           e.stopPropagation()
           if (data.type === 'SSHKey') {

--- a/src/modules/30-secrets/strings/strings.en.yaml
+++ b/src/modules/30-secrets/strings/strings.en.yaml
@@ -56,7 +56,6 @@ createSSHCredWizard:
   validateRealm: 'Realm is required'
   verifyStepOne: 'Checking for Delegates'
   verifyStepTwo: 'Verifying Connection'
-  verifyRetest: 'RETEST CONNECTION'
 createWinRmCredWizard:
   titleDetails: 'WinRm Details'
   validateDomain: 'Domain is required'

--- a/src/stringTypes.ts
+++ b/src/stringTypes.ts
@@ -1401,7 +1401,6 @@ export interface StringsMap {
   'secrets.createSSHCredWizard.validateRealm': string
   'secrets.createSSHCredWizard.validateSshKey': string
   'secrets.createSSHCredWizard.validateUsername': string
-  'secrets.createSSHCredWizard.verifyRetest': string
   'secrets.createSSHCredWizard.verifyStepOne': string
   'secrets.createSSHCredWizard.verifyStepTwo': string
   'secrets.createSecret': string


### PR DESCRIPTION
### Summary

 UI Fixes for Win-Rm and SSH Secrets

#### Screenshots



https://user-images.githubusercontent.com/106532291/190412972-86d6866f-dbc1-48f0-91cd-d5e7245337de.mov

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/106532291/190413238-ccaf334e-e856-4e30-9e40-6d65e6b0d18d.png">



#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
