### PR TITLE
fix: [SRM-12774]: Persist AWS Prometheus changes if user switches back to define health source page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nextgenui",
   "description": "Harness Inc",
-  "version": "0.327.8",
+  "version": "0.327.9",
   "author": "Harness Inc",
   "license": "Harness Inc",
   "homepage": "http://app.harness.io/",

--- a/src/modules/85-cv/pages/health-source/HealthSourceDrawer/component/defineHealthSource/DefineHealthSource.types.ts
+++ b/src/modules/85-cv/pages/health-source/HealthSourceDrawer/component/defineHealthSource/DefineHealthSource.types.ts
@@ -37,3 +37,9 @@ export interface DataSourceTypeValidateFunctionProps {
   sourceType?: string
   dataSourceType?: string
 }
+
+export interface GetDataSourceTypeParams {
+  type?: string
+  dataSourceType?: string
+  isDataSourceTypeSelectorEnabled?: boolean
+}

--- a/src/modules/85-cv/pages/health-source/HealthSourceDrawer/component/defineHealthSource/DefineHealthSource.utils.ts
+++ b/src/modules/85-cv/pages/health-source/HealthSourceDrawer/component/defineHealthSource/DefineHealthSource.utils.ts
@@ -29,7 +29,8 @@ import type {
   ConnectorDisableFunctionProps,
   DataSourceTypeValidateFunctionProps,
   DefineHealthSourceFormInterface,
-  FormValidationFunctionProps
+  FormValidationFunctionProps,
+  GetDataSourceTypeParams
 } from './DefineHealthSource.types'
 
 export const validate = (getString: UseStringsReturn['getString']): Yup.ObjectSchema => {
@@ -296,8 +297,12 @@ const getHealthSourceType = (type?: string, sourceType?: string): string | undef
   return sourceType
 }
 
-const getDataSourceType = (type?: string, isDataSourceTypeSelectorEnabled?: boolean): string | null => {
-  if (type === HealthSourceTypes.AwsPrometheus) {
+export const getDataSourceType = ({
+  type,
+  dataSourceType,
+  isDataSourceTypeSelectorEnabled
+}: GetDataSourceTypeParams): string | null => {
+  if (type === HealthSourceTypes.AwsPrometheus || dataSourceType === AWSDataSourceType) {
     return AWSDataSourceType
   } else if (isDataSourceTypeSelectorEnabled) {
     return HealthSourceTypes.Prometheus
@@ -319,7 +324,7 @@ export const getInitialValues = (
 
   const { region, workspaceId } = currentHealthSource?.spec || {}
 
-  const { sourceType } = sourceData || {}
+  const { sourceType, dataSourceType, region: sourceDataRegion, workspaceId: sourceDataWorkspaceId } = sourceData || {}
 
   // TODO: remove check for prometheus when BE changes are done
   const selectedFeature = PrometheusTypes.includes(currentHealthSource?.type) ? '' : currentHealthSource?.spec?.feature
@@ -328,9 +333,13 @@ export const getInitialValues = (
     ...sourceData,
     type: getHealthSourceType(currentHealthSource?.type),
     sourceType: getHealthSourceType(currentHealthSource?.type, sourceType),
-    dataSourceType: getDataSourceType(currentHealthSource?.type, isDataSourceTypeSelectorEnabled),
-    region,
-    workspaceId,
+    dataSourceType: getDataSourceType({
+      type: currentHealthSource?.type,
+      dataSourceType,
+      isDataSourceTypeSelectorEnabled
+    }),
+    region: sourceDataRegion || region,
+    workspaceId: sourceDataWorkspaceId || workspaceId,
     product: selectedFeature
       ? { label: selectedFeature, value: selectedFeature }
       : getProductBasedOnType(getString, currentHealthSource?.type, sourceData?.product)

--- a/src/modules/85-cv/pages/health-source/HealthSourceDrawer/component/defineHealthSource/__tests__/DefineHealthSource.utils.test.ts
+++ b/src/modules/85-cv/pages/health-source/HealthSourceDrawer/component/defineHealthSource/__tests__/DefineHealthSource.utils.test.ts
@@ -1,4 +1,11 @@
-import { formValidation, getConnectorPlaceholderText, getIsConnectorDisabled } from '../DefineHealthSource.utils'
+import { HealthSourceTypes } from '@cv/pages/health-source/types'
+import { AWSDataSourceType } from '../DefineHealthSource.constant'
+import {
+  formValidation,
+  getConnectorPlaceholderText,
+  getDataSourceType,
+  getIsConnectorDisabled
+} from '../DefineHealthSource.utils'
 
 describe('DefineHealthSource.utils.test', () => {
   test('should return correct connector placeholder text', () => {
@@ -51,5 +58,17 @@ describe('DefineHealthSource.utils.test', () => {
       dataSourceType: 'AwsPrometheus'
     })
     expect(result).toBe(false)
+  })
+
+  test('getDataSourceType should return AwsPrometheus, if selected dataSourceType is AWS', () => {
+    const result = getDataSourceType({ dataSourceType: AWSDataSourceType, isDataSourceTypeSelectorEnabled: true })
+
+    expect(result).toBe(AWSDataSourceType)
+  })
+
+  test('getDataSourceType should return AwsPrometheus, if selected health source type is AwaPrometheus', () => {
+    const result = getDataSourceType({ type: HealthSourceTypes.AwsPrometheus, isDataSourceTypeSelectorEnabled: true })
+
+    expect(result).toBe(AWSDataSourceType)
   })
 })

--- a/src/modules/85-cv/pages/health-source/HealthSourceDrawer/component/defineHealthSource/components/DataInfoSelector/DataInfoSelector.tsx
+++ b/src/modules/85-cv/pages/health-source/HealthSourceDrawer/component/defineHealthSource/components/DataInfoSelector/DataInfoSelector.tsx
@@ -44,7 +44,7 @@ export default function DataInfoSelector({ isEdit }: { isEdit?: boolean }): JSX.
         }
       })
     }
-  }, [accountId, connectorRef, orgIdentifier, projectIdentifier, region])
+  }, [accountId, connectorRef, orgIdentifier, projectIdentifier, region, isEdit])
 
   const regionPlaceholderText = regionsLoading
     ? getString('loading')
@@ -73,7 +73,7 @@ export default function DataInfoSelector({ isEdit }: { isEdit?: boolean }): JSX.
         items={workspaceItems}
         placeholder={workspacePlaceholderText}
         name={DataSourceTypeFieldNames.WorkspaceId}
-        disabled={workspaceLoading || isEdit || !region}
+        disabled={workspaceLoading || isEdit || !region || !connectorRef}
         label={getString('cv.healthSource.awsWorkspaceLabel')}
         tooltipProps={{ dataTooltipId: 'healthSourcesAWSWorkspace' }}
       />

--- a/src/modules/85-cv/pages/health-source/HealthSourceTable/HealthSourceTable.utils.ts
+++ b/src/modules/85-cv/pages/health-source/HealthSourceTable/HealthSourceTable.utils.ts
@@ -64,6 +64,7 @@ export const getIconBySourceType = (type: string): IconName => {
     case 'PROMETHEUS':
     case 'Prometheus':
     case 'AwsPrometheus':
+    case 'AWS_PROMETHEUS':
       return 'service-prometheus'
     //TODO one type will be removed once it is full deprecated from backend.
     case 'STACKDRIVER_LOG':
@@ -94,6 +95,7 @@ export const getIconBySourceType = (type: string): IconName => {
     case 'ErrorTracking':
       return 'error-tracking'
     case HealthSourceTypes.CloudWatchMetrics:
+    case 'CLOUDWATCH_METRICS':
       return 'service-aws'
     default:
       return 'placeholder'

--- a/src/modules/85-cv/pages/health-source/HealthSourceTable/__tests__/HealthSourceTable.utils.test.ts
+++ b/src/modules/85-cv/pages/health-source/HealthSourceTable/__tests__/HealthSourceTable.utils.test.ts
@@ -42,6 +42,8 @@ describe('Validate Healthsource table Utils', () => {
     expect(getIconBySourceType('SplunkMetric')).toEqual('service-splunk')
     expect(getIconBySourceType('Splunk')).toEqual('service-splunk')
     expect(getIconBySourceType('AwsPrometheus')).toEqual('service-prometheus')
+    expect(getIconBySourceType('AWS_PROMETHEUS')).toEqual('service-prometheus')
+    expect(getIconBySourceType('CLOUDWATCH_METRICS')).toEqual('service-aws')
   })
 
   test('Ensure correct type is returned by getTypeByFeature', async () => {


### PR DESCRIPTION
### Summary

<!-- ✍️ A clear and concise description...-->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
