### PR TITLE
fix: [DEL-5259]: change UUID with date now in k8sdelegate

### DIFF
--- a/src/modules/75-cd/pages/get-started-with-cd/CreateKubernetesDelegateWizard/CreateK8sDelegate.tsx
+++ b/src/modules/75-cd/pages/get-started-with-cd/CreateKubernetesDelegateWizard/CreateK8sDelegate.tsx
@@ -92,7 +92,7 @@ export const CreateK8sDelegate = ({
       showError(getString('somethingWentWrong'))
     } else {
       const delegateToken = get(delegateTokens, 'resource[0].name')
-      const uuidTemp = `${Date.now()}${window.performance.now().toFixed()}`.slice(0, 25)
+      const uuidTemp = `${Date.now()}${window.performance.now().toFixed()}`.slice(0, 25) // making sure uuid is  of length 25
       const delegateName1 = `del-${uuidTemp}`
       setDelegateName(delegateName1)
       delegateNameRef.current = delegateName1

--- a/src/modules/75-cd/pages/get-started-with-cd/CreateKubernetesDelegateWizard/CreateK8sDelegate.tsx
+++ b/src/modules/75-cd/pages/get-started-with-cd/CreateKubernetesDelegateWizard/CreateK8sDelegate.tsx
@@ -7,7 +7,6 @@
 
 import React, { useEffect } from 'react'
 import { useParams } from 'react-router-dom'
-import { v4 as uuid } from 'uuid'
 import { Button, Container, Layout, PageSpinner, Text, useToaster } from '@harness/uicore'
 import { Color, FontVariation } from '@harness/design-system'
 import cx from 'classnames'

--- a/src/modules/75-cd/pages/get-started-with-cd/CreateKubernetesDelegateWizard/CreateK8sDelegate.tsx
+++ b/src/modules/75-cd/pages/get-started-with-cd/CreateKubernetesDelegateWizard/CreateK8sDelegate.tsx
@@ -92,7 +92,8 @@ export const CreateK8sDelegate = ({
       showError(getString('somethingWentWrong'))
     } else {
       const delegateToken = get(delegateTokens, 'resource[0].name')
-      const delegateName1 = `sample-${Date.now()}-delegate`
+      const uuidTemp = `${Date.now()}${window.performance.now().toFixed()}`.slice(0, 25)
+      const delegateName1 = `del-${uuidTemp}`
       setDelegateName(delegateName1)
       delegateNameRef.current = delegateName1
       trackEvent(CDOnboardingActions.StartOnboardingDelegateCreation, {

--- a/src/modules/75-cd/pages/get-started-with-cd/CreateKubernetesDelegateWizard/CreateK8sDelegate.tsx
+++ b/src/modules/75-cd/pages/get-started-with-cd/CreateKubernetesDelegateWizard/CreateK8sDelegate.tsx
@@ -93,7 +93,7 @@ export const CreateK8sDelegate = ({
       showError(getString('somethingWentWrong'))
     } else {
       const delegateToken = get(delegateTokens, 'resource[0].name')
-      const delegateName1 = `sample-${uuid()}-delegate`
+      const delegateName1 = `sample-${Date.now()}-delegate`
       setDelegateName(delegateName1)
       delegateNameRef.current = delegateName1
       trackEvent(CDOnboardingActions.StartOnboardingDelegateCreation, {


### PR DESCRIPTION
### Summary
change UUID with date now in k8sdelegate
<!-- ✍️ A clear and concise description...-->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
