### PR TITLE
fix: [PIE-6355]: Reseting formik form instead of setting values in PrimaryArtifactRef after useGetArtifactSourceInputs API response as it makes the form dirty

### DIFF
--- a/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/PrimaryArtifact/PrimaryArtifactRef.tsx
+++ b/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/PrimaryArtifact/PrimaryArtifactRef.tsx
@@ -89,13 +89,12 @@ function PrimaryArtifactRef({
         if (idSourceMap) {
           //In templateusage view type, the formik is directly set by reading the values from pipeline yaml, whereas in run pipeline form, the set value is reset on switching between yaml and visual view
           if (shouldSetDefaultArtifactSource) {
-            formik?.setValues(
-              produce(formik?.values, (draft: any) => {
-                set(draft, `${path}.artifacts.primary.primaryArtifactRef`, artifactSources[0].value)
-                isEmpty(serviceInputsFormikValue) &&
-                  set(draft, `${path}.artifacts.primary.sources`, [clearRuntimeInput(idSourceMap)])
-              })
-            )
+            const updatedFormikValues = produce(formik?.values, (draft: any) => {
+              set(draft, `${path}.artifacts.primary.primaryArtifactRef`, artifactSources[0].value)
+              isEmpty(serviceInputsFormikValue) &&
+                set(draft, `${path}.artifacts.primary.sources`, [clearRuntimeInput(idSourceMap)])
+            })
+            formik?.resetForm({ ...formik, values: updatedFormikValues })
           }
           updateStageFormTemplate([idSourceMap], `${path}.artifacts.primary.sources`)
         }


### PR DESCRIPTION


### Summary

<!-- ✍️ A clear and concise description...-->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
