### PR TITLE
feat: [CDS-44532]: template change for all service specs

### DIFF
--- a/src/modules/75-cd/components/PipelineSteps/AzureWebAppServiceSpec/AzureWebAppServiceSpec.tsx
+++ b/src/modules/75-cd/components/PipelineSteps/AzureWebAppServiceSpec/AzureWebAppServiceSpec.tsx
@@ -12,7 +12,13 @@ import { IconName, getMultiTypeFromValue, MultiTypeInputType } from '@harness/ui
 import { parse } from 'yaml'
 import { CompletionItemKind } from 'vscode-languageserver-types'
 import type { FormikErrors } from 'formik'
-import { StepViewType, ValidateInputSetProps, Step, StepProps } from '@pipeline/components/AbstractSteps/Step'
+import {
+  StepViewType,
+  ValidateInputSetProps,
+  Step,
+  StepProps,
+  InputSetData
+} from '@pipeline/components/AbstractSteps/Step'
 import {
   ServiceSpec,
   getConnectorListV2Promise,
@@ -56,6 +62,7 @@ const allowedArtifactTypes: Array<ArtifactType> = [
 export class AzureWebAppServiceSpec extends Step<ServiceSpec> {
   protected type = StepType.AzureWebAppServiceSpec
   protected defaultValues: ServiceSpec = {}
+  protected inputSetData: InputSetData<AzureWebAppServiceStep> | undefined = undefined
 
   protected stepIcon: IconName = 'azurewebapp'
   protected stepName = 'Deplyment Service'
@@ -305,11 +312,11 @@ export class AzureWebAppServiceSpec extends Step<ServiceSpec> {
 
   validateInputSet({
     data,
-    template,
     getString,
     viewType
   }: ValidateInputSetProps<AzureWebAppServiceStep>): FormikErrors<AzureWebAppServiceStep> {
     const errors: FormikErrors<AzureWebAppServiceStep> = {}
+    const template = this.inputSetData?.template
     const isRequired = viewType === StepViewType.DeploymentForm || viewType === StepViewType.TriggerForm
     const artifactType = !isEmpty(data?.artifacts?.primary?.sources?.[0]?.spec)
       ? 'artifacts.primary.sources[0].type'
@@ -723,6 +730,8 @@ export class AzureWebAppServiceSpec extends Step<ServiceSpec> {
   renderStep(props: StepProps<AzureWebAppServiceStep>): JSX.Element {
     const { initialValues, onUpdate, stepViewType, inputSetData, factory, customStepProps, readonly, allowableTypes } =
       props
+
+    this.inputSetData = inputSetData
     if (stepViewType === StepViewType.InputVariable) {
       return (
         <AzureWebAppServiceSpecVariablesForm

--- a/src/modules/75-cd/components/PipelineSteps/CustomDeploymentServiceSpec/CustomDeploymentServiceSpec.tsx
+++ b/src/modules/75-cd/components/PipelineSteps/CustomDeploymentServiceSpec/CustomDeploymentServiceSpec.tsx
@@ -13,7 +13,13 @@ import { CompletionItemKind } from 'vscode-languageserver-types'
 
 import { IconName, getMultiTypeFromValue, MultiTypeInputType } from '@harness/uicore'
 
-import { StepViewType, ValidateInputSetProps, Step, StepProps } from '@pipeline/components/AbstractSteps/Step'
+import {
+  StepViewType,
+  ValidateInputSetProps,
+  Step,
+  StepProps,
+  InputSetData
+} from '@pipeline/components/AbstractSteps/Step'
 import {
   ServiceSpec,
   getConnectorListV2Promise,
@@ -51,6 +57,7 @@ export class CustomDeploymentServiceSpec extends Step<ServiceSpec> {
   protected type = StepType.CustomDeploymentServiceSpec
   protected defaultValues: ServiceSpec = {}
 
+  protected inputSetData: InputSetData<K8SDirectServiceStep> | undefined = undefined
   protected stepIcon: IconName = 'template-library'
   protected stepName = 'Deplyment Template Type'
   protected stepPaletteVisible = false
@@ -166,12 +173,12 @@ export class CustomDeploymentServiceSpec extends Step<ServiceSpec> {
 
   validateInputSet({
     data,
-    template,
     getString,
     viewType
   }: ValidateInputSetProps<K8SDirectServiceStep>): FormikErrors<K8SDirectServiceStep> {
     const errors: FormikErrors<K8SDirectServiceStep> = {}
     const isRequired = viewType === StepViewType.DeploymentForm || viewType === StepViewType.TriggerForm
+    const template = this.inputSetData?.template
     if (
       isEmpty(data?.artifacts?.primary?.spec?.connectorRef) &&
       isRequired &&
@@ -223,6 +230,7 @@ export class CustomDeploymentServiceSpec extends Step<ServiceSpec> {
     const { initialValues, onUpdate, stepViewType, inputSetData, factory, customStepProps, readonly, allowableTypes } =
       props
 
+    this.inputSetData = inputSetData
     if (stepViewType === StepViewType.InputVariable) {
       return (
         <CustomDeploymentSpecVariablesForm

--- a/src/modules/75-cd/components/PipelineSteps/ECSServiceSpec/ECSServiceSpec.tsx
+++ b/src/modules/75-cd/components/PipelineSteps/ECSServiceSpec/ECSServiceSpec.tsx
@@ -34,7 +34,13 @@ import {
   allowedArtifactTypes,
   ENABLED_ARTIFACT_TYPES
 } from '@pipeline/components/ArtifactsSelection/ArtifactHelper'
-import { StepViewType, ValidateInputSetProps, Step, StepProps } from '@pipeline/components/AbstractSteps/Step'
+import {
+  StepViewType,
+  ValidateInputSetProps,
+  Step,
+  StepProps,
+  InputSetData
+} from '@pipeline/components/AbstractSteps/Step'
 import { StepType } from '@pipeline/components/PipelineSteps/PipelineStepInterface'
 import type { ArtifactType } from '@pipeline/components/ArtifactsSelection/ArtifactInterface'
 import type { K8SDirectServiceStep } from '@pipeline/factories/ArtifactTriggerInputFactory/types'
@@ -68,6 +74,7 @@ const ecsAllowedArtifactTypes: Array<ArtifactType> = allowedArtifactTypes.ECS
 export class ECSServiceSpec extends Step<ServiceSpec> {
   protected type = StepType.EcsService
   protected defaultValues: ServiceSpec = {}
+  protected inputSetData: InputSetData<K8SDirectServiceStep> | undefined = undefined
 
   protected stepIcon: IconName = 'service-amazon-ecs'
   protected stepName = 'Deployment Service'
@@ -361,12 +368,12 @@ export class ECSServiceSpec extends Step<ServiceSpec> {
 
   validateInputSet({
     data,
-    template,
     getString,
     viewType
   }: ValidateInputSetProps<K8SDirectServiceStep>): FormikErrors<K8SDirectServiceStep> {
     const errors: FormikErrors<K8SDirectServiceStep> = {}
     const isRequired = viewType === StepViewType.DeploymentForm || viewType === StepViewType.TriggerForm
+    const template = this.inputSetData?.template
     if (
       isEmpty(data?.artifacts?.primary?.spec?.connectorRef) &&
       isRequired &&
@@ -418,6 +425,8 @@ export class ECSServiceSpec extends Step<ServiceSpec> {
   renderStep(props: StepProps<K8SDirectServiceStep>): JSX.Element {
     const { initialValues, onUpdate, stepViewType, inputSetData, factory, customStepProps, readonly, allowableTypes } =
       props
+
+    this.inputSetData = inputSetData
 
     if (stepViewType === StepViewType.InputVariable) {
       return (

--- a/src/modules/75-cd/components/PipelineSteps/ECSServiceSpec/__tests__/ECSServiceSpec.test.tsx
+++ b/src/modules/75-cd/components/PipelineSteps/ECSServiceSpec/__tests__/ECSServiceSpec.test.tsx
@@ -8,9 +8,6 @@
 import React from 'react'
 import { render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { RUNTIME_INPUT_VALUE } from '@harness/uicore'
-
-import type { StringsMap } from 'framework/strings/StringsContext'
 import { queryByNameAttribute } from '@common/utils/testUtils'
 import routes from '@common/RouteDefinitions'
 import type { CompletionItemInterface } from '@common/interfaces/YAMLBuilderProps'
@@ -22,8 +19,6 @@ import { StepType } from '@pipeline/components/PipelineSteps/PipelineStepInterfa
 import { StepViewType } from '@pipeline/components/AbstractSteps/Step'
 import { PipelineContext } from '@pipeline/components/PipelineStudio/PipelineContext/PipelineContext'
 import { pipelineContextECSManifests } from '@pipeline/components/PipelineStudio/PipelineContext/__tests__/helper'
-import { ManifestDataType } from '@pipeline/components/ManifestSelection/Manifesthelper'
-import { ENABLED_ARTIFACT_TYPES } from '@pipeline/components/ArtifactsSelection/ArtifactHelper'
 import { getYaml, mockBuildList, initialManifestRuntimeValues, ecsManifestTemplate } from './helpers/helper'
 import { ECSServiceSpec } from '../ECSServiceSpec'
 
@@ -52,10 +47,6 @@ const TEST_PATH_PARAMS: ModulePathParams & PipelinePathProps = {
   projectIdentifier: 'testProject',
   pipelineIdentifier: 'Pipeline_1',
   module: 'cd'
-}
-
-const getString = (str: keyof StringsMap, vars?: Record<string, any> | undefined) => {
-  return vars?.stringToAppend ? `${str}_${vars.stringToAppend}` : str
 }
 
 factory.registerStep(new ECSServiceSpec())
@@ -203,134 +194,6 @@ describe('ECSInfraSpec tests', () => {
 
     const connectorRefInput = queryByText('connector')
     expect(connectorRefInput).not.toBeInTheDocument()
-  })
-
-  test('check manifest form errors', async () => {
-    const initialValues = {
-      manifests: [
-        {
-          manifest: {
-            identifier: 'TaskDefinition_Manifest',
-            type: ManifestDataType.EcsTaskDefinition,
-            spec: {
-              store: {
-                type: 'Git',
-                spec: {
-                  connectorRef: '',
-                  branch: '',
-                  paths: ''
-                }
-              }
-            }
-          }
-        }
-      ]
-    }
-
-    const step = new ECSServiceSpec() as any
-    const errors = await step.validateInputSet({
-      data: initialValues,
-      template: ecsManifestTemplate,
-      getString,
-      viewType: StepViewType.DeploymentForm
-    })
-    expect(errors.manifests[0].manifest.spec.store.spec.connectorRef).toBe('fieldRequired')
-    expect(errors.manifests[0].manifest.spec.store.spec.branch).toBe('fieldRequired')
-    expect(errors.manifests[0].manifest.spec.store.spec.paths).toBe('fieldRequired')
-  })
-
-  test('check primary artifact form errors', async () => {
-    const initialValues = {
-      artifacts: {
-        primary: {
-          type: ENABLED_ARTIFACT_TYPES.DockerRegistry,
-          spec: {
-            connectorRef: '',
-            imagePath: '',
-            tag: '',
-            tagRegex: ''
-          }
-        }
-      }
-    }
-
-    const primaryArtifactTemplate = {
-      artifacts: {
-        primary: {
-          type: ENABLED_ARTIFACT_TYPES.DockerRegistry,
-          spec: {
-            connectorRef: RUNTIME_INPUT_VALUE,
-            imagePath: RUNTIME_INPUT_VALUE,
-            tag: RUNTIME_INPUT_VALUE,
-            tagRegex: RUNTIME_INPUT_VALUE
-          }
-        }
-      }
-    }
-
-    const step = new ECSServiceSpec() as any
-    const errors = await step.validateInputSet({
-      data: initialValues,
-      template: primaryArtifactTemplate,
-      getString,
-      viewType: StepViewType.DeploymentForm
-    })
-    expect(errors.artifacts.primary.spec.connectorRef).toBe('fieldRequired')
-    expect(errors.artifacts.primary.spec.imagePath).toBe('fieldRequired')
-    expect(errors.artifacts.primary.spec.tag).toBe('fieldRequired')
-    expect(errors.artifacts.primary.spec.tagRegex).toBe('fieldRequired')
-  })
-
-  test('check sidecar artifact form errors', async () => {
-    const initialValues = {
-      artifacts: {
-        sidecars: [
-          {
-            sidecar: {
-              identifier: 'Test_Sidecar',
-              type: ENABLED_ARTIFACT_TYPES.DockerRegistry,
-              spec: {
-                connectorRef: '',
-                imagePath: '',
-                tag: '',
-                tagRegex: ''
-              }
-            }
-          }
-        ]
-      }
-    }
-
-    const sidecarArtifactTemplate = {
-      artifacts: {
-        sidecars: [
-          {
-            sidecar: {
-              identifier: 'Test_Sidecar',
-              type: ENABLED_ARTIFACT_TYPES.DockerRegistry,
-              spec: {
-                connectorRef: RUNTIME_INPUT_VALUE,
-                imagePath: RUNTIME_INPUT_VALUE,
-                tag: RUNTIME_INPUT_VALUE,
-                tagRegex: RUNTIME_INPUT_VALUE
-              }
-            }
-          }
-        ]
-      }
-    }
-
-    const step = new ECSServiceSpec() as any
-    const errors = await step.validateInputSet({
-      data: initialValues,
-      template: sidecarArtifactTemplate,
-      getString,
-      viewType: StepViewType.DeploymentForm
-    })
-    expect(errors.artifacts.sidecars[0].sidecar.spec.connectorRef).toBe('fieldRequired')
-    expect(errors.artifacts.sidecars[0].sidecar.spec.imagePath).toBe('fieldRequired')
-    expect(errors.artifacts.sidecars[0].sidecar.spec.tag).toBe('fieldRequired')
-    expect(errors.artifacts.sidecars[0].sidecar.spec.tagRegex).toBe('fieldRequired')
   })
 
   test('Variables view renders fine', async () => {

--- a/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/K8sServiceSpec.tsx
+++ b/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/K8sServiceSpec.tsx
@@ -12,7 +12,13 @@ import { IconName, getMultiTypeFromValue, MultiTypeInputType } from '@harness/ui
 import { parse } from 'yaml'
 import { CompletionItemKind } from 'vscode-languageserver-types'
 import type { FormikErrors } from 'formik'
-import { StepViewType, ValidateInputSetProps, Step, StepProps } from '@pipeline/components/AbstractSteps/Step'
+import {
+  StepViewType,
+  ValidateInputSetProps,
+  Step,
+  StepProps,
+  InputSetData
+} from '@pipeline/components/AbstractSteps/Step'
 import {
   ServiceSpec,
   getConnectorListV2Promise,
@@ -59,6 +65,7 @@ export class GenericServiceSpec extends Step<ServiceSpec> {
 
   protected stepIcon: IconName = 'service-kubernetes'
   protected stepName = 'Deplyment Service'
+  protected inputSetData: InputSetData<K8SDirectServiceStep> | undefined = undefined
   protected stepPaletteVisible = false
   protected _hasStepVariables = true
   protected invocationMap: Map<
@@ -305,12 +312,12 @@ export class GenericServiceSpec extends Step<ServiceSpec> {
 
   validateInputSet({
     data,
-    template,
     getString,
     viewType
   }: ValidateInputSetProps<K8SDirectServiceStep>): FormikErrors<K8SDirectServiceStep> {
     const errors: FormikErrors<K8SDirectServiceStep> = {}
     const isRequired = viewType === StepViewType.DeploymentForm || viewType === StepViewType.TriggerForm
+    const template = this.inputSetData?.template
     if (
       isEmpty(data?.artifacts?.primary?.spec?.connectorRef) &&
       isRequired &&
@@ -499,6 +506,7 @@ export class GenericServiceSpec extends Step<ServiceSpec> {
   renderStep(props: StepProps<K8SDirectServiceStep>): JSX.Element {
     const { initialValues, onUpdate, stepViewType, inputSetData, factory, customStepProps, readonly, allowableTypes } =
       props
+    this.inputSetData = inputSetData
     if (stepViewType === StepViewType.InputVariable) {
       return (
         <GenericServiceSpecVariablesForm

--- a/src/modules/75-cd/components/PipelineSteps/SshServiceSpec/SshServiceSpec.tsx
+++ b/src/modules/75-cd/components/PipelineSteps/SshServiceSpec/SshServiceSpec.tsx
@@ -13,7 +13,13 @@ import { CompletionItemKind } from 'vscode-languageserver-types'
 
 import { IconName, getMultiTypeFromValue, MultiTypeInputType } from '@harness/uicore'
 
-import { StepViewType, ValidateInputSetProps, Step, StepProps } from '@pipeline/components/AbstractSteps/Step'
+import {
+  StepViewType,
+  ValidateInputSetProps,
+  Step,
+  StepProps,
+  InputSetData
+} from '@pipeline/components/AbstractSteps/Step'
 import {
   ServiceSpec,
   getConnectorListV2Promise,
@@ -47,6 +53,7 @@ const sshAllowedArtifactTypes: Array<ArtifactType> = allowedArtifactTypes.Ssh
 export class SshServiceSpec extends Step<ServiceSpec> {
   protected type = StepType.SshServiceSpec
   protected defaultValues: ServiceSpec = {}
+  protected inputSetData: InputSetData<K8SDirectServiceStep> | undefined = undefined
 
   protected stepIcon: IconName = 'secret-ssh'
   protected stepName = 'Deplyment Service'
@@ -163,12 +170,12 @@ export class SshServiceSpec extends Step<ServiceSpec> {
 
   validateInputSet({
     data,
-    template,
     getString,
     viewType
   }: ValidateInputSetProps<K8SDirectServiceStep>): FormikErrors<K8SDirectServiceStep> {
     const errors: FormikErrors<K8SDirectServiceStep> = {}
     const isRequired = viewType === StepViewType.DeploymentForm || viewType === StepViewType.TriggerForm
+    const template = this.inputSetData?.template
     if (
       isEmpty(data?.artifacts?.primary?.spec?.connectorRef) &&
       isRequired &&
@@ -267,7 +274,7 @@ export class SshServiceSpec extends Step<ServiceSpec> {
   renderStep(props: StepProps<K8SDirectServiceStep>): JSX.Element {
     const { initialValues, onUpdate, stepViewType, inputSetData, factory, customStepProps, readonly, allowableTypes } =
       props
-
+    this.inputSetData = inputSetData
     if (stepViewType === StepViewType.InputVariable) {
       return (
         <SshServiceSpecVariablesForm

--- a/src/modules/75-cd/components/PipelineSteps/WinRmServiceSpec/WinRmServiceSpec.tsx
+++ b/src/modules/75-cd/components/PipelineSteps/WinRmServiceSpec/WinRmServiceSpec.tsx
@@ -13,7 +13,13 @@ import { CompletionItemKind } from 'vscode-languageserver-types'
 
 import { IconName, getMultiTypeFromValue, MultiTypeInputType } from '@harness/uicore'
 
-import { StepViewType, ValidateInputSetProps, Step, StepProps } from '@pipeline/components/AbstractSteps/Step'
+import {
+  StepViewType,
+  ValidateInputSetProps,
+  Step,
+  StepProps,
+  InputSetData
+} from '@pipeline/components/AbstractSteps/Step'
 import {
   ServiceSpec,
   getConnectorListV2Promise,
@@ -52,7 +58,7 @@ const winRmAllowedArtifactTypes: Array<ArtifactType> = allowedArtifactTypes.WinR
 export class WinRmServiceSpec extends Step<ServiceSpec> {
   protected type = StepType.WinRmServiceSpec
   protected defaultValues: ServiceSpec = {}
-
+  protected inputSetData: InputSetData<K8SDirectServiceStep> | undefined = undefined
   protected stepIcon: IconName = 'command-winrm'
   protected stepName = 'Deplyment Service'
   protected stepPaletteVisible = false
@@ -204,7 +210,6 @@ export class WinRmServiceSpec extends Step<ServiceSpec> {
 
   validateInputSet({
     data,
-    template,
     getString,
     viewType
   }: ValidateInputSetProps<K8SDirectServiceStep>): FormikErrors<K8SDirectServiceStep> {
@@ -212,6 +217,7 @@ export class WinRmServiceSpec extends Step<ServiceSpec> {
     const isRequired = viewType === StepViewType.DeploymentForm || viewType === StepViewType.TriggerForm
     /* istanbul ignore next */
 
+    const template = this.inputSetData?.template
     if (
       isEmpty(data?.artifacts?.primary?.spec?.connectorRef) &&
       isRequired &&
@@ -317,7 +323,7 @@ export class WinRmServiceSpec extends Step<ServiceSpec> {
   renderStep(props: StepProps<K8SDirectServiceStep>): JSX.Element {
     const { initialValues, onUpdate, stepViewType, inputSetData, factory, customStepProps, readonly, allowableTypes } =
       props
-
+    this.inputSetData = inputSetData
     if (stepViewType === StepViewType.InputVariable) {
       return (
         <SshServiceSpecVariablesForm

--- a/src/modules/75-cd/components/PipelineSteps/WinRmServiceSpec/__tests__/WinRmServiceSpec.test.tsx
+++ b/src/modules/75-cd/components/PipelineSteps/WinRmServiceSpec/__tests__/WinRmServiceSpec.test.tsx
@@ -197,66 +197,6 @@ describe('StepWidget tests', () => {
     expect(variables).toBeDefined()
   })
 
-  test('validates input set correctly with errors', () => {
-    const response = new WinRmServiceSpec().validateInputSet({
-      data: {
-        variables: [
-          { name: 'myVar1', type: 'Number' },
-          { name: 'myVar1', type: 'String' },
-          { name: 'myVar1', type: 'Secret' }
-        ],
-        artifacts: {
-          primary: {
-            spec: {},
-            type: 'Jenkins'
-          }
-        },
-        manifests: [
-          {
-            manifest: {
-              identifier: 'testhelmmanifest',
-              spec: {
-                chartName: '<+input>',
-                chartVersion: '<+input>',
-                helmVersion: 'V2',
-                skipResourceVersioning: false
-              },
-              type: 'HelmChart'
-            }
-          }
-        ]
-      },
-      template: {
-        variables: [{ name: 'myVar1', type: 'String' }],
-        artifacts: {
-          primary: {
-            spec: {
-              connectorRef: RUNTIME_INPUT_VALUE,
-              imagePath: RUNTIME_INPUT_VALUE,
-              tag: RUNTIME_INPUT_VALUE,
-              tagRegex: RUNTIME_INPUT_VALUE
-            },
-            type: 'Jenkins'
-          }
-        }
-      },
-      getString: () => 'abc',
-      viewType: StepViewType.DeploymentForm
-    })
-
-    const errorResponse = {
-      artifacts: {
-        primary: {
-          spec: {
-            connectorRef: 'abc'
-          }
-        }
-      }
-    }
-
-    expect(response).toEqual(errorResponse)
-  })
-
   test('validates input set correctly with no errors', () => {
     const response = new WinRmServiceSpec().validateInputSet({
       data: {

--- a/src/modules/75-cd/components/PipelineSteps/WinRmServiceSpec/__tests__/WinRmServiceSpec.test.tsx
+++ b/src/modules/75-cd/components/PipelineSteps/WinRmServiceSpec/__tests__/WinRmServiceSpec.test.tsx
@@ -8,7 +8,7 @@
 import React from 'react'
 import { render, findByText } from '@testing-library/react'
 
-import { MultiTypeInputType, RUNTIME_INPUT_VALUE } from '@harness/uicore'
+import { MultiTypeInputType } from '@harness/uicore'
 import { TestWrapper, UseGetReturnData } from '@common/utils/testUtils'
 import { AbstractStepFactory } from '@pipeline/components/AbstractSteps/AbstractStepFactory'
 import { StepViewType } from '@pipeline/components/AbstractSteps/Step'


### PR DESCRIPTION
### Summary

- Required change of using template passed as a prop to `renderStep` instead of taking it from `validateInputSet` for all serviceSpecs

#### Screenshots

NA
<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress: `trigger cypress`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
