### PR TITLE
fix: [PIE-6461]: Handled type error for the API prop

### DIFF
--- a/src/modules/10-common/components/RepoFilter/RepoFilter.tsx
+++ b/src/modules/10-common/components/RepoFilter/RepoFilter.tsx
@@ -79,22 +79,22 @@ export function RepoFilter({
   }, [selectedScope, accountId, orgIdentifier, projectIdentifier])
 
   const {
-    data: repoListOfPipelines,
-    error: ErrorForPipelines,
-    loading: loadingForPipelines,
-    refetch: refetchRepoForPipelines
+    data: repoListOfPipeline,
+    error: errorForPipeline,
+    loading: loadingForPipeline,
+    refetch: refetchRepoForPipeline
   } = useGetRepositoryList({
     queryParams: {
       accountIdentifier: accountId,
       orgIdentifier,
       projectIdentifier
     },
-    lazy: isPipelinePage
+    lazy: !isPipelinePage
   })
 
   const {
     data: repoListOfExecutions,
-    error: ErrorForExecutions,
+    error: errorForExecution,
     loading: loadingForExecutions,
     refetch: refetchRepoForExecutions
   } = useGetExecutionRepositoriesList({
@@ -103,42 +103,42 @@ export function RepoFilter({
       orgIdentifier,
       projectIdentifier
     },
-    lazy: isExecutionsPage
+    lazy: !isExecutionsPage
   })
 
   const {
-    data: repoListOfTemplates,
-    error: ErrorForTemplates,
-    loading: loadingForTemplates,
-    refetch: refetchRepoForTemplates
+    data: repoListOfTemplate,
+    error: errorForTemplate,
+    loading: loadingForTemplate,
+    refetch: refetchRepoForTemplate
   } = getRepoListForTemplate({
     queryParams: queryParamsForTemplate,
-    lazy: isTemplatesPage
+    lazy: !isTemplatesPage
   })
 
   const onRefetch = React.useCallback((): void => {
-    if (isPipelinePage) refetchRepoForPipelines()
+    if (isPipelinePage) refetchRepoForPipeline()
     else if (isExecutionsPage) refetchRepoForExecutions()
-    else refetchRepoForTemplates()
-  }, [isExecutionsPage, isPipelinePage, refetchRepoForExecutions, refetchRepoForPipelines, refetchRepoForTemplates])
+    else refetchRepoForTemplate()
+  }, [isExecutionsPage, isPipelinePage, refetchRepoForExecutions, refetchRepoForPipeline, refetchRepoForTemplate])
 
   const repositories = useMemo(() => {
-    if (isPipelinePage) return repoListOfPipelines?.data?.repositories
+    if (isPipelinePage) return repoListOfPipeline?.data?.repositories
     else if (isExecutionsPage) return repoListOfExecutions?.data?.repositories
-    return repoListOfTemplates?.data?.repositories
-  }, [isExecutionsPage, isPipelinePage, repoListOfExecutions, repoListOfPipelines, repoListOfTemplates])
+    return repoListOfTemplate?.data?.repositories
+  }, [isExecutionsPage, isPipelinePage, repoListOfExecutions, repoListOfPipeline, repoListOfTemplate])
 
   const isLoading = useMemo((): boolean => {
-    if (isPipelinePage) return loadingForPipelines
+    if (isPipelinePage) return loadingForPipeline
     else if (isExecutionsPage) return loadingForExecutions
-    return loadingForTemplates
-  }, [isExecutionsPage, isPipelinePage, loadingForExecutions, loadingForPipelines, loadingForTemplates])
+    return loadingForTemplate
+  }, [isExecutionsPage, isPipelinePage, loadingForExecutions, loadingForPipeline, loadingForTemplate])
 
   const error = useMemo(() => {
-    if (isPipelinePage) return ErrorForPipelines
-    else if (isExecutionsPage) return ErrorForExecutions
-    return ErrorForTemplates
-  }, [ErrorForExecutions, ErrorForPipelines, ErrorForTemplates, isExecutionsPage, isPipelinePage])
+    if (isPipelinePage) return errorForPipeline
+    else if (isExecutionsPage) return errorForExecution
+    return errorForTemplate
+  }, [errorForExecution, errorForPipeline, errorForTemplate, isExecutionsPage, isPipelinePage])
 
   const dropDownItems = React.useMemo(
     () =>

--- a/src/modules/10-common/components/RepoFilter/RepoFilter.tsx
+++ b/src/modules/10-common/components/RepoFilter/RepoFilter.tsx
@@ -5,7 +5,7 @@
  * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
  */
 
-import React, { useEffect, useMemo } from 'react'
+import React, { useMemo } from 'react'
 import { Container, DropDown, Icon, Layout, SelectOption } from '@harness/uicore'
 import { Color } from '@harness/design-system'
 import { defaultTo, isEmpty } from 'lodash-es'
@@ -29,6 +29,7 @@ export interface RepoFilterProps {
   selectedScope?: string
   isPipelinePage?: boolean
   isExecutionsPage?: boolean
+  isTemplatesPage?: boolean
 }
 
 export function RepoFilter({
@@ -37,6 +38,7 @@ export function RepoFilter({
   showBranchFilter,
   isPipelinePage = false,
   isExecutionsPage = false,
+  isTemplatesPage = false,
   onBranchChange,
   selectedBranch,
   selectedScope
@@ -69,6 +71,11 @@ export function RepoFilter({
           projectIdentifier
         }
     }
+    return {
+      accountIdentifier: accountId,
+      orgIdentifier,
+      projectIdentifier
+    }
   }, [selectedScope, accountId, orgIdentifier, projectIdentifier])
 
   const {
@@ -82,7 +89,7 @@ export function RepoFilter({
       orgIdentifier,
       projectIdentifier
     },
-    lazy: true
+    lazy: isPipelinePage
   })
 
   const {
@@ -96,7 +103,7 @@ export function RepoFilter({
       orgIdentifier,
       projectIdentifier
     },
-    lazy: true
+    lazy: isExecutionsPage
   })
 
   const {
@@ -106,14 +113,8 @@ export function RepoFilter({
     refetch: refetchRepoForTemplates
   } = getRepoListForTemplate({
     queryParams: queryParamsForTemplate,
-    lazy: true
+    lazy: isTemplatesPage
   })
-
-  useEffect(() => {
-    if (isPipelinePage) refetchRepoForPipelines()
-    else if (isExecutionsPage) refetchRepoForExecutions()
-    else refetchRepoForTemplates()
-  }, [isExecutionsPage, isPipelinePage, refetchRepoForExecutions, refetchRepoForPipelines, refetchRepoForTemplates])
 
   const onRefetch = React.useCallback((): void => {
     if (isPipelinePage) refetchRepoForPipelines()

--- a/src/modules/10-common/components/RepoFilter/__tests__/RepoFilter.test.tsx
+++ b/src/modules/10-common/components/RepoFilter/__tests__/RepoFilter.test.tsx
@@ -59,7 +59,7 @@ jest.mock('services/pipeline-ng', () => {
 const renderPipelinesListPage = (module = 'cd'): RenderResult =>
   render(
     <TestWrapper path={TEST_PATH} pathParams={getModuleParams(module)}>
-      <RepoFilter getRepoListPromise={useGetRepositoryList} />
+      <RepoFilter />
     </TestWrapper>
   )
 
@@ -99,7 +99,7 @@ describe('Repo Filter test', () => {
 
     const { container } = render(
       <TestWrapper path={TEST_PATH} pathParams={getModuleParams('cd')}>
-        <RepoFilter getRepoListPromise={useGetRepositoryList} />
+        <RepoFilter />
       </TestWrapper>
     )
 
@@ -113,7 +113,7 @@ describe('Repo Filter test', () => {
     const repoChangeHandler = jest.fn()
     const { container, getByText } = render(
       <TestWrapper path={TEST_PATH} pathParams={getModuleParams('cd')}>
-        <RepoFilter getRepoListPromise={useGetRepositoryList} onChange={repoChangeHandler} />
+        <RepoFilter onChange={repoChangeHandler} />
       </TestWrapper>
     )
 
@@ -137,7 +137,7 @@ describe('Repo Filter test', () => {
   test('Branch Filter render test in deplyments page', async () => {
     const { container, getByText } = render(
       <TestWrapper path={TEST_PATH} pathParams={getModuleParams('cd')}>
-        <RepoFilter getRepoListPromise={useGetRepositoryList} showBranchFilter={true} />
+        <RepoFilter showBranchFilter={true} />
       </TestWrapper>
     )
 
@@ -151,12 +151,7 @@ describe('Repo Filter test', () => {
     const branchChangeHandler = jest.fn()
     render(
       <TestWrapper path={TEST_PATH} pathParams={getModuleParams('cd')}>
-        <RepoFilter
-          getRepoListPromise={useGetRepositoryList}
-          value={'main'}
-          showBranchFilter={true}
-          onBranchChange={branchChangeHandler}
-        />
+        <RepoFilter value={'main'} showBranchFilter={true} onBranchChange={branchChangeHandler} />
       </TestWrapper>
     )
     expect(useGetExecutionBranchesList).toBeCalled()
@@ -179,7 +174,7 @@ describe('Repo Filter test', () => {
 
     const { container } = render(
       <TestWrapper path={TEST_PATH} pathParams={getModuleParams('cd')}>
-        <RepoFilter getRepoListPromise={useGetRepositoryList} value={'main'} showBranchFilter={true} />
+        <RepoFilter value={'main'} showBranchFilter={true} />
       </TestWrapper>
     )
 

--- a/src/modules/10-common/components/RepoFilter/__tests__/RepoFilter.test.tsx
+++ b/src/modules/10-common/components/RepoFilter/__tests__/RepoFilter.test.tsx
@@ -80,7 +80,7 @@ const renderPipelinesListPage = (module = 'cd'): RenderResult =>
 
 describe('Repo Filter test', () => {
   test('should render filter dropdown', async () => {
-    const { getByText } = renderPipelinesListPage()
+    const { getByText, container } = renderPipelinesListPage()
     expect(useGetRepositoryList).toHaveBeenLastCalledWith(
       expect.objectContaining({
         queryParams: {
@@ -91,6 +91,12 @@ describe('Repo Filter test', () => {
       })
     )
     expect(getByText('common.selectRepository')).toBeInTheDocument()
+    const dropdown = container.querySelector('[data-icon="main-chevron-down"]') as HTMLInputElement
+
+    fireEvent.click(dropdown)
+    await waitFor(() => {
+      expect(getByText('main')).toBeInTheDocument()
+    })
 
     render(
       <TestWrapper path={TEST_PATH} pathParams={getModuleParams('cd')}>
@@ -98,12 +104,24 @@ describe('Repo Filter test', () => {
       </TestWrapper>
     )
     expect(useGetExecutionRepositoriesList).toBeCalled()
+    const dropdown1 = container.querySelector('[data-icon="main-chevron-down"]') as HTMLInputElement
+
+    fireEvent.click(dropdown1)
+    await waitFor(() => {
+      expect(getByText('main-patch')).toBeInTheDocument()
+    })
     render(
       <TestWrapper path={TEST_PATH} pathParams={getModuleParams('cd')}>
         <RepoFilter isTemplatesPage />
       </TestWrapper>
     )
     expect(getRepoListForTemplate).toBeCalled()
+    const dropdown2 = container.querySelector('[data-icon="main-chevron-down"]') as HTMLInputElement
+
+    fireEvent.click(dropdown2)
+    await waitFor(() => {
+      expect(getByText('main-patch1')).toBeInTheDocument()
+    })
   })
 
   test('default rendering RepoFilter - loading true', async () => {

--- a/src/modules/70-pipeline/pages/execution-list-page/__tests__/ExecutionListPage.test.tsx
+++ b/src/modules/70-pipeline/pages/execution-list-page/__tests__/ExecutionListPage.test.tsx
@@ -10,7 +10,7 @@ import { render, screen, waitForElementToBeRemoved } from '@testing-library/reac
 import { TestWrapper } from '@common/utils/testUtils'
 import routes from '@common/RouteDefinitions'
 import { branchStatusMock, gitConfigs, sourceCodeManagers } from '@connectors/mocks/mock'
-import { useGetExecutionRepositoriesList, useGetListOfExecutions } from 'services/pipeline-ng'
+import { useGetListOfExecutions } from 'services/pipeline-ng'
 import filters from '@pipeline/pages/execution-list/__tests__/mocks/filters.json'
 import services from '@pipeline/pages/pipeline-list/__tests__/mocks/services.json'
 import environments from '@pipeline/pages/pipeline-list/__tests__/mocks/environments.json'
@@ -135,7 +135,6 @@ describe('ExecutionListPage', () => {
         <ExecutionListPage />
       </TestWrapper>
     )
-    expect(useGetExecutionRepositoriesList).toBeCalled()
 
     await waitForElementToBeRemoved(() => screen.getByText('Loading, please wait...'))
     const noRunsLabel = await screen.findByText('pipeline.noRunsText')
@@ -151,7 +150,6 @@ describe('ExecutionListPage', () => {
         <ExecutionListPage />
       </TestWrapper>
     )
-    expect(useGetExecutionRepositoriesList).toBeCalled()
     await waitForElementToBeRemoved(() => screen.getByText('Loading, please wait...'))
     const noRunsText = await screen.findByText('pipeline.noRunsText')
     expect(noRunsText).toBeInTheDocument()
@@ -166,7 +164,6 @@ describe('ExecutionListPage', () => {
         <ExecutionListPage />
       </TestWrapper>
     )
-    expect(useGetExecutionRepositoriesList).toBeCalled()
 
     await waitForElementToBeRemoved(() => screen.getByText('Loading, please wait...'))
     const noScansText = await screen.findByText('pipeline.noRunsText')

--- a/src/modules/70-pipeline/pages/execution-list-page/__tests__/ExecutionListPage.test.tsx
+++ b/src/modules/70-pipeline/pages/execution-list-page/__tests__/ExecutionListPage.test.tsx
@@ -56,6 +56,9 @@ jest.mock('services/pipeline-ng', () => ({
   useGetExecutionRepositoriesList: jest.fn().mockImplementation(() => {
     return { data: mockRepositories, refetch: fetchRepositories, error: null, loading: false }
   }),
+  useGetRepositoryList: jest.fn().mockImplementation(() => {
+    return { data: mockRepositories, refetch: fetchRepositories, error: null, loading: false }
+  }),
   useGetExecutionBranchesList: jest.fn().mockImplementation(() => {
     return { data: mockBranches, refetch: fetchBranches, error: null, loading: false }
   }),
@@ -149,7 +152,6 @@ describe('ExecutionListPage', () => {
       </TestWrapper>
     )
     expect(useGetExecutionRepositoriesList).toBeCalled()
-
     await waitForElementToBeRemoved(() => screen.getByText('Loading, please wait...'))
     const noRunsText = await screen.findByText('pipeline.noRunsText')
     expect(noRunsText).toBeInTheDocument()

--- a/src/modules/70-pipeline/pages/execution-list/ExecutionListSubHeader/ExecutionListSubHeader.tsx
+++ b/src/modules/70-pipeline/pages/execution-list/ExecutionListSubHeader/ExecutionListSubHeader.tsx
@@ -19,7 +19,6 @@ import { getFeaturePropsForRunPipelineButton, getRbacButtonModules } from '@pipe
 import { useBooleanStatus, useQueryParams, useUpdateQueryParams } from '@common/hooks'
 import { Page } from '@common/exports'
 import type { ExecutionStatus } from '@pipeline/utils/statusHelpers'
-import { GetListOfExecutionsQueryParams, useGetExecutionRepositoriesList } from 'services/pipeline-ng'
 import RbacButton from '@rbac/components/Button/Button'
 import { ResourceType } from '@rbac/interfaces/ResourceType'
 import { PermissionIdentifier } from '@rbac/interfaces/PermissionIdentifier'
@@ -30,6 +29,7 @@ import { DEFAULT_PAGE_INDEX } from '@pipeline/utils/constants'
 import { useAppStore } from 'framework/AppStore/AppStoreContext'
 import { StoreType } from '@common/constants/GitSyncTypes'
 import RepoFilter from '@common/components/RepoFilter/RepoFilter'
+import type { GetListOfExecutionsQueryParams } from 'services/pipeline-ng'
 import { useExecutionListFilterContext } from '../ExecutionListFilterContext/ExecutionListFilterContext'
 import { ExecutionListFilter } from '../ExecutionListFilter/ExecutionListFilter'
 import type { ExecutionListProps } from '../ExecutionList'
@@ -186,7 +186,6 @@ export function ExecutionListSubHeader(
 
         {props.showRepoBranchFilter && !isGitSyncEnabled && (
           <RepoFilter
-            getRepoListPromise={useGetExecutionRepositoriesList}
             onChange={props.onChangeRepo}
             value={props.repoName}
             showBranchFilter={props.showRepoBranchFilter}
@@ -194,6 +193,7 @@ export function ExecutionListSubHeader(
               onBranchChange(selected.value as string)
             }}
             selectedBranch={selectedBranch}
+            isExecutionsPage={true}
           />
         )}
       </div>

--- a/src/modules/70-pipeline/pages/execution-list/ExecutionListSubHeader/ExecutionListSubHeader.tsx
+++ b/src/modules/70-pipeline/pages/execution-list/ExecutionListSubHeader/ExecutionListSubHeader.tsx
@@ -193,7 +193,7 @@ export function ExecutionListSubHeader(
               onBranchChange(selected.value as string)
             }}
             selectedBranch={selectedBranch}
-            isExecutionsPage={true}
+            isExecutionsPage
           />
         )}
       </div>

--- a/src/modules/70-pipeline/pages/execution-list/__tests__/ExecutionList.test.tsx
+++ b/src/modules/70-pipeline/pages/execution-list/__tests__/ExecutionList.test.tsx
@@ -21,7 +21,7 @@ import pipelineList from '@pipeline/pages/execution-list/__tests__/mocks/pipelin
 import deploymentTypes from '@pipeline/pages/pipeline-list/__tests__/mocks/deploymentTypes.json'
 import environments from '@pipeline/pages/pipeline-list/__tests__/mocks/environments.json'
 import services from '@pipeline/pages/pipeline-list/__tests__/mocks/services.json'
-import { useGetExecutionData, useGetListOfExecutions } from 'services/pipeline-ng'
+import { useGetExecutionData, useGetListOfExecutions, useGetExecutionRepositoriesList } from 'services/pipeline-ng'
 import { ExecutionList } from '../ExecutionList'
 
 jest.mock('@common/components/YAMLBuilder/YamlBuilder')
@@ -65,6 +65,9 @@ jest.mock('services/pipeline-ng', () => ({
     cancel: jest.fn()
   })),
   useGetExecutionRepositoriesList: jest.fn().mockImplementation(() => {
+    return { data: mockRepositories, refetch: fetchRepositories, error: null, loading: false }
+  }),
+  useGetRepositoryList: jest.fn().mockImplementation(() => {
     return { data: mockRepositories, refetch: fetchRepositories, error: null, loading: false }
   }),
   useGetPipelineList: jest.fn().mockImplementation(args => {
@@ -182,10 +185,9 @@ describe('Execution List', () => {
 
   test('should have relevant navigation links for CD execution', async () => {
     renderExecutionPage()
-
     const rows = await screen.findAllByRole('row')
     const cdExecutionRow = rows[4]
-
+    expect(useGetExecutionRepositoriesList).toBeCalled()
     // should navigate to execution details as primary link
     expect(
       within(cdExecutionRow).getByRole('link', {

--- a/src/modules/70-pipeline/pages/execution-list/__tests__/ExecutionList.test.tsx
+++ b/src/modules/70-pipeline/pages/execution-list/__tests__/ExecutionList.test.tsx
@@ -21,7 +21,7 @@ import pipelineList from '@pipeline/pages/execution-list/__tests__/mocks/pipelin
 import deploymentTypes from '@pipeline/pages/pipeline-list/__tests__/mocks/deploymentTypes.json'
 import environments from '@pipeline/pages/pipeline-list/__tests__/mocks/environments.json'
 import services from '@pipeline/pages/pipeline-list/__tests__/mocks/services.json'
-import { useGetExecutionData, useGetListOfExecutions, useGetExecutionRepositoriesList } from 'services/pipeline-ng'
+import { useGetExecutionData, useGetListOfExecutions } from 'services/pipeline-ng'
 import { ExecutionList } from '../ExecutionList'
 
 jest.mock('@common/components/YAMLBuilder/YamlBuilder')
@@ -187,7 +187,7 @@ describe('Execution List', () => {
     renderExecutionPage()
     const rows = await screen.findAllByRole('row')
     const cdExecutionRow = rows[4]
-    expect(useGetExecutionRepositoriesList).toBeCalled()
+
     // should navigate to execution details as primary link
     expect(
       within(cdExecutionRow).getByRole('link', {

--- a/src/modules/70-pipeline/pages/pipeline-list/PipelineListPage.tsx
+++ b/src/modules/70-pipeline/pages/pipeline-list/PipelineListPage.tsx
@@ -264,7 +264,7 @@ export function PipelineListPage(): React.ReactElement {
               }}
             />
           ) : (
-            <RepoFilter onChange={onChangeRepo} value={repoName} isPipelinePage={true} />
+            <RepoFilter onChange={onChangeRepo} value={repoName} isPipelinePage />
           )}
         </Layout.Horizontal>
         <Layout.Horizontal style={{ alignItems: 'center' }}>

--- a/src/modules/70-pipeline/pages/pipeline-list/PipelineListPage.tsx
+++ b/src/modules/70-pipeline/pages/pipeline-list/PipelineListPage.tsx
@@ -39,7 +39,6 @@ import {
   PipelineFilterProperties,
   PMSPipelineSummaryResponse,
   useGetPipelineList,
-  useGetRepositoryList,
   useSoftDeletePipeline
 } from 'services/pipeline-ng'
 import { DEFAULT_PIPELINE_LIST_TABLE_SORT, DEFAULT_PAGE_INDEX, DEFAULT_PAGE_SIZE } from '@pipeline/utils/constants'
@@ -265,7 +264,7 @@ export function PipelineListPage(): React.ReactElement {
               }}
             />
           ) : (
-            <RepoFilter onChange={onChangeRepo} value={repoName} getRepoListPromise={useGetRepositoryList} />
+            <RepoFilter onChange={onChangeRepo} value={repoName} isPipelinePage={true} />
           )}
         </Layout.Horizontal>
         <Layout.Horizontal style={{ alignItems: 'center' }}>

--- a/src/modules/70-pipeline/pages/pipeline-list/__tests__/PipelineListPage.test.tsx
+++ b/src/modules/70-pipeline/pages/pipeline-list/__tests__/PipelineListPage.test.tsx
@@ -14,7 +14,7 @@ import { defaultAppStoreValues } from '@common/utils/DefaultAppStoreData'
 import routes from '@common/RouteDefinitions'
 import { projectPathProps, accountPathProps, pipelineModuleParams } from '@common/utils/routeUtils'
 import { branchStatusMock, sourceCodeManagers } from '@connectors/mocks/mock'
-import { useGetPipelineList, useGetRepositoryList } from 'services/pipeline-ng'
+import { useGetPipelineList } from 'services/pipeline-ng'
 import { PipelineListPage } from '../PipelineListPage'
 import filters from './mocks/filters.json'
 import deploymentTypes from './mocks/deploymentTypes.json'
@@ -127,7 +127,6 @@ const renderPipelinesListPage = (module = 'cd'): RenderResult =>
 describe('CD Pipeline List Page', () => {
   test('should render pipeline table and able to go to a pipeline', async () => {
     renderPipelinesListPage()
-    expect(useGetRepositoryList).toBeCalled()
 
     const rows = await screen.findAllByRole('row')
     const pipelineRow = rows[1]
@@ -169,7 +168,6 @@ describe('CD Pipeline List Page', () => {
     })
 
     renderPipelinesListPage()
-    expect(useGetRepositoryList).toBeCalled()
 
     const refresh = await screen.findByRole('button', {
       name: /refresh/i
@@ -181,7 +179,6 @@ describe('CD Pipeline List Page', () => {
 
   test('should be able to add a new pipeline with identifier as "-1"', async () => {
     renderPipelinesListPage()
-    expect(useGetRepositoryList).toBeCalled()
     const addPipeline = await screen.findByTestId('add-pipeline')
     userEvent.click(addPipeline)
     const location = await screen.findByTestId('location')
@@ -192,7 +189,6 @@ describe('CD Pipeline List Page', () => {
 
   test('should be able to run pipeline from menu', async () => {
     renderPipelinesListPage()
-    expect(useGetRepositoryList).toBeCalled()
     const row = await screen.findAllByRole('row')
     const moreOptions = within(row[1]).getByRole('button', {
       name: /pipeline menu actions/i
@@ -206,7 +202,6 @@ describe('CD Pipeline List Page', () => {
 
   test('should be able to view pipeline from menu', async () => {
     renderPipelinesListPage()
-    expect(useGetRepositoryList).toBeCalled()
     const row = await screen.findAllByRole('row')
     const moreOptions = within(row[1]).getByRole('button', {
       name: /pipeline menu actions/i
@@ -229,7 +224,6 @@ describe('CD Pipeline List Page', () => {
 
   test('should be able delete pipeline from the menu', async () => {
     renderPipelinesListPage()
-    expect(useGetRepositoryList).toBeCalled()
     const row = await screen.findAllByRole('row')
     const moreOptions = within(row[1]).getByRole('button', {
       name: /pipeline menu actions/i
@@ -259,7 +253,6 @@ describe('CD Pipeline List Page', () => {
     })
 
     renderPipelinesListPage()
-    expect(useGetRepositoryList).toBeCalled()
     expect(await screen.findByText('NG Docker Image')).toBeInTheDocument()
     mutateListOfPipelines.mockReset()
     userEvent.type(screen.getByRole('searchbox'), 'asd')
@@ -292,7 +285,6 @@ describe('CI Pipeline List Page', () => {
     })
 
     renderPipelinesListPage('ci')
-    expect(useGetRepositoryList).toBeCalled()
     const rows = await screen.findAllByRole('row')
     const pipelineRow = rows[1]
     expect(
@@ -337,7 +329,6 @@ describe('CI Pipeline List Page', () => {
     })
 
     renderPipelinesListPage('ci')
-    expect(useGetRepositoryList).toBeCalled()
     const rows = await screen.findAllByRole('row')
     const webhookPipeline = rows[7]
     const cronPipeline = rows[8]
@@ -383,7 +374,6 @@ describe('Pipeline List Page with git details', () => {
     })
 
     renderPipelinesListPage('ci')
-    expect(useGetRepositoryList).toBeCalled()
     const rows = await screen.findAllByRole('row')
     const remotePipeline = rows[6]
     expect(

--- a/src/modules/70-pipeline/pages/pipeline-list/__tests__/PipelineListPage.test.tsx
+++ b/src/modules/70-pipeline/pages/pipeline-list/__tests__/PipelineListPage.test.tsx
@@ -67,6 +67,9 @@ jest.mock('services/pipeline-ng', () => {
     useGetRepositoryList: jest.fn().mockImplementation(() => {
       return { data: mockRepositories, refetch: fetchRepositories, error: null, loading: false }
     }),
+    useGetExecutionRepositoriesList: jest.fn().mockImplementation(() => {
+      return { data: mockRepositories, refetch: fetchRepositories, error: null, loading: false }
+    }),
     useSoftDeletePipeline: jest.fn(() => ({ mutate: deletePipeline, loading: false })),
     useGetFilterList: jest.fn(() => ({ mutate: jest.fn().mockResolvedValue(filters), loading: false })),
     usePostFilter: mockMutate,

--- a/src/modules/72-templates-library/components/TemplateSelector/TemplateSelectorLeftView/TemplateSelectorLeftView.tsx
+++ b/src/modules/72-templates-library/components/TemplateSelector/TemplateSelectorLeftView/TemplateSelectorLeftView.tsx
@@ -230,7 +230,7 @@ export const TemplateSelectorLeftView: React.FC<TemplateSelectorLeftViewProps> =
                     value={selectedRepo}
                     onChange={repoName => setSelectedRepo(repoName)}
                     selectedScope={selectedScope.value.toString()}
-                    isTemplatesPage={true}
+                    isTemplatesPage
                   />
                 )}
                 <ExpandingSearchInput

--- a/src/modules/72-templates-library/components/TemplateSelector/TemplateSelectorLeftView/TemplateSelectorLeftView.tsx
+++ b/src/modules/72-templates-library/components/TemplateSelector/TemplateSelectorLeftView/TemplateSelectorLeftView.tsx
@@ -23,12 +23,7 @@ import { defaultTo } from 'lodash-es'
 import { useParams } from 'react-router-dom'
 import { Breadcrumbs } from '@common/components/Breadcrumbs/Breadcrumbs'
 import type { ModulePathParams, ProjectPathProps } from '@common/interfaces/RouteInterfaces'
-import {
-  TemplateSummaryResponse,
-  useGetRepositoryList,
-  useGetTemplateList,
-  useGetTemplateMetadataList
-} from 'services/template-ng'
+import { TemplateSummaryResponse, useGetTemplateList, useGetTemplateMetadataList } from 'services/template-ng'
 import { useStrings } from 'framework/strings'
 import { PageSpinner } from '@common/components'
 import { useMutateAsGet } from '@common/hooks'
@@ -234,7 +229,6 @@ export const TemplateSelectorLeftView: React.FC<TemplateSelectorLeftViewProps> =
                   <RepoFilter
                     value={selectedRepo}
                     onChange={repoName => setSelectedRepo(repoName)}
-                    getRepoListPromise={useGetRepositoryList}
                     selectedScope={selectedScope.value.toString()}
                   />
                 )}

--- a/src/modules/72-templates-library/components/TemplateSelector/TemplateSelectorLeftView/TemplateSelectorLeftView.tsx
+++ b/src/modules/72-templates-library/components/TemplateSelector/TemplateSelectorLeftView/TemplateSelectorLeftView.tsx
@@ -230,6 +230,7 @@ export const TemplateSelectorLeftView: React.FC<TemplateSelectorLeftViewProps> =
                     value={selectedRepo}
                     onChange={repoName => setSelectedRepo(repoName)}
                     selectedScope={selectedScope.value.toString()}
+                    isTemplatesPage={true}
                   />
                 )}
                 <ExpandingSearchInput

--- a/src/modules/72-templates-library/components/TemplateSelector/TemplateSelectorLeftView/__tests__/TemplateSelectorLeftView.test.tsx
+++ b/src/modules/72-templates-library/components/TemplateSelector/TemplateSelectorLeftView/__tests__/TemplateSelectorLeftView.test.tsx
@@ -20,7 +20,6 @@ import {
   mockApiFetchingResponse
 } from '@templates-library/components/TemplateActivityLog/__tests__/TemplateActivityLogTestHelper'
 import { templateSelectorContextMock } from 'framework/Templates/TemplateSelectorContext/stateMocks'
-import { useGetRepositoryList } from 'services/template-ng'
 import { TemplateSelectorLeftView, TemplateSelectorLeftViewProps } from '../TemplateSelectorLeftView'
 
 const TEST_PATH = routes.toPipelineStudio({ ...accountPathProps, ...pipelinePathProps, ...pipelineModuleParams })
@@ -102,7 +101,6 @@ describe('<TemplateSelectorLeftView> tests', () => {
         <TemplateSelectorLeftView {...baseProps} />
       </TestWrapper>
     )
-    expect(useGetRepositoryList).toBeCalled()
     expect(container).toMatchSnapshot()
 
     expect(templateListCallMock).toBeCalledWith(

--- a/src/modules/72-templates-library/components/TemplateSelector/TemplateSelectorLeftView/__tests__/TemplateSelectorLeftView.test.tsx
+++ b/src/modules/72-templates-library/components/TemplateSelector/TemplateSelectorLeftView/__tests__/TemplateSelectorLeftView.test.tsx
@@ -102,8 +102,8 @@ describe('<TemplateSelectorLeftView> tests', () => {
         <TemplateSelectorLeftView {...baseProps} />
       </TestWrapper>
     )
-    expect(container).toMatchSnapshot()
     expect(useGetRepositoryList).toBeCalled()
+    expect(container).toMatchSnapshot()
 
     expect(templateListCallMock).toBeCalledWith(
       undefined,

--- a/src/modules/72-templates-library/pages/TemplatesPage/TemplatesPage.tsx
+++ b/src/modules/72-templates-library/pages/TemplatesPage/TemplatesPage.tsx
@@ -229,7 +229,7 @@ export default function TemplatesPage(): React.ReactElement {
               />
             </GitSyncStoreProvider>
           ) : (
-            <RepoFilter onChange={onChangeRepo} value={repoName} />
+            <RepoFilter onChange={onChangeRepo} value={repoName} isTemplatesPage={true} />
           )}
         </Layout.Horizontal>
         <Layout.Horizontal spacing="small" style={{ alignItems: 'center' }}>

--- a/src/modules/72-templates-library/pages/TemplatesPage/TemplatesPage.tsx
+++ b/src/modules/72-templates-library/pages/TemplatesPage/TemplatesPage.tsx
@@ -23,12 +23,7 @@ import { Page } from '@common/exports'
 import { useStrings } from 'framework/strings'
 import { Sort, SortFields, TemplateListType } from '@templates-library/pages/TemplatesPage/TemplatesPageUtils'
 import { TemplateDetailsDrawer } from '@templates-library/components/TemplateDetailDrawer/TemplateDetailDrawer'
-import {
-  TemplateSummaryResponse,
-  useGetRepositoryList,
-  useGetTemplateList,
-  useGetTemplateMetadataList
-} from 'services/template-ng'
+import { TemplateSummaryResponse, useGetTemplateList, useGetTemplateMetadataList } from 'services/template-ng'
 import type { ModulePathParams, ProjectPathProps } from '@common/interfaces/RouteInterfaces'
 import { NGBreadcrumbs } from '@common/components/NGBreadcrumbs/NGBreadcrumbs'
 import { NewTemplatePopover } from '@templates-library/pages/TemplatesPage/views/NewTemplatePopover/NewTemplatePopover'
@@ -234,7 +229,7 @@ export default function TemplatesPage(): React.ReactElement {
               />
             </GitSyncStoreProvider>
           ) : (
-            <RepoFilter onChange={onChangeRepo} value={repoName} getRepoListPromise={useGetRepositoryList} />
+            <RepoFilter onChange={onChangeRepo} value={repoName} />
           )}
         </Layout.Horizontal>
         <Layout.Horizontal spacing="small" style={{ alignItems: 'center' }}>

--- a/src/modules/72-templates-library/pages/TemplatesPage/TemplatesPage.tsx
+++ b/src/modules/72-templates-library/pages/TemplatesPage/TemplatesPage.tsx
@@ -229,7 +229,7 @@ export default function TemplatesPage(): React.ReactElement {
               />
             </GitSyncStoreProvider>
           ) : (
-            <RepoFilter onChange={onChangeRepo} value={repoName} isTemplatesPage={true} />
+            <RepoFilter onChange={onChangeRepo} value={repoName} isTemplatesPage />
           )}
         </Layout.Horizontal>
         <Layout.Horizontal spacing="small" style={{ alignItems: 'center' }}>

--- a/src/modules/72-templates-library/pages/TemplatesPage/__tests__/TemplatesPage.test.tsx
+++ b/src/modules/72-templates-library/pages/TemplatesPage/__tests__/TemplatesPage.test.tsx
@@ -28,7 +28,6 @@ import { StageTemplate } from '@templates-library/components/Templates/StageTemp
 import { StepTemplate } from '@templates-library/components/Templates/StepTemplate/StepTemplate'
 import templateFactory from '@templates-library/components/Templates/TemplatesFactory'
 import { PipelineTemplate } from '@templates-library/components/Templates/PipelineTemplate/PipelineTemplate'
-import { useGetRepositoryList } from 'services/template-ng'
 
 const templateListCallMock = jest
   .spyOn(hooks, 'useMutateAsGet')
@@ -144,8 +143,6 @@ describe('<TemplatesPage /> tests', () => {
       </TestWrapper>
     )
 
-    expect(useGetRepositoryList).toBeCalled()
-
     expect(container).toMatchSnapshot()
     expect(templateListCallMock).toBeCalledWith(
       undefined,
@@ -161,7 +158,6 @@ describe('<TemplatesPage /> tests', () => {
         <TemplatesPage />
       </TestWrapper>
     )
-    expect(useGetRepositoryList).toBeCalled()
 
     const typeFilterButton = getByText('all')
     act(() => {
@@ -190,7 +186,7 @@ describe('<TemplatesPage /> tests', () => {
         <TemplatesPage />
       </TestWrapper>
     )
-    expect(useGetRepositoryList).toBeCalled()
+
     const selectTemplateButton = getByText('Select Template')
     act(() => {
       fireEvent.click(selectTemplateButton)
@@ -238,7 +234,6 @@ describe('<TemplatesPage /> tests', () => {
         <TemplatesPage />
       </TestWrapper>
     )
-    expect(useGetRepositoryList).toBeCalled()
 
     expect(container).toMatchSnapshot()
   })
@@ -251,7 +246,6 @@ describe('<TemplatesPage /> tests', () => {
         <TemplatesPage />
       </TestWrapper>
     )
-    expect(useGetRepositoryList).toBeCalled()
 
     expect(container).toMatchSnapshot()
   })
@@ -265,7 +259,6 @@ describe('<TemplatesPage /> tests', () => {
         <TemplatesPage />
       </TestWrapper>
     )
-    expect(useGetRepositoryList).toBeCalled()
 
     expect(container).toMatchSnapshot()
 

--- a/src/modules/72-templates-library/pages/TemplatesPage/__tests__/TemplatesPage.test.tsx
+++ b/src/modules/72-templates-library/pages/TemplatesPage/__tests__/TemplatesPage.test.tsx
@@ -143,6 +143,7 @@ describe('<TemplatesPage /> tests', () => {
         <TemplatesPage />
       </TestWrapper>
     )
+
     expect(useGetRepositoryList).toBeCalled()
 
     expect(container).toMatchSnapshot()
@@ -189,7 +190,7 @@ describe('<TemplatesPage /> tests', () => {
         <TemplatesPage />
       </TestWrapper>
     )
-
+    expect(useGetRepositoryList).toBeCalled()
     const selectTemplateButton = getByText('Select Template')
     act(() => {
       fireEvent.click(selectTemplateButton)


### PR DESCRIPTION
### Summary
Initially, i was passing API as a prop to the repo Filter component from parent component as   `**getRepoListPromise: (props: any) => UseGetReturn<any, Failure | Error, any, unknown>**`
. but, it was not good and throwing the type error after pipeline service was updated. To clear this error, i have seperately called the required APIs in the repoFilter component itself and filtering the data. 
<!-- ✍️ A clear and concise description...-->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
