### PR TITLE
feat: [SPG-275]: add Chaos stage to PipelineStudio

### DIFF
--- a/src/modules/70-pipeline/strings/strings.en.yaml
+++ b/src/modules/70-pipeline/strings/strings.en.yaml
@@ -773,6 +773,7 @@ pipelineSteps:
   deployStageDescription: Deploy services, Serverless functions, or other workloads.
   featureStageDescription: Enable or disable functionality remotely without redeploying code.
   approvalStageDescription: Approve or reject changes during Pipeline progress.
+  chaosStageDescription: Use Chaos Engineering to inject fault into your system to test resilience.
 aboutYourStage:
   stageNamePlaceholder: Enter Stage Name
 infraSpecifications:

--- a/src/modules/70-pipeline/utils/stageHelpers.ts
+++ b/src/modules/70-pipeline/utils/stageHelpers.ts
@@ -42,7 +42,8 @@ export enum StageType {
   SECURITY = 'SecurityTests',
   MATRIX = 'MATRIX',
   LOOP = 'LOOP',
-  PARALLELISM = 'PARALLELISM'
+  PARALLELISM = 'PARALLELISM',
+  CHAOS = 'CHAOS'
 }
 
 export enum ServiceDeploymentType {

--- a/src/modules/75-chaos/RouteDestinations.tsx
+++ b/src/modules/75-chaos/RouteDestinations.tsx
@@ -71,6 +71,7 @@ import useCreateConnectorModal from '@connectors/modals/ConnectorModal/useCreate
 import ChaosHomePage from './pages/home/ChaosHomePage'
 import type { ChaosCustomMicroFrontendProps } from './interfaces/Chaos.types'
 import ChaosSideNav from './components/ChaosSideNav/ChaosSideNav'
+import { registerChaosPipelineStage } from './components/ChaosStage'
 
 // eslint-disable-next-line import/no-unresolved
 const ChaosMicroFrontend = React.lazy(() => import('chaos/MicroFrontendApp'))
@@ -181,6 +182,9 @@ export default function ChaosRoutes(): React.ReactElement {
 
   // Register Chaos into RBAC Factory and AuditTrail only when Feature Flag is enabled
   if (isChaosEnabled) {
+    // Pipeline Stage registration
+    registerChaosPipelineStage()
+
     // RBAC registrations
     RbacFactory.registerResourceCategory(ResourceCategory.CHAOS, {
       icon: 'chaos-main',

--- a/src/modules/75-chaos/components/ChaosStage/AddEditStageView.module.scss
+++ b/src/modules/75-chaos/components/ChaosStage/AddEditStageView.module.scss
@@ -1,0 +1,16 @@
+.addEditStageView {
+}
+
+.addExperimentDrawer {
+  .close-button {
+    position: absolute;
+    top: 0;
+    left: -43px;
+    box-shadow: none !important;
+    opacity: 0.8;
+
+    &:hover {
+      opacity: 1;
+    }
+  }
+}

--- a/src/modules/75-chaos/components/ChaosStage/AddEditStageView.module.scss.d.ts
+++ b/src/modules/75-chaos/components/ChaosStage/AddEditStageView.module.scss.d.ts
@@ -1,0 +1,13 @@
+/* eslint-disable */
+/**
+ * Copyright 2021 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ **/
+// this is an auto-generated file, do not update this manually
+declare const styles: {
+  readonly addExperimentDrawer: string
+  readonly closeButton: string
+}
+export default styles

--- a/src/modules/75-chaos/components/ChaosStage/AddEditStageView.tsx
+++ b/src/modules/75-chaos/components/ChaosStage/AddEditStageView.tsx
@@ -1,0 +1,152 @@
+import React, { ReactElement } from 'react'
+import * as Yup from 'yup'
+import { Button, Color, Container, Formik, FormikForm, Icon, Text, useToggleOpen } from '@harness/uicore'
+import type { FormikConfig, FormikErrors } from 'formik'
+import { Drawer } from '@blueprintjs/core'
+import type { StageElementWrapper } from '@pipeline/utils/pipelineTypes'
+import { useStrings } from 'framework/strings'
+import { NameIdDescription } from '@common/components/NameIdDescriptionTags/NameIdDescriptionTags'
+import {
+  PipelineContextType,
+  usePipelineContext
+} from '@pipeline/components/PipelineStudio/PipelineContext/PipelineContext'
+import type { TemplateSummaryResponse } from 'services/template-ng'
+import { createTemplate, getTemplateNameWithLabel } from '@pipeline/utils/templateUtils'
+import { illegalIdentifiers, regexIdentifier } from '@common/utils/StringUtils'
+import { isDuplicateStageId } from '@pipeline/components/PipelineStudio/StageBuilder/StageBuilderUtil'
+import css from './AddEditStageView.module.scss'
+
+interface Values {
+  identifier: string
+  name: string
+  description?: string
+}
+
+interface AddEditStageViewProps {
+  data?: StageElementWrapper
+  template?: TemplateSummaryResponse
+  onSubmit?: (values: StageElementWrapper, identifier: string) => void
+  onChange?: (values: Values) => void
+}
+
+const AddEditStageView = (props: AddEditStageViewProps): ReactElement => {
+  const { data, template, onSubmit, onChange } = props
+  const { getString } = useStrings()
+  const {
+    state: { pipeline },
+    contextType
+  } = usePipelineContext()
+  const {
+    isOpen: isExperimentDrawerOpen,
+    open: openExperimentDrawer,
+    close: closeExperimentDrawer
+  } = useToggleOpen(false)
+
+  const isTemplate = contextType === PipelineContextType.StageTemplate
+
+  const initialValues: Values = {
+    identifier: data?.stage?.identifier || '',
+    name: data?.stage?.name || '',
+    description: data?.stage?.description
+  }
+
+  const validationSchema = () =>
+    Yup.lazy((_values: Values): any =>
+      Yup.object().shape({
+        name: Yup.string()
+          .trim()
+          .required(getString('fieldRequired', { field: getString('stageNameLabel') })),
+        identifier: Yup.string().when('name', {
+          is: val => val?.length,
+          then: Yup.string()
+            .required(getString('validation.identifierRequired'))
+            .matches(regexIdentifier, getString('validation.validIdRegex'))
+            .notOneOf(illegalIdentifiers)
+        })
+      })
+    )
+
+  const handleValidate = (values: Values): FormikErrors<Values> => {
+    const errors: { name?: string } = {}
+    if (isDuplicateStageId(values.identifier, pipeline?.stages || [])) {
+      errors.name = getString('validation.identifierDuplicate')
+    }
+    if (data) {
+      onChange?.(values)
+    }
+    return errors
+  }
+
+  const handleSubmit = (values: Values): void => {
+    if (data?.stage) {
+      if (template) {
+        onSubmit?.({ stage: createTemplate(values, template) }, values.identifier)
+      } else {
+        data.stage.identifier = values.identifier
+        data.stage.name = values.name
+        if (values.description) data.stage.description = values.description
+        if (!data.stage.spec) data.stage.spec = {}
+
+        onSubmit?.(data, values.identifier)
+      }
+    }
+  }
+
+  const validation: Partial<FormikConfig<Values>> = {}
+
+  if (!isTemplate) {
+    validation.validate = handleValidate
+    validation.validationSchema = validationSchema
+  }
+
+  return (
+    <Container padding="medium" width={430} className={css.addEditStageView}>
+      <Formik
+        enableReinitialize
+        formName="chaosAddStage"
+        initialValues={initialValues}
+        onSubmit={openExperimentDrawer}
+        {...validation}
+      >
+        {formikProps => (
+          <FormikForm>
+            <Text font={{ weight: 'bold' }} icon="chaos-main" iconProps={{ size: 16 }} margin={{ bottom: 'medium' }}>
+              {getString('pipelineSteps.build.create.aboutYourStage')}
+            </Text>
+            {!isTemplate && (
+              <NameIdDescription
+                formikProps={formikProps}
+                identifierProps={{
+                  inputLabel: getString('stageNameLabel')
+                }}
+              />
+            )}
+            {template && (
+              <Text
+                icon={'template-library'}
+                margin={{ top: 'medium', bottom: 'medium' }}
+                font={{ size: 'small' }}
+                iconProps={{ size: 12, margin: { right: 'xsmall' } }}
+                color={Color.BLACK}
+              >
+                {`Using Template: ${getTemplateNameWithLabel(template)}`}
+              </Text>
+            )}
+            <Button
+              type="submit"
+              intent="primary"
+              text={getString('pipelineSteps.build.create.setupStage')}
+              margin={{ top: 'small' }}
+            />
+          </FormikForm>
+        )}
+      </Formik>
+      <Drawer isOpen={isExperimentDrawerOpen} className={css.addExperimentDrawer}>
+        <Button intent="primary" icon="cross" onClick={closeExperimentDrawer} className={css.closeButton} />
+        Placeholder for drawer content from Chaos Microfrontend
+      </Drawer>
+    </Container>
+  )
+}
+
+export default AddEditStageView

--- a/src/modules/75-chaos/components/ChaosStage/ChaosStage.tsx
+++ b/src/modules/75-chaos/components/ChaosStage/ChaosStage.tsx
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2021 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import React from 'react'
+import { PipelineStage } from '@pipeline/components/PipelineStages/PipelineStage'
+import AddEditStageView from './AddEditStageView'
+
+export default class ChaosStage extends PipelineStage {
+  render(): JSX.Element {
+    const { minimal, stageProps } = this.props
+    if (minimal) {
+      return <AddEditStageView {...stageProps} />
+    }
+    return <div>hello world</div>
+  }
+}

--- a/src/modules/75-chaos/components/ChaosStage/index.tsx
+++ b/src/modules/75-chaos/components/ChaosStage/index.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import React, { ReactElement } from 'react'
+import type { UseStringsReturn } from 'framework/strings'
+import { StageType } from '@pipeline/utils/stageHelpers'
+import { stagesCollection } from '@pipeline/components/PipelineStudio/Stages/StagesCollection'
+import type { StageAttributes } from '@pipeline/components/PipelineStudio/PipelineContext/PipelineContext'
+import ChaosStage from './ChaosStage'
+
+/* istanbul ignore next */
+const getStageAttributes = (getString: UseStringsReturn['getString']): StageAttributes => ({
+  name: getString('common.chaosText'),
+  type: StageType.CHAOS,
+  icon: 'chaos-main',
+  iconColor: 'var(--pipeline-build-stage-color)',
+  isApproval: false,
+  openExecutionStrategy: false
+})
+
+/* istanbul ignore next */
+const getStageEditorImplementation = (isEnabled: boolean, getString: UseStringsReturn['getString']): ReactElement => (
+  <ChaosStage
+    icon={'chaos-main'}
+    hoverIcon={'chaos-main'}
+    // iconsStyle={{ color: 'var(--pipeline-chaos-stage-color)' }}
+    name={getString('common.chaosText')}
+    type={StageType.CHAOS}
+    title={getString('common.chaosText')}
+    description={getString('pipeline.pipelineSteps.chaosStageDescription')}
+    isDisabled={false}
+    isHidden={!isEnabled}
+    isApproval={false}
+  />
+)
+
+export function registerChaosPipelineStage(): void {
+  stagesCollection.registerStageFactory(StageType.FEATURE, getStageAttributes, getStageEditorImplementation)
+}

--- a/src/stringTypes.ts
+++ b/src/stringTypes.ts
@@ -3681,6 +3681,7 @@ export interface StringsMap {
   'pipeline.pipelineSteps.approvalStageDescription': string
   'pipeline.pipelineSteps.chainedPipeline': string
   'pipeline.pipelineSteps.chainedPipelineDescription': string
+  'pipeline.pipelineSteps.chaosStageDescription': string
   'pipeline.pipelineSteps.customStage': string
   'pipeline.pipelineSteps.customStageDescription': string
   'pipeline.pipelineSteps.deployStageDescription': string


### PR DESCRIPTION
### Summary

Adds a new Chaos stage to the Pipeline Studio

#### Screenshots

![Screenshot 2022-09-22 at 12 41 30 PM](https://user-images.githubusercontent.com/47316575/191685571-5c2a1ae2-3421-4c13-b7f3-8d8931e20ecd.png)
![Screenshot 2022-09-22 at 12 41 45 PM](https://user-images.githubusercontent.com/47316575/191685590-81473972-9117-4878-9c4c-0e3d2b1b393f.png)
![Screenshot 2022-09-22 at 12 41 54 PM](https://user-images.githubusercontent.com/47316575/191685594-70b03976-dccf-4089-8f7e-1de443ec4a0f.png)

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
