### PR TITLE
fix: [CDS-44433]: fix env inputs and infra inputs not retaining in template

### DIFF
--- a/src/modules/75-cd/components/PipelineSteps/DeployInfrastructureStep/DeployEnvironment/DeployEnvironment.tsx
+++ b/src/modules/75-cd/components/PipelineSteps/DeployInfrastructureStep/DeployEnvironment/DeployEnvironment.tsx
@@ -154,11 +154,10 @@ function DeployEnvironment({
             },
             path
           )
-
           const values = { ...formik?.values }
           if (parsedEnvironmentYaml.environmentInputs) {
             set(values, 'environment.environmentInputs', {
-              ...clearRuntimeInput(parsedEnvironmentYaml.environmentInputs)
+              ...clearRuntimeInput(values?.environment?.environmentInputs)
             })
           } else {
             unset(values, 'environment.environmentInputs')
@@ -166,16 +165,10 @@ function DeployEnvironment({
 
           if (parsedServiceOverridesYaml.serviceOverrideInputs) {
             set(values, 'environment.serviceOverrideInputs', {
-              ...clearRuntimeInput(parsedServiceOverridesYaml.serviceOverrideInputs)
+              ...clearRuntimeInput(values?.environment?.serviceOverrideInputs)
             })
           } else {
             unset(values, `environment.serviceOverrideInputs`)
-          }
-
-          if (gitOpsEnabled) {
-            set(values, `environment.gitOpsClusters`, '')
-          } else {
-            set(values, `environment.infrastructureDefinitions`, '')
           }
           formik?.setValues({ ...values, isEnvInputLoaded: true })
         } else {
@@ -310,7 +303,8 @@ function DeployEnvironment({
             setEnvironmentsSelectOptions(options)
           }
         } else {
-          formik?.setFieldValue('environment.environmentRef', existingEnvironment?.value)
+          console.log(initialValues)
+          formik?.setFieldValue('environment', initialValues.environment)
           setSelectedEnvironment(
             environments?.find(environment => environment.identifier === existingEnvironment?.value)
           )


### PR DESCRIPTION
### Summary

- If we have any environment or service override inputs no value was retaining on the switch from VISUAL -> YAML -> VISUAL

#### Screenshots

NA
<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
