### PR TITLE
fix: [CDS-42730]: Filtering support added for linked templates

### DIFF
--- a/src/modules/70-pipeline/components/PipelineStudio/PipelineContext/PipelineActions.ts
+++ b/src/modules/70-pipeline/components/PipelineStudio/PipelineContext/PipelineActions.ts
@@ -36,7 +36,7 @@ export enum PipelineActions {
   SetYamlHandler = 'SetYamlHandler',
   SetTemplateTypes = 'SetTemplateTypes',
   SetTemplateServiceData = 'SetTemplateServiceData',
-  SetLinkedTemplatesByCustomDeploymentRef = 'SetLinkedTemplatesByCustomDeploymentRef',
+  SetResolvedCustomDeploymentDetailsByRef = 'SetResolvedCustomDeploymentDetailsByRef',
   PipelineSaved = 'PipelineSaved',
   UpdateSchemaErrorsFlag = 'UpdateSchemaErrorsFlag',
   Success = 'Success',
@@ -134,7 +134,7 @@ export interface PipelineReducerState {
   schemaErrors: boolean
   templateTypes: { [key: string]: string }
   templateServiceData: TemplateServiceDataType
-  linkedTemplatesByCustomDeploymentRef: { [key: string]: string[] }
+  resolvedCustomDeploymentDetailsByRef: { [key: string]: Record<string, string | string[]> }
   storeMetadata?: StoreMetadata
   gitDetails: EntityGitDetails
   entityValidityDetails: EntityValidityDetails
@@ -167,7 +167,7 @@ export interface ActionResponse {
   yamlHandler?: YamlBuilderHandlerBinding
   templateTypes?: { [key: string]: string }
   templateServiceData?: TemplateServiceDataType
-  linkedTemplatesByCustomDeploymentRef?: { [key: string]: string[] }
+  resolvedCustomDeploymentDetailsByRef?: { [key: string]: Record<string, string | string[]> }
   originalPipeline?: PipelineInfoConfig
   isBEPipelineUpdated?: boolean
   pipelineView?: PipelineViewData
@@ -204,8 +204,8 @@ const setTemplateServiceData = (response: ActionResponse): ActionReturnType => (
   type: PipelineActions.SetTemplateServiceData,
   response
 })
-const setLinkedTemplatesByCustomDeploymentRef = (response: ActionResponse): ActionReturnType => ({
-  type: PipelineActions.SetLinkedTemplatesByCustomDeploymentRef,
+const setResolvedCustomDeploymentDetailsByRef = (response: ActionResponse): ActionReturnType => ({
+  type: PipelineActions.SetResolvedCustomDeploymentDetailsByRef,
   response
 })
 const updating = (): ActionReturnType => ({ type: PipelineActions.UpdatePipeline })
@@ -236,7 +236,7 @@ export const PipelineContextActions = {
   setYamlHandler,
   setTemplateTypes,
   setTemplateServiceData,
-  setLinkedTemplatesByCustomDeploymentRef,
+  setResolvedCustomDeploymentDetailsByRef,
   success,
   error,
   updateSchemaErrorsFlag,
@@ -262,7 +262,7 @@ export const initialState: PipelineReducerState = {
   entityValidityDetails: {},
   templateTypes: {},
   templateServiceData: {},
-  linkedTemplatesByCustomDeploymentRef: {},
+  resolvedCustomDeploymentDetailsByRef: {},
   isLoading: false,
   isBEPipelineUpdated: false,
   isDBInitialized: false,
@@ -308,10 +308,10 @@ export const PipelineReducer = (state = initialState, data: ActionReturnType): P
         ...state,
         templateServiceData: data.response?.templateServiceData || {}
       }
-    case PipelineActions.SetLinkedTemplatesByCustomDeploymentRef:
+    case PipelineActions.SetResolvedCustomDeploymentDetailsByRef:
       return {
         ...state,
-        linkedTemplatesByCustomDeploymentRef: data.response?.linkedTemplatesByCustomDeploymentRef || {}
+        resolvedCustomDeploymentDetailsByRef: data.response?.resolvedCustomDeploymentDetailsByRef || {}
       }
     case PipelineActions.UpdatePipelineView:
       return {

--- a/src/modules/70-pipeline/components/PipelineStudio/PipelineContext/PipelineActions.ts
+++ b/src/modules/70-pipeline/components/PipelineStudio/PipelineContext/PipelineActions.ts
@@ -36,6 +36,7 @@ export enum PipelineActions {
   SetYamlHandler = 'SetYamlHandler',
   SetTemplateTypes = 'SetTemplateTypes',
   SetTemplateServiceData = 'SetTemplateServiceData',
+  SetLinkedTemplatesByCustomDeploymentRef = 'SetLinkedTemplatesByCustomDeploymentRef',
   PipelineSaved = 'PipelineSaved',
   UpdateSchemaErrorsFlag = 'UpdateSchemaErrorsFlag',
   Success = 'Success',
@@ -133,6 +134,7 @@ export interface PipelineReducerState {
   schemaErrors: boolean
   templateTypes: { [key: string]: string }
   templateServiceData: TemplateServiceDataType
+  linkedTemplatesByCustomDeploymentRef: { [key: string]: string[] }
   storeMetadata?: StoreMetadata
   gitDetails: EntityGitDetails
   entityValidityDetails: EntityValidityDetails
@@ -165,6 +167,7 @@ export interface ActionResponse {
   yamlHandler?: YamlBuilderHandlerBinding
   templateTypes?: { [key: string]: string }
   templateServiceData?: TemplateServiceDataType
+  linkedTemplatesByCustomDeploymentRef?: { [key: string]: string[] }
   originalPipeline?: PipelineInfoConfig
   isBEPipelineUpdated?: boolean
   pipelineView?: PipelineViewData
@@ -201,6 +204,10 @@ const setTemplateServiceData = (response: ActionResponse): ActionReturnType => (
   type: PipelineActions.SetTemplateServiceData,
   response
 })
+const setLinkedTemplatesByCustomDeploymentRef = (response: ActionResponse): ActionReturnType => ({
+  type: PipelineActions.SetLinkedTemplatesByCustomDeploymentRef,
+  response
+})
 const updating = (): ActionReturnType => ({ type: PipelineActions.UpdatePipeline })
 const fetching = (): ActionReturnType => ({ type: PipelineActions.Fetching })
 const pipelineSavedAction = (response: ActionResponse): ActionReturnType => ({
@@ -229,6 +236,7 @@ export const PipelineContextActions = {
   setYamlHandler,
   setTemplateTypes,
   setTemplateServiceData,
+  setLinkedTemplatesByCustomDeploymentRef,
   success,
   error,
   updateSchemaErrorsFlag,
@@ -254,6 +262,7 @@ export const initialState: PipelineReducerState = {
   entityValidityDetails: {},
   templateTypes: {},
   templateServiceData: {},
+  linkedTemplatesByCustomDeploymentRef: {},
   isLoading: false,
   isBEPipelineUpdated: false,
   isDBInitialized: false,
@@ -298,6 +307,11 @@ export const PipelineReducer = (state = initialState, data: ActionReturnType): P
       return {
         ...state,
         templateServiceData: data.response?.templateServiceData || {}
+      }
+    case PipelineActions.SetLinkedTemplatesByCustomDeploymentRef:
+      return {
+        ...state,
+        linkedTemplatesByCustomDeploymentRef: data.response?.linkedTemplatesByCustomDeploymentRef || {}
       }
     case PipelineActions.UpdatePipelineView:
       return {

--- a/src/modules/70-pipeline/components/PipelineStudio/PipelineContext/PipelineContext.tsx
+++ b/src/modules/70-pipeline/components/PipelineStudio/PipelineContext/PipelineContext.tsx
@@ -53,7 +53,7 @@ import type { PipelineStageWrapper } from '@pipeline/utils/pipelineTypes'
 import { getScopeFromDTO } from '@common/components/EntityReference/EntityReference'
 import { Scope } from '@common/interfaces/SecretsInterface'
 import {
-  getLinkedStepTemplatesByRef,
+  getResolvedCustomDeploymentDetailsByRef,
   getTemplateTypesByRef,
   TemplateServiceDataType
 } from '@pipeline/utils/templateUtils'
@@ -331,9 +331,9 @@ export const findAllByKey = (keyToFind: string, obj?: PipelineInfoConfig): strin
     : []
 }
 
-const getLinkedTemplatesMap = (pipeline: PipelineInfoConfig, queryParams: GetPipelineQueryParams) => {
+const getResolvedCustomDeploymentDetailsMap = (pipeline: PipelineInfoConfig, queryParams: GetPipelineQueryParams) => {
   const templateRefs = map(findAllByKey('customDeploymentRef', pipeline), 'templateRef')
-  return getLinkedStepTemplatesByRef(
+  return getResolvedCustomDeploymentDetailsByRef(
     {
       accountIdentifier: queryParams.accountIdentifier,
       orgIdentifier: queryParams.orgIdentifier,
@@ -469,9 +469,9 @@ const _fetchPipeline = async (props: FetchPipelineBoundProps, params: FetchPipel
         ? await getTemplateType(data.pipeline, templateQueryParams)
         : { templateTypes: {}, templateServiceData: {} }
 
-      const { linkedTemplatesByCustomDeploymentRef } = data.pipeline
-        ? await getLinkedTemplatesMap(data.pipeline, templateQueryParams)
-        : { linkedTemplatesByCustomDeploymentRef: {} }
+      const { resolvedCustomDeploymentDetailsByRef } = data.pipeline
+        ? await getResolvedCustomDeploymentDetailsMap(data.pipeline, templateQueryParams)
+        : { resolvedCustomDeploymentDetailsByRef: {} }
 
       dispatch(
         PipelineContextActions.success({
@@ -486,7 +486,7 @@ const _fetchPipeline = async (props: FetchPipelineBoundProps, params: FetchPipel
               : defaultTo(data?.gitDetails, {}),
           templateTypes,
           templateServiceData,
-          linkedTemplatesByCustomDeploymentRef,
+          resolvedCustomDeploymentDetailsByRef,
           entityValidityDetails: defaultTo(
             pipelineWithGitDetails?.entityValidityDetails,
             defaultTo(data?.entityValidityDetails, {})
@@ -506,7 +506,10 @@ const _fetchPipeline = async (props: FetchPipelineBoundProps, params: FetchPipel
         logger.info(DBNotFoundErrorMessage)
       }
       const { templateTypes, templateServiceData } = await getTemplateType(pipeline, templateQueryParams)
-      const { linkedTemplatesByCustomDeploymentRef } = await getLinkedTemplatesMap(pipeline, templateQueryParams)
+      const { resolvedCustomDeploymentDetailsByRef } = await getResolvedCustomDeploymentDetailsMap(
+        pipeline,
+        templateQueryParams
+      )
       dispatch(
         PipelineContextActions.success({
           error: '',
@@ -518,7 +521,7 @@ const _fetchPipeline = async (props: FetchPipelineBoundProps, params: FetchPipel
           entityValidityDetails: payload.entityValidityDetails,
           templateTypes,
           templateServiceData,
-          linkedTemplatesByCustomDeploymentRef,
+          resolvedCustomDeploymentDetailsByRef,
           templateInputsErrorNodeSummary,
           yamlSchemaErrorWrapper: payload?.yamlSchemaErrorWrapper
         })
@@ -1097,9 +1100,9 @@ export function PipelineProvider({
     const unresolvedCustomDeploymentRefs = map(
       findAllByKey('customDeploymentRef', state.pipeline),
       'templateRef'
-    )?.filter(customDeploymentRef => isEmpty(get(state.linkedTemplatesByCustomDeploymentRef, customDeploymentRef)))
+    )?.filter(customDeploymentRef => isEmpty(get(state.resolvedCustomDeploymentDetailsByRef, customDeploymentRef)))
 
-    getLinkedStepTemplatesByRef(
+    getResolvedCustomDeploymentDetailsByRef(
       {
         ...queryParams,
         templateListType: 'Stable',
@@ -1108,9 +1111,9 @@ export function PipelineProvider({
         getDefaultFromOtherRepo: true
       },
       unresolvedCustomDeploymentRefs
-    ).then(({ linkedTemplatesByCustomDeploymentRef }) => {
-      setLinkedTemplatesByCustomDeploymentRef(
-        merge(state.linkedTemplatesByCustomDeploymentRef, linkedTemplatesByCustomDeploymentRef)
+    ).then(({ resolvedCustomDeploymentDetailsByRef }) => {
+      setResolvedCustomDeploymentDetailsByRef(
+        merge(state.resolvedCustomDeploymentDetailsByRef, resolvedCustomDeploymentDetailsByRef)
       )
     })
   }, [state.pipeline])
@@ -1143,8 +1146,8 @@ export function PipelineProvider({
     dispatch(PipelineContextActions.setTemplateServiceData({ templateServiceData }))
   }, [])
 
-  const setLinkedTemplatesByCustomDeploymentRef = React.useCallback(linkedTemplatesByCustomDeploymentRef => {
-    dispatch(PipelineContextActions.setLinkedTemplatesByCustomDeploymentRef({ linkedTemplatesByCustomDeploymentRef }))
+  const setResolvedCustomDeploymentDetailsByRef = React.useCallback(resolvedCustomDeploymentDetailsByRef => {
+    dispatch(PipelineContextActions.setResolvedCustomDeploymentDetailsByRef({ resolvedCustomDeploymentDetailsByRef }))
   }, [])
 
   const setSchemaErrorView = React.useCallback(flag => {

--- a/src/modules/70-pipeline/strings/strings.en.yaml
+++ b/src/modules/70-pipeline/strings/strings.en.yaml
@@ -1374,6 +1374,7 @@ skipInstances:
 selectiveStageExecution: 'Selective stage execution'
 customDeployment:
   infraVariablesTitle: 'Define the variables to be used in your environment and infrastructure.'
+  seeOnlyTemplatesFor: See only templates for {{name}}
   hostObjectArrayPath: 'Host Object Array Path'
   hostAttributes: 'Host Attributes'
   newAttribute: 'New Attribute'

--- a/src/modules/70-pipeline/utils/stageHelpers.ts
+++ b/src/modules/70-pipeline/utils/stageHelpers.ts
@@ -15,7 +15,7 @@ import type {
   StageElementConfig,
   StageElementWrapperConfig
 } from 'services/pipeline-ng'
-import type { StringKeys } from 'framework/strings'
+import type { StringKeys, UseStringsReturn } from 'framework/strings'
 import type {
   GetExecutionStrategyYamlQueryParams,
   Infrastructure,
@@ -627,4 +627,26 @@ export const isSshOrWinrmDeploymentType = (deploymentType: string): boolean => {
 
 export const withoutSideCar = (deploymentType: string): boolean => {
   return isSshOrWinrmDeploymentType(deploymentType)
+}
+
+interface Params {
+  getString: UseStringsReturn['getString']
+  resolvedCustomDeploymentDetails?: { [key: string]: string | string[] }
+}
+
+export const getLinkedTemplateFromResolvedCustomDeploymentDetails = (params: Params) => {
+  const { resolvedCustomDeploymentDetails, getString } = params
+  const customDeploymentTemplateName = get(resolvedCustomDeploymentDetails, 'name', '') as string
+  const linkedTemplateRefs = get(resolvedCustomDeploymentDetails, 'linkedTemplateRefs', [])
+
+  return !isEmpty(linkedTemplateRefs)
+    ? {
+        linkedTemplate: {
+          identifiers: linkedTemplateRefs as string[],
+          checkboxLabel:
+            customDeploymentTemplateName &&
+            getString('pipeline.customDeployment.seeOnlyTemplatesFor', { name: customDeploymentTemplateName })
+        }
+      }
+    : {}
 }

--- a/src/modules/70-pipeline/utils/templateUtils.ts
+++ b/src/modules/70-pipeline/utils/templateUtils.ts
@@ -150,31 +150,31 @@ const getPromisesForTemplateList = (params: GetTemplateListQueryParams, template
   return promises
 }
 
-export const getLinkedStepTemplatesByRef = (
+export const getResolvedCustomDeploymentDetailsByRef = (
   params: GetTemplateListQueryParams,
   templateRefs: string[]
-): Promise<{ linkedTemplatesByCustomDeploymentRef: { [key: string]: string[] } }> => {
+): Promise<{ resolvedCustomDeploymentDetailsByRef: { [key: string]: Record<string, string | string[]> } }> => {
   const promises = getPromisesForTemplateList(params, templateRefs)
   return Promise.all(promises)
     .then(responses => {
-      const linkedTemplatesByCustomDeploymentRef = {}
+      const resolvedCustomDeploymentDetailsByRef = {}
       responses.forEach(response => {
         response.data?.content?.forEach(item => {
           const templateData = parse<any>(item.yaml || '').template
           const scopeBasedTemplateRef = getScopeBasedTemplateRef(item)
-          set(
-            linkedTemplatesByCustomDeploymentRef,
-            scopeBasedTemplateRef,
-            map(templateData?.spec?.execution?.stepTemplateRefs, (stepTemplateRefObj: TemplateLinkConfig) =>
-              getIdentifierFromValue(stepTemplateRefObj.templateRef)
+          set(resolvedCustomDeploymentDetailsByRef, scopeBasedTemplateRef, {
+            name: item.name,
+            linkedTemplateRefs: map(
+              templateData?.spec?.execution?.stepTemplateRefs,
+              (stepTemplateRefObj: TemplateLinkConfig) => getIdentifierFromValue(stepTemplateRefObj.templateRef)
             )
-          )
+          })
         })
       })
-      return { linkedTemplatesByCustomDeploymentRef }
+      return { resolvedCustomDeploymentDetailsByRef }
     })
     .catch(_ => {
-      return { linkedTemplatesByCustomDeploymentRef: {} }
+      return { resolvedCustomDeploymentDetailsByRef: {} }
     })
 }
 

--- a/src/modules/72-templates-library/components/TemplateSelector/TemplateSelectorLeftView/TemplateSelectorLeftView.module.scss
+++ b/src/modules/72-templates-library/components/TemplateSelector/TemplateSelectorLeftView/TemplateSelectorLeftView.module.scss
@@ -24,6 +24,10 @@
       background: var(--primary-1);
       padding: 6px var(--spacing-3) !important;
       border-radius: var(--spacing-2);
+
+      .linkedTemplateCheckboxLabel {
+        max-width: 280px !important;
+      }
     }
     .templatesContainer {
       flex-grow: 1;

--- a/src/modules/72-templates-library/components/TemplateSelector/TemplateSelectorLeftView/TemplateSelectorLeftView.module.scss.d.ts
+++ b/src/modules/72-templates-library/components/TemplateSelector/TemplateSelectorLeftView/TemplateSelectorLeftView.module.scss.d.ts
@@ -9,6 +9,7 @@
 declare const styles: {
   readonly container: string
   readonly linkedTemplateCheckbox: string
+  readonly linkedTemplateCheckboxLabel: string
   readonly mainContainer: string
   readonly searchBox: string
   readonly templatesContainer: string

--- a/src/modules/72-templates-library/components/TemplateSelector/TemplateSelectorLeftView/TemplateSelectorLeftView.tsx
+++ b/src/modules/72-templates-library/components/TemplateSelector/TemplateSelectorLeftView/TemplateSelectorLeftView.tsx
@@ -258,7 +258,11 @@ export const TemplateSelectorLeftView: React.FC<TemplateSelectorLeftViewProps> =
                     {!isEmpty(identifiers) && (
                       <Checkbox
                         checked={!isEmpty(selectedTemplateRefs)}
-                        label={checkboxLabel}
+                        labelElement={
+                          <Text lineClamp={1} font={{ size: 'small' }} className={css.linkedTemplateCheckboxLabel}>
+                            {checkboxLabel}
+                          </Text>
+                        }
                         onChange={onLinkedTemplateChange}
                         className={css.linkedTemplateCheckbox}
                       />

--- a/src/modules/72-templates-library/components/TemplateSelector/TemplateSelectorLeftView/__tests__/__snapshots__/TemplateSelectorLeftView.test.tsx.snap
+++ b/src/modules/72-templates-library/components/TemplateSelector/TemplateSelectorLeftView/__tests__/__snapshots__/TemplateSelectorLeftView.test.tsx.snap
@@ -177,7 +177,12 @@ exports[`<TemplateSelectorLeftView> tests should match snapshot 1`] = `
                     <span
                       class="bp3-control-indicator"
                     />
-                    templatesLibrary.seeLinkedTemplate
+                    <p
+                      class="StyledProps--font Text--lineclamp StyledProps--main linkedTemplateCheckboxLabel StyledProps--font-size-small"
+                      style="--text-line-clamp: 1;"
+                    >
+                      templatesLibrary.seeLinkedTemplate
+                    </p>
                   </label>
                   <div
                     class="bp3-popover-wrapper DropDown--main"
@@ -483,7 +488,12 @@ exports[`<TemplateSelectorLeftView> tests should render error view correctly 1`]
                     <span
                       class="bp3-control-indicator"
                     />
-                    templatesLibrary.seeLinkedTemplate
+                    <p
+                      class="StyledProps--font Text--lineclamp StyledProps--main linkedTemplateCheckboxLabel StyledProps--font-size-small"
+                      style="--text-line-clamp: 1;"
+                    >
+                      templatesLibrary.seeLinkedTemplate
+                    </p>
                   </label>
                   <div
                     class="bp3-popover-wrapper DropDown--main"
@@ -830,7 +840,12 @@ exports[`<TemplateSelectorLeftView> tests should render loading view correctly 1
                     <span
                       class="bp3-control-indicator"
                     />
-                    templatesLibrary.seeLinkedTemplate
+                    <p
+                      class="StyledProps--font Text--lineclamp StyledProps--main linkedTemplateCheckboxLabel StyledProps--font-size-small"
+                      style="--text-line-clamp: 1;"
+                    >
+                      templatesLibrary.seeLinkedTemplate
+                    </p>
                   </label>
                   <div
                     class="bp3-popover-wrapper DropDown--main"
@@ -1208,7 +1223,12 @@ exports[`<TemplateSelectorLeftView> tests should render no results view correctl
                     <span
                       class="bp3-control-indicator"
                     />
-                    templatesLibrary.seeLinkedTemplate
+                    <p
+                      class="StyledProps--font Text--lineclamp StyledProps--main linkedTemplateCheckboxLabel StyledProps--font-size-small"
+                      style="--text-line-clamp: 1;"
+                    >
+                      templatesLibrary.seeLinkedTemplate
+                    </p>
                   </label>
                   <div
                     class="bp3-popover-wrapper DropDown--main"

--- a/src/modules/75-cd/components/PipelineStudio/DeployStageSpecifications/__tests__/DeployStageSpecifications.test.tsx
+++ b/src/modules/75-cd/components/PipelineStudio/DeployStageSpecifications/__tests__/DeployStageSpecifications.test.tsx
@@ -66,7 +66,7 @@ const getPipelineContext = (): PipelineContextInterface => ({
     isUpdated: true,
     templateTypes: {},
     templateServiceData: {},
-    linkedTemplatesByCustomDeploymentRef: {}
+    resolvedCustomDeploymentDetailsByRef: {}
   },
   contextType: PipelineContextType.Pipeline,
   allowableTypes: [

--- a/src/modules/75-cd/components/PipelineStudio/DeployStageSpecifications/__tests__/DeployStageSpecifications.test.tsx
+++ b/src/modules/75-cd/components/PipelineStudio/DeployStageSpecifications/__tests__/DeployStageSpecifications.test.tsx
@@ -65,7 +65,8 @@ const getPipelineContext = (): PipelineContextInterface => ({
     entityValidityDetails: {},
     isUpdated: true,
     templateTypes: {},
-    templateServiceData: {}
+    templateServiceData: {},
+    linkedTemplatesByCustomDeploymentRef: {}
   },
   contextType: PipelineContextType.Pipeline,
   allowableTypes: [

--- a/src/modules/75-cf/pages/pipeline-studio/views/StageOverview/__tests__/FeatureStageSpecifications.test.tsx
+++ b/src/modules/75-cf/pages/pipeline-studio/views/StageOverview/__tests__/FeatureStageSpecifications.test.tsx
@@ -48,7 +48,7 @@ const getPipelineContext = (): PipelineContextInterface => ({
     isUpdated: true,
     templateTypes: {},
     templateServiceData: {},
-    linkedTemplatesByCustomDeploymentRef: {}
+    resolvedCustomDeploymentDetailsByRef: {}
   },
   contextType: PipelineContextType.Pipeline,
   allowableTypes: [

--- a/src/modules/75-cf/pages/pipeline-studio/views/StageOverview/__tests__/FeatureStageSpecifications.test.tsx
+++ b/src/modules/75-cf/pages/pipeline-studio/views/StageOverview/__tests__/FeatureStageSpecifications.test.tsx
@@ -47,7 +47,8 @@ const getPipelineContext = (): PipelineContextInterface => ({
     isLoading: false,
     isUpdated: true,
     templateTypes: {},
-    templateServiceData: {}
+    templateServiceData: {},
+    linkedTemplatesByCustomDeploymentRef: {}
   },
   contextType: PipelineContextType.Pipeline,
   allowableTypes: [

--- a/src/modules/75-cf/pages/pipeline-studio/views/StageOverview/__tests__/StageOverviewTestHelper.ts
+++ b/src/modules/75-cf/pages/pipeline-studio/views/StageOverview/__tests__/StageOverviewTestHelper.ts
@@ -39,7 +39,8 @@ export const getPipelineContext = (): PipelineContextInterface => ({
     isLoading: false,
     isUpdated: false,
     templateTypes: {},
-    templateServiceData: {}
+    templateServiceData: {},
+    linkedTemplatesByCustomDeploymentRef: {}
   },
   contextType: PipelineContextType.Pipeline,
   allowableTypes: [
@@ -98,7 +99,8 @@ export const getEditPipelineContext = (): PipelineContextInterface => ({
     isLoading: false,
     isUpdated: true,
     templateTypes: {},
-    templateServiceData: {}
+    templateServiceData: {},
+    linkedTemplatesByCustomDeploymentRef: {}
   },
   contextType: PipelineContextType.Pipeline,
   allowableTypes: [

--- a/src/modules/75-cf/pages/pipeline-studio/views/StageOverview/__tests__/StageOverviewTestHelper.ts
+++ b/src/modules/75-cf/pages/pipeline-studio/views/StageOverview/__tests__/StageOverviewTestHelper.ts
@@ -40,7 +40,7 @@ export const getPipelineContext = (): PipelineContextInterface => ({
     isUpdated: false,
     templateTypes: {},
     templateServiceData: {},
-    linkedTemplatesByCustomDeploymentRef: {}
+    resolvedCustomDeploymentDetailsByRef: {}
   },
   contextType: PipelineContextType.Pipeline,
   allowableTypes: [
@@ -100,7 +100,7 @@ export const getEditPipelineContext = (): PipelineContextInterface => ({
     isUpdated: true,
     templateTypes: {},
     templateServiceData: {},
-    linkedTemplatesByCustomDeploymentRef: {}
+    resolvedCustomDeploymentDetailsByRef: {}
   },
   contextType: PipelineContextType.Pipeline,
   allowableTypes: [

--- a/src/stringTypes.ts
+++ b/src/stringTypes.ts
@@ -3169,6 +3169,7 @@ export interface StringsMap {
   'pipeline.customDeployment.infraVariablesTitle': string
   'pipeline.customDeployment.jsonPathRelativeLabel': string
   'pipeline.customDeployment.newAttribute': string
+  'pipeline.customDeployment.seeOnlyTemplatesFor': string
   'pipeline.customDeployment.validations.nameUnique': string
   'pipeline.dashboardDeploymentsWidget.failed24Hrs.plural': string
   'pipeline.dashboardDeploymentsWidget.failed24Hrs.singular': string


### PR DESCRIPTION
### Summary

<!-- ✍️ A clear and concise description...-->
Adds support to show linked templates in template selector for deployment template and for resolution of deployment template to store stepTemplateRefs in context

#### Screenshots

NA
<!-- ✍️ Add screenshots of before and after changes where applicable-->

https://user-images.githubusercontent.com/96409598/192143291-2a212fa5-a7ac-4fd7-afc5-d1edb3d06580.mov

<img width="1792" alt="Screenshot 2022-09-26 at 7 15 45 PM" src="https://user-images.githubusercontent.com/96409598/192364014-531fef35-291f-4913-865c-554898dc3996.png">
<img width="1792" alt="Screenshot 2022-09-26 at 7 15 29 PM" src="https://user-images.githubusercontent.com/96409598/192364023-505a43ae-2335-4fee-9c54-1a23f3621071.png">


<img width="1792" alt="Screenshot 2022-09-26 at 7 15 52 PM" src="https://user-images.githubusercontent.com/96409598/192363991-4f926168-55c5-4446-9181-0d091b90a8be.png">



#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
