### PR TITLE
fix: [PL-28236]: Editing the stage and pipeline template reseting the step what we have configured

### DIFF
--- a/src/modules/72-templates-library/components/TemplateStudio/PipelineTemplateCanvas/PipelineTemplateCanvasWrapper.tsx
+++ b/src/modules/72-templates-library/components/TemplateStudio/PipelineTemplateCanvas/PipelineTemplateCanvasWrapper.tsx
@@ -39,19 +39,22 @@ const PipelineTemplateCanvasWrapper = (): JSX.Element => {
   } = React.useContext(TemplateContext)
   const { accountId, projectIdentifier, orgIdentifier } = useParams<ProjectPathProps>()
 
-  const createPipelineFromTemplate = (): PipelineInfoConfig =>
-    merge({}, template.spec, {
-      name: DefaultNewPipelineName,
-      identifier: DefaultNewPipelineId
-    })
+  const createPipelineFromTemplate = React.useCallback(
+    (): PipelineInfoConfig =>
+      merge({}, template.spec, {
+        name: DefaultNewPipelineName,
+        identifier: DefaultNewPipelineId
+      }),
+    [template.spec]
+  )
 
   const [pipeline, setPipeline] = React.useState<PipelineInfoConfig>(createPipelineFromTemplate())
 
   React.useEffect(() => {
-    if (!isLoading && !isUpdated) {
+    if (!isLoading && isUpdated) {
       setPipeline(createPipelineFromTemplate())
     }
-  }, [isLoading, isUpdated])
+  }, [createPipelineFromTemplate, isLoading, isUpdated])
 
   const onUpdatePipeline = async (pipelineConfig: PipelineInfoConfig) => {
     const processNode = omit(pipelineConfig, 'name', 'identifier', 'description', 'tags')

--- a/src/modules/72-templates-library/components/TemplateStudio/PipelineTemplateCanvas/PipelineTemplateCanvasWrapper.tsx
+++ b/src/modules/72-templates-library/components/TemplateStudio/PipelineTemplateCanvas/PipelineTemplateCanvasWrapper.tsx
@@ -48,11 +48,11 @@ const PipelineTemplateCanvasWrapper = (): JSX.Element => {
     [template.spec]
   )
 
-  const [Template, setTemplate] = React.useState<PipelineInfoConfig>(createPipelineFromTemplate())
+  const [pipeline, setPipeline] = React.useState<PipelineInfoConfig>(createPipelineFromTemplate())
 
   React.useEffect(() => {
     if (!isLoading && isUpdated) {
-      setTemplate(createPipelineFromTemplate())
+      setPipeline(createPipelineFromTemplate())
     }
   }, [createPipelineFromTemplate, isLoading, isUpdated])
 
@@ -77,7 +77,7 @@ const PipelineTemplateCanvasWrapper = (): JSX.Element => {
   return (
     <TemplatePipelineProvider
       queryParams={{ accountIdentifier: accountId, orgIdentifier, projectIdentifier }}
-      initialValue={Template}
+      initialValue={pipeline}
       gitDetails={gitDetails}
       storeMetadata={storeMetadata}
       onUpdatePipeline={onUpdatePipeline}

--- a/src/modules/72-templates-library/components/TemplateStudio/PipelineTemplateCanvas/PipelineTemplateCanvasWrapper.tsx
+++ b/src/modules/72-templates-library/components/TemplateStudio/PipelineTemplateCanvas/PipelineTemplateCanvasWrapper.tsx
@@ -48,11 +48,11 @@ const PipelineTemplateCanvasWrapper = (): JSX.Element => {
     [template.spec]
   )
 
-  const [pipeline, setPipeline] = React.useState<PipelineInfoConfig>(createPipelineFromTemplate())
+  const [Template, setTemplate] = React.useState<PipelineInfoConfig>(createPipelineFromTemplate())
 
   React.useEffect(() => {
     if (!isLoading && isUpdated) {
-      setPipeline(createPipelineFromTemplate())
+      setTemplate(createPipelineFromTemplate())
     }
   }, [createPipelineFromTemplate, isLoading, isUpdated])
 
@@ -77,7 +77,7 @@ const PipelineTemplateCanvasWrapper = (): JSX.Element => {
   return (
     <TemplatePipelineProvider
       queryParams={{ accountIdentifier: accountId, orgIdentifier, projectIdentifier }}
-      initialValue={pipeline}
+      initialValue={Template}
       gitDetails={gitDetails}
       storeMetadata={storeMetadata}
       onUpdatePipeline={onUpdatePipeline}

--- a/src/modules/72-templates-library/components/TemplateStudio/StageTemplateCanvas/StageTemplateCanvasWrapper.tsx
+++ b/src/modules/72-templates-library/components/TemplateStudio/StageTemplateCanvas/StageTemplateCanvasWrapper.tsx
@@ -22,8 +22,7 @@ import type { ProjectPathProps } from '@common/interfaces/RouteInterfaces'
 import { sanitize } from '@common/utils/JSONUtils'
 import { PipelineContextType } from '@pipeline/components/PipelineStudio/PipelineContext/PipelineContext'
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-const StageTemplateCanvasWrapper = () => {
+const StageTemplateCanvasWrapper = (): JSX.Element => {
   const {
     state: { template, isLoading, isUpdated, gitDetails, storeMetadata },
     updateTemplate,
@@ -55,7 +54,6 @@ const StageTemplateCanvasWrapper = () => {
     }
   }, [createPipelineFromTemplate, isLoading, isUpdated])
 
-  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   const onUpdatePipeline = async (pipelineConfig: PipelineInfoConfig) => {
     const stage = get(pipelineConfig, 'stages[0].stage')
 

--- a/src/modules/72-templates-library/components/TemplateStudio/StageTemplateCanvas/StageTemplateCanvasWrapper.tsx
+++ b/src/modules/72-templates-library/components/TemplateStudio/StageTemplateCanvas/StageTemplateCanvasWrapper.tsx
@@ -31,28 +31,32 @@ const StageTemplateCanvasWrapper = () => {
   } = React.useContext(TemplateContext)
   const { accountId, projectIdentifier, orgIdentifier } = useParams<ProjectPathProps>()
 
-  const createPipelineFromTemplate = () =>
-    produce({ ...DefaultPipeline }, draft => {
-      set(
-        draft,
-        'stages[0].stage',
-        merge({}, template.spec as StageElementConfig, {
-          name: DefaultNewStageName,
-          identifier: DefaultNewStageId
-        })
-      )
-    })
+  const createPipelineFromTemplate = React.useCallback(
+    () =>
+      produce({ ...DefaultPipeline }, draft => {
+        set(
+          draft,
+          'stages[0].stage',
+          merge({}, template.spec as StageElementConfig, {
+            name: DefaultNewStageName,
+            identifier: DefaultNewStageId
+          })
+        )
+      }),
+    [template.spec]
+  )
 
   const [pipeline, setPipeline] = React.useState<PipelineInfoConfig>(createPipelineFromTemplate())
 
   React.useEffect(() => {
-    if (!isLoading && !isUpdated) {
+    if (!isLoading && isUpdated) {
       setPipeline(createPipelineFromTemplate())
     }
-  }, [isLoading, isUpdated])
+  }, [createPipelineFromTemplate, isLoading, isUpdated])
 
   const onUpdatePipeline = async (pipelineConfig: PipelineInfoConfig) => {
     const stage = get(pipelineConfig, 'stages[0].stage')
+
     const processNode = omit(stage, 'name', 'identifier', 'description', 'tags')
     sanitize(processNode, { removeEmptyArray: false, removeEmptyObject: false, removeEmptyString: false })
     set(template, 'spec', processNode)

--- a/src/modules/72-templates-library/components/TemplateStudio/StageTemplateCanvas/StageTemplateCanvasWrapper.tsx
+++ b/src/modules/72-templates-library/components/TemplateStudio/StageTemplateCanvas/StageTemplateCanvasWrapper.tsx
@@ -46,11 +46,11 @@ const StageTemplateCanvasWrapper = () => {
     [template.spec]
   )
 
-  const [pipeline, setPipeline] = React.useState<PipelineInfoConfig>(createPipelineFromTemplate())
+  const [Template, setTemplate] = React.useState<PipelineInfoConfig>(createPipelineFromTemplate())
 
   React.useEffect(() => {
     if (!isLoading && isUpdated) {
-      setPipeline(createPipelineFromTemplate())
+      setTemplate(createPipelineFromTemplate())
     }
   }, [createPipelineFromTemplate, isLoading, isUpdated])
 
@@ -66,7 +66,7 @@ const StageTemplateCanvasWrapper = () => {
   return (
     <TemplatePipelineProvider
       queryParams={{ accountIdentifier: accountId, orgIdentifier, projectIdentifier }}
-      initialValue={pipeline}
+      initialValue={Template}
       gitDetails={gitDetails}
       storeMetadata={storeMetadata}
       onUpdatePipeline={onUpdatePipeline}

--- a/src/modules/72-templates-library/components/TemplateStudio/StageTemplateCanvas/StageTemplateCanvasWrapper.tsx
+++ b/src/modules/72-templates-library/components/TemplateStudio/StageTemplateCanvas/StageTemplateCanvasWrapper.tsx
@@ -22,6 +22,7 @@ import type { ProjectPathProps } from '@common/interfaces/RouteInterfaces'
 import { sanitize } from '@common/utils/JSONUtils'
 import { PipelineContextType } from '@pipeline/components/PipelineStudio/PipelineContext/PipelineContext'
 
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const StageTemplateCanvasWrapper = () => {
   const {
     state: { template, isLoading, isUpdated, gitDetails, storeMetadata },
@@ -46,14 +47,15 @@ const StageTemplateCanvasWrapper = () => {
     [template.spec]
   )
 
-  const [Template, setTemplate] = React.useState<PipelineInfoConfig>(createPipelineFromTemplate())
+  const [pipeline, setPipeline] = React.useState<PipelineInfoConfig>(createPipelineFromTemplate())
 
   React.useEffect(() => {
     if (!isLoading && isUpdated) {
-      setTemplate(createPipelineFromTemplate())
+      setPipeline(createPipelineFromTemplate())
     }
   }, [createPipelineFromTemplate, isLoading, isUpdated])
 
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   const onUpdatePipeline = async (pipelineConfig: PipelineInfoConfig) => {
     const stage = get(pipelineConfig, 'stages[0].stage')
 
@@ -66,7 +68,7 @@ const StageTemplateCanvasWrapper = () => {
   return (
     <TemplatePipelineProvider
       queryParams={{ accountIdentifier: accountId, orgIdentifier, projectIdentifier }}
-      initialValue={Template}
+      initialValue={pipeline}
       gitDetails={gitDetails}
       storeMetadata={storeMetadata}
       onUpdatePipeline={onUpdatePipeline}


### PR DESCRIPTION


### Summary

For pipeline and stage Template, when we add any number of steps, and if we try to edit the template and press continue, the steps that we created will cleaned up. This is fixed.

<!-- ✍️ A clear and concise description...-->

#### Screenshots

NA
<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
