### PR TITLE
feat: [OPA-919]: make policies available w/o module selection

### DIFF
--- a/src/modules/10-common/navigation/ProjectSetupMenu/ProjectSetupMenu.tsx
+++ b/src/modules/10-common/navigation/ProjectSetupMenu/ProjectSetupMenu.tsx
@@ -98,10 +98,7 @@ const ProjectSetupMenu: React.FC<ProjectSetupMenuProps> = ({ module, defaultExpa
             to={routes.toTemplates({ ...params, templateType: 'MonitoredService' })}
           />
         )}
-        {OPA_PIPELINE_GOVERNANCE && isCIorCDorSTO && canUsePolicyEngine && (
-          <SidebarLink label={getString('common.governance')} to={routes.toGovernance(params as GovernancePathProps)} />
-        )}
-        {OPA_PIPELINE_GOVERNANCE && isCV && canUsePolicyEngine && (
+        {OPA_PIPELINE_GOVERNANCE && canUsePolicyEngine && (
           <SidebarLink label={getString('common.governance')} to={routes.toGovernance(params as GovernancePathProps)} />
         )}
         {showDeploymentFreeze ? (

--- a/src/modules/45-projects-orgs/RouteDestinations.tsx
+++ b/src/modules/45-projects-orgs/RouteDestinations.tsx
@@ -715,8 +715,12 @@ export default (
       </GitSyncPage>
     </RouteWithLayout>
     {GovernanceRouteDestinations({
+      sidebarProps: ProjectDetailsSideNavProps,
+      pathProps: { ...projectPathProps }
+    })}
+    {GovernanceRouteDestinations({
       sidebarProps: AccountSideNavProps,
-      pathProps: { ...accountPathProps, ...orgPathProps }
+      pathProps: { ...orgPathProps }
     })}
   </>
 )


### PR DESCRIPTION
### Summary

Make "Policies" available in the project setup menu independent of module selection.

![Screenshot 2022-10-31 at 11 25 07 AM](https://user-images.githubusercontent.com/47316575/198940918-af2bbf5e-de57-4d58-b09f-1007ac629a05.png)

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
