### PR TITLE
feat: [CI-5699]: ux callgraph

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@emotion/styled": "^10.0.27",
     "@harness/design-system": "1.0.0",
     "@harness/help-panel": "1.14.0",
-    "@harness/icons": "^1.81.0",
+    "@harness/icons": "^1.83.0",
     "@harness/monaco-yaml": "^1.0.0",
     "@harness/ng-tooltip": "^1.31.25",
     "@harness/telemetry": "^1.0.42",

--- a/src/modules/70-pipeline/pages/execution/ExecutionTestView/BuildTests.module.scss
+++ b/src/modules/70-pipeline/pages/execution/ExecutionTestView/BuildTests.module.scss
@@ -417,18 +417,8 @@
         padding-left: 28px !important;
       }
     }
-    [class*='clickable'] {
-      [role='row']:not([class*='header']) {
-        &:hover,
-        &.rowSelected {
-          background-color: transparent !important;
-          border-color: transparent !important;
-          border-bottom-color: rgba(143, 144, 166, 0.1) !important;
-        }
-      }
-    }
   }
-  &.isUngroupedList {
+  &.ungroupedList {
     [class*='testSuiteTable'] {
       margin-left: var(--spacing-xxxlarge) !important;
       box-shadow: 0px 0px 1px rgba(40, 41, 61, 0.04), 0px 2px 4px rgba(96, 97, 112, 0.16);

--- a/src/modules/70-pipeline/pages/execution/ExecutionTestView/BuildTests.module.scss
+++ b/src/modules/70-pipeline/pages/execution/ExecutionTestView/BuildTests.module.scss
@@ -398,6 +398,52 @@
     }
   }
 
+  [role='cell'] {
+    padding-left: var(--spacing-3) !important;
+  }
+  [role='columnheader'] {
+    padding-left: var(--spacing-3) !important;
+    color: var(--grey-600) !important;
+  }
+
+  &.groupedList {
+    margin-top: var(--spacing-4) !important;
+    [class*='testSuiteTable'] {
+      margin-top: 0 !important;
+      margin-left: var(--spacing-xlarge);
+
+      [role='row'] {
+        padding-top: var(--spacing-4) !important;
+        padding-left: 28px !important;
+      }
+    }
+    [class*='clickable'] {
+      [role='row']:not([class*='header']) {
+        &:hover,
+        &.rowSelected {
+          background-color: transparent !important;
+          border-color: transparent !important;
+          border-bottom-color: rgba(143, 144, 166, 0.1) !important;
+        }
+      }
+    }
+  }
+  &.isUngroupedList {
+    [class*='testSuiteTable'] {
+      margin-left: var(--spacing-xxxlarge) !important;
+      box-shadow: 0px 0px 1px rgba(40, 41, 61, 0.04), 0px 2px 4px rgba(96, 97, 112, 0.16);
+
+      &.clickable {
+        [role='row']:not([class*='header']) {
+          &:hover,
+          &.rowSelected {
+            background-color: var(--primary-1);
+          }
+        }
+      }
+    }
+  }
+
   .headingContainer {
     cursor: pointer;
     margin-left: -15px !important;
@@ -450,19 +496,8 @@
 
   .testSuiteTable {
     border-radius: 4px;
-    box-shadow: 0px 0px 1px rgba(40, 41, 61, 0.04), 0px 2px 4px rgba(96, 97, 112, 0.16);
     margin: var(--spacing-medium);
-    margin-left: var(--spacing-xxxlarge);
     overflow: hidden;
-
-    &.clickable {
-      [role='row']:not([class*='header']) {
-        &:hover,
-        &.rowSelected {
-          background-color: var(--primary-1);
-        }
-      }
-    }
 
     [role='row'] {
       border-bottom: 1px solid rgba(143, 144, 166, 0.1);
@@ -498,6 +533,26 @@
 
   .testSuiteName {
     word-break: break-all;
+  }
+  .classNameTitle {
+    padding-left: 22px !important;
+    padding-top: var(--spacing-4) !important;
+    margin-bottom: var(--spacing-3) !important;
+    &:hover {
+      box-shadow: none !important;
+    }
+
+    span,
+    span svg {
+      color: var(--grey-600) !important;
+    }
+
+    span[class*='bp3-button-text'] {
+      padding-left: var(--spacing-5) !important;
+    }
+  }
+  .viewCallgraph {
+    margin: var(--spacing-3) 0 !important;
   }
 }
 

--- a/src/modules/70-pipeline/pages/execution/ExecutionTestView/BuildTests.module.scss.d.ts
+++ b/src/modules/70-pipeline/pages/execution/ExecutionTestView/BuildTests.module.scss.d.ts
@@ -42,7 +42,6 @@ declare const styles: {
   readonly header: string
   readonly headingContainer: string
   readonly indirect: string
-  readonly isUngroupedList: string
   readonly leftContainer: string
   readonly line: string
   readonly linesWrapper: string
@@ -97,6 +96,7 @@ declare const styles: {
   readonly timeSaved: string
   readonly type: string
   readonly unchanged: string
+  readonly ungroupedList: string
   readonly upgradeRequiredWrapper: string
   readonly viewCallgraph: string
   readonly widget: string

--- a/src/modules/70-pipeline/pages/execution/ExecutionTestView/BuildTests.module.scss.d.ts
+++ b/src/modules/70-pipeline/pages/execution/ExecutionTestView/BuildTests.module.scss.d.ts
@@ -16,6 +16,7 @@ declare const styles: {
   readonly callgraphModal: string
   readonly callgraphTooltip: string
   readonly changed: string
+  readonly classNameTitle: string
   readonly clickable: string
   readonly columnNames: string
   readonly commitHash: string
@@ -37,9 +38,11 @@ declare const styles: {
   readonly graphLabel: string
   readonly graphTitle: string
   readonly graphWrapper: string
+  readonly groupedList: string
   readonly header: string
   readonly headingContainer: string
   readonly indirect: string
+  readonly isUngroupedList: string
   readonly leftContainer: string
   readonly line: string
   readonly linesWrapper: string

--- a/src/modules/70-pipeline/pages/execution/ExecutionTestView/TestsExecution.tsx
+++ b/src/modules/70-pipeline/pages/execution/ExecutionTestView/TestsExecution.tsx
@@ -100,7 +100,7 @@ export function TestsExecution({
   const context = useExecutionContext()
   const { getString } = useStrings()
   const status = (context?.pipelineExecutionDetail?.pipelineExecutionSummary?.status || '').toUpperCase()
-  const [showAllTests, setShowAllTests] = useState(false)
+  const [showAllTests, setShowAllTests] = useState(true) //!change before merge
   const [showGroupedView, setShowGroupedView] = useState(true)
   const [expandedIndex, setExpandedIndex] = useState<number | undefined>(0)
   const { accountId, orgIdentifier, projectIdentifier } = useParams<{
@@ -504,6 +504,18 @@ export function TestsExecution({
                         onShowCallGraphForClass={showCallGraph ? onClassSelected : undefined}
                         isUngroupedList={false}
                         testCaseSearchTerm={testCaseSearchTerm}
+                        refetchCallgraph={className => {
+                          fetchCallGraph({
+                            queryParams: Object.assign(
+                              {},
+                              omit(queryParams, ['report', 'pageIndex', 'sort', 'pageSize', 'order']),
+                              {
+                                limit: CALL_GRAPH_API_LIMIT,
+                                class: className
+                              }
+                            )
+                          })
+                        }}
                       />
                     ))
                   ) : (

--- a/src/modules/70-pipeline/pages/execution/ExecutionTestView/TestsUtils.tsx
+++ b/src/modules/70-pipeline/pages/execution/ExecutionTestView/TestsUtils.tsx
@@ -5,11 +5,12 @@
  * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
  */
 
-import type { SetStateAction, Dispatch } from 'react'
+import React, { SetStateAction, Dispatch } from 'react'
 import type { GetDataError } from 'restful-react'
 import type { SelectOption } from '@harness/uicore'
 import { uniqWith, isEqual, orderBy } from 'lodash-es'
-import type { StepInfo, Error } from 'services/ti-service'
+import ExecutionStatusLabel from '@pipeline/components/ExecutionStatusLabel/ExecutionStatusLabel'
+import type { StepInfo, Error, TestCase, TestCaseStatus } from 'services/ti-service'
 import type { GraphLayoutNode, ExecutionNode } from 'services/pipeline-ng'
 
 export const StepTypes = {
@@ -329,3 +330,42 @@ export const getError = ({
   (testInfoData && testInfoData?.length > 0 && testOverviewError) ||
   reportInfoError ||
   testInfoError
+
+interface ClassNameSplitData {
+  [key: string]: TestCase[]
+}
+
+export const getClassNameSplitData = (testCases?: TestCase[]): ClassNameSplitData[] => {
+  const classNameSplitData: ClassNameSplitData[] = []
+  testCases?.forEach(d => {
+    if (typeof d?.class_name !== 'undefined') {
+      const matchIndex = classNameSplitData.findIndex(cnsd => Object.keys(cnsd).includes(d.class_name!))
+      if (matchIndex && matchIndex > -1) {
+        classNameSplitData[matchIndex][d.class_name].push(d)
+      } else {
+        classNameSplitData.push({ [d.class_name]: [d] })
+      }
+    }
+  })
+
+  return classNameSplitData
+}
+
+export const renderResult = (status?: TestCaseStatus): JSX.Element | string => {
+  if (!status) {
+    return ''
+  }
+
+  const failed = ['error', 'failed'].includes(status)
+  const success = ['passed'].includes(status)
+  const skipped = ['skipped'].includes(status)
+
+  if (failed) {
+    return <ExecutionStatusLabel status={'Failed'} />
+  } else if (success) {
+    return <ExecutionStatusLabel status={'Success'} />
+  } else if (skipped) {
+    return <ExecutionStatusLabel status={'Skipped'} />
+  }
+  return ''
+}

--- a/src/modules/70-pipeline/pages/execution/ExecutionTestView/TestsUtils.tsx
+++ b/src/modules/70-pipeline/pages/execution/ExecutionTestView/TestsUtils.tsx
@@ -340,7 +340,7 @@ export const getClassNameSplitData = (testCases?: TestCase[]): ClassNameSplitDat
   testCases?.forEach(d => {
     if (typeof d?.class_name !== 'undefined') {
       const matchIndex = classNameSplitData.findIndex(cnsd => Object.keys(cnsd).includes(d.class_name!))
-      if (matchIndex && matchIndex > -1) {
+      if (typeof matchIndex === 'number' && matchIndex > -1) {
         classNameSplitData[matchIndex][d.class_name].push(d)
       } else {
         classNameSplitData.push({ [d.class_name]: [d] })

--- a/src/modules/70-pipeline/strings/strings.en.yaml
+++ b/src/modules/70-pipeline/strings/strings.en.yaml
@@ -699,7 +699,7 @@ testsReports:
     params: Params
     file: '{{ $.common.file }}'
     type: '{{ $.typeLabel }}'
-  viewCallgraph: View Callgraph
+  viewCallgraph: View Call Graph
   testMethods: Test methods
   changedTestMethods: Changed/New Test methods
   changedSourceMethods: Changed/New Source methods
@@ -735,7 +735,7 @@ testsReports:
   consoleOutput: Console Output
   testSuite: 'Test Suite:'
   totalTests: Total Tests
-  testCaseName: Test Name
+  testCaseName: Test Case Name
   className: Class Name
   result: RESULT
   testCasesExecution: Tests Execution

--- a/yarn.lock
+++ b/yarn.lock
@@ -1771,10 +1771,10 @@
     "@contentful/rich-text-react-renderer" "^15.12.0"
     contentful "^9.1.20"
 
-"@harness/icons@^1.81.0":
-  version "1.81.0"
-  resolved "https://npm.pkg.github.com/download/@harness/icons/1.81.0/6d940ce9161694dfa630d74dc7d9325e6e1bcbe7#6d940ce9161694dfa630d74dc7d9325e6e1bcbe7"
-  integrity sha512-rmRtr3MW6Zot2Y2RIxnd+5BHJzg2xyi5yGTJbPbYYXgkIr7SFdZDNdaTBEg77nLbyz23Zrx3s9rDUXoNRbseJQ==
+"@harness/icons@^1.83.0":
+  version "1.83.0"
+  resolved "https://npm.pkg.github.com/download/@harness/icons/1.83.0/bd2118cab4c2ee72ab4934d99619c52218e0119a#bd2118cab4c2ee72ab4934d99619c52218e0119a"
+  integrity sha512-7Sb62DECJJ7l6XZYBu2xuOY3CCp0THhPAyEnBvYP9Dk2t+j0Lh7nFWCV5y9GBq62CfmIDBvaUeCiWFLlkh+tGg==
 
 "@harness/jarvis@0.16.0":
   version "0.16.0"


### PR DESCRIPTION
### Summary

<!-- ✍️ A clear and concise description...-->
Style in this PR is correct. Pending PM decision on whether this change is needed. If so, then we'll also need to upgrade the test cases api so that we can get them split by class_names and have pagination working as expected. Then we should also get the data from the api instead of having UI split by class_name
#### Screenshots
<img width="1664" alt="image" src="https://user-images.githubusercontent.com/43422351/202318841-65967915-8fc1-4468-baff-1be39a47082a.png">

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
