### PR TITLE
fix: [PIE-6172]: bring back tags and desc fields in import template modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nextgenui",
   "description": "Harness Inc",
-  "version": "0.328.0",
+  "version": "0.328.1",
   "author": "Harness Inc",
   "license": "Harness Inc",
   "homepage": "https://app.harness.io/",

--- a/src/modules/70-pipeline/components/ArtifactsSelection/ArtifactRepository/ArtifactLastSteps/GoogleArtifactRegistry/__tests__/__snapshots__/GoogleArtifactRegistry.test.tsx.snap
+++ b/src/modules/70-pipeline/components/ArtifactsSelection/ArtifactRepository/ArtifactLastSteps/GoogleArtifactRegistry/__tests__/__snapshots__/GoogleArtifactRegistry.test.tsx.snap
@@ -1902,11 +1902,7 @@ exports[`GoogleArtifactRegistry tests renders fine for the versionType as value 
                       </span>
                     </button>
                   </div>
-                  <div
-                    class="bp3-form-helper-text"
-                  >
-                    pipeline.artifactsSelection.feed  is  pipeline.tagDependencyRequired
-                  </div>
+                  
                 </div>
               </div>
             </div>

--- a/src/modules/70-pipeline/components/ImportResource/ImportResource.tsx
+++ b/src/modules/70-pipeline/components/ImportResource/ImportResource.tsx
@@ -32,7 +32,7 @@ import { GitSyncForm, gitSyncFormSchema } from '@gitsync/components/GitSyncForm/
 import type { ResponseMessage } from '@common/components/ErrorHandler/ErrorHandler'
 import type { PipelinePathProps } from '@common/interfaces/RouteInterfaces'
 import { ResourceType } from '@common/interfaces/GitSyncInterface'
-import { NameId } from '@common/components/NameIdDescriptionTags/NameIdDescriptionTags'
+import { NameId, NameIdDescriptionTags } from '@common/components/NameIdDescriptionTags/NameIdDescriptionTags'
 import type { ExtraQueryParams, InitialValuesType, ModifiedInitialValuesType } from './useImportResource'
 import css from './ImportResource.module.scss'
 
@@ -279,7 +279,14 @@ export default function ImportResource({
               <PageSpinner message={getString('loading')} />
             ) : (
               <>
-                <NameId />
+                {resourceType === ResourceType.TEMPLATE ? (
+                  <NameIdDescriptionTags
+                    formikProps={formikProps}
+                    tooltipProps={{ dataTooltipId: `create${resourceType}` }}
+                  />
+                ) : (
+                  <NameId />
+                )}
                 {resourceType === ResourceType.TEMPLATE && (
                   <FormInput.Text
                     name="versionLabel"

--- a/src/modules/70-pipeline/utils/__tests__/stageHelpers.test.ts
+++ b/src/modules/70-pipeline/utils/__tests__/stageHelpers.test.ts
@@ -121,7 +121,7 @@ test('isServerlessDeploymentType', () => {
 test('getHelpeTextForTags', () => {
   expect(
     getHelpeTextForTags({ imagePath: '/image', artifactPath: '', connectorRef: 'RUNTIME' }, (str: string) => str, false)
-  ).toBe('pipeline.artifactsSelection.feed, pipeline.artifactPathLabel  are  pipeline.tagDependencyRequired')
+  ).toBe('pipeline.artifactPathLabel  is  pipeline.tagDependencyRequired')
 
   expect(
     getHelpeTextForTags(
@@ -129,13 +129,11 @@ test('getHelpeTextForTags', () => {
       (str: string) => str,
       false
     )
-  ).toBe('pipeline.artifactsSelection.feed, pipeline.imagePathLabel  are  pipeline.tagDependencyRequired')
+  ).toBe('pipeline.imagePathLabel  is  pipeline.tagDependencyRequired')
 
   expect(
     getHelpeTextForTags({ imagePath: '/image', artifactPath: '', connectorRef: 'RUNTIME' }, (str: string) => str, true)
-  ).toBe(
-    'pipeline.artifactsSelection.feed, pipeline.artifactsSelection.artifactDirectory  are  pipeline.artifactPathDependencyRequired'
-  )
+  ).toBe('pipeline.artifactsSelection.artifactDirectory  is  pipeline.artifactPathDependencyRequired')
 })
 
 test('getCustomStepProps', () => {

--- a/src/modules/70-pipeline/utils/stageHelpers.ts
+++ b/src/modules/70-pipeline/utils/stageHelpers.ts
@@ -220,7 +220,7 @@ export const getHelpeTextForTags = (
   if (!connectorRef || getMultiTypeFromValue(connectorRef) === MultiTypeInputType.RUNTIME) {
     invalidFields.push(getString('connector'))
   }
-  if (!feed || getMultiTypeFromValue(feed) === MultiTypeInputType.RUNTIME) {
+  if (feed !== undefined && (!feed || getMultiTypeFromValue(feed) === MultiTypeInputType.RUNTIME)) {
     invalidFields.push(getString('pipeline.artifactsSelection.feed'))
   }
   if (


### PR DESCRIPTION
### Summary
- The reason for this change is that BE changes for removal of those fields are not done yet from template service side

#### Screenshots


#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
