### PR TITLE
fix: [CI-6179]: support for oauth connector at project and org scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nextgenui",
   "description": "Harness Inc",
-  "version": "0.328.3",
+  "version": "0.328.4",
   "author": "Harness Inc",
   "license": "Harness Inc",
   "homepage": "https://app.harness.io/",

--- a/src/modules/35-connectors/common/ConnectViaOAuth/ConnectViaOAuth.tsx
+++ b/src/modules/35-connectors/common/ConnectViaOAuth/ConnectViaOAuth.tsx
@@ -74,11 +74,8 @@ export const ConnectViaOAuth: React.FC<ConnectViaOAuthProps> = props => {
     try {
       const { headers } = getRequestOptions()
       let oauthRedirectEndpoint = `${OAUTH_REDIRECT_URL_PREFIX}?provider=${gitProviderType.toLowerCase()}&accountId=${accountId}`
-      oauthRedirectEndpoint += orgIdentifier
-        ? projectIdentifier
-          ? `&orgId=${orgIdentifier}&projectId=${projectIdentifier}`
-          : `&orgId=${orgIdentifier}`
-        : ''
+      if (orgIdentifier) oauthRedirectEndpoint += `&orgId=${orgIdentifier}`
+      if (orgIdentifier && projectIdentifier) oauthRedirectEndpoint += `&projectId=${projectIdentifier}`
       const response = await fetch(oauthRedirectEndpoint, {
         headers
       })

--- a/src/modules/35-connectors/common/ConnectViaOAuth/ConnectViaOAuth.tsx
+++ b/src/modules/35-connectors/common/ConnectViaOAuth/ConnectViaOAuth.tsx
@@ -31,6 +31,8 @@ export interface ConnectViaOAuthProps {
   oAuthSecretIntercepted?: React.MutableRefObject<boolean>
   forceFailOAuthTimeoutId?: NodeJS.Timeout
   setForceFailOAuthTimeoutId: React.Dispatch<React.SetStateAction<NodeJS.Timeout | undefined>>
+  orgIdentifier: string | undefined
+  projectIdentifier: string | undefined
 }
 
 export const ConnectViaOAuth: React.FC<ConnectViaOAuthProps> = props => {
@@ -43,7 +45,9 @@ export const ConnectViaOAuth: React.FC<ConnectViaOAuthProps> = props => {
     oAuthSecretIntercepted,
     setOAuthStatus,
     forceFailOAuthTimeoutId,
-    setForceFailOAuthTimeoutId
+    setForceFailOAuthTimeoutId,
+    orgIdentifier,
+    projectIdentifier
   } = props
   const { getString } = useStrings()
 
@@ -69,7 +73,12 @@ export const ConnectViaOAuth: React.FC<ConnectViaOAuthProps> = props => {
     }
     try {
       const { headers } = getRequestOptions()
-      const oauthRedirectEndpoint = `${OAUTH_REDIRECT_URL_PREFIX}?provider=${gitProviderType.toLowerCase()}&accountId=${accountId}`
+      let oauthRedirectEndpoint = `${OAUTH_REDIRECT_URL_PREFIX}?provider=${gitProviderType.toLowerCase()}&accountId=${accountId}`
+      oauthRedirectEndpoint += orgIdentifier
+        ? projectIdentifier
+          ? `&orgId=${orgIdentifier}&projectId=${projectIdentifier}`
+          : `&orgId=${orgIdentifier}`
+        : ''
       const response = await fetch(oauthRedirectEndpoint, {
         headers
       })

--- a/src/modules/35-connectors/common/ConnectViaOAuth/__test__/ConnectViaOAuth.test.tsx
+++ b/src/modules/35-connectors/common/ConnectViaOAuth/__test__/ConnectViaOAuth.test.tsx
@@ -27,7 +27,9 @@ describe('Test ConnectViaOAuth component', () => {
     accountId: 'accountId',
     gitProviderType: 'Github',
     setOAuthStatus: jest.fn(),
-    setForceFailOAuthTimeoutId: jest.fn()
+    setForceFailOAuthTimeoutId: jest.fn(),
+    orgIdentifier: 'orgId',
+    projectIdentifier: 'projectId'
   }
   test('Initial render for Github connector', () => {
     const { getByText } = render(<ConnectViaOAuth {...props} />)

--- a/src/modules/35-connectors/components/CreateConnector/GithubConnector/StepAuth/StepGithubAuthentication.tsx
+++ b/src/modules/35-connectors/components/CreateConnector/GithubConnector/StepAuth/StepGithubAuthentication.tsx
@@ -445,6 +445,8 @@ const StepGithubAuthentication: React.FC<StepProps<StepGithubAuthenticationProps
                       oAuthSecretIntercepted={oAuthSecretIntercepted}
                       forceFailOAuthTimeoutId={forceFailOAuthTimeoutId}
                       setForceFailOAuthTimeoutId={setForceFailOAuthTimeoutId}
+                      orgIdentifier={props.orgIdentifier}
+                      projectIdentifier={props.projectIdentifier}
                     />
                   ) : (
                     <>

--- a/src/modules/35-connectors/components/CreateConnector/GitlabConnector/StepAuth/StepGitlabAuthentication.tsx
+++ b/src/modules/35-connectors/components/CreateConnector/GitlabConnector/StepAuth/StepGitlabAuthentication.tsx
@@ -461,6 +461,8 @@ const StepGitlabAuthentication: React.FC<StepProps<StepGitlabAuthenticationProps
                         oAuthSecretIntercepted={oAuthSecretIntercepted}
                         forceFailOAuthTimeoutId={forceFailOAuthTimeoutId}
                         setForceFailOAuthTimeoutId={setForceFailOAuthTimeoutId}
+                        orgIdentifier={props.orgIdentifier}
+                        projectIdentifier={props.projectIdentifier}
                       />
                     </Layout.Vertical>
                   ) : (

--- a/src/modules/75-ci/pages/get-started-with-ci/InfraProvisioningWizard/SelectGitProvider.tsx
+++ b/src/modules/75-ci/pages/get-started-with-ci/InfraProvisioningWizard/SelectGitProvider.tsx
@@ -115,7 +115,7 @@ const SelectGitProviderRef = (
   const [authMethod, setAuthMethod] = useState<GitAuthenticationMethod>()
   const [testConnectionStatus, setTestConnectionStatus] = useState<TestStatus>(TestStatus.NOT_INITIATED)
   const formikRef = useRef<FormikContextType<SelectGitProviderInterface>>()
-  const { accountId, projectIdentifier, orgIdentifier } = useParams<ProjectPathProps>()
+  const { accountId } = useParams<ProjectPathProps>()
   const [testConnectionErrors, setTestConnectionErrors] = useState<ResponseMessage[]>()
   const [connector, setConnector] = useState<ConnectorInfoDTO>()
   const [secret, setSecret] = useState<SecretDTOV2>()
@@ -143,9 +143,7 @@ const SelectGitProviderRef = (
               getOAuthConnectorPayload({
                 tokenRef: tokenRef,
                 refreshTokenRef: refreshTokenRef ? refreshTokenRef : '',
-                gitProviderType: gitProvider.type as ConnectorInfoDTO['type'],
-                orgIdentifier,
-                projectIdentifier
+                gitProviderType: gitProvider.type as ConnectorInfoDTO['type']
               }),
               'connector.spec.url',
               getGitUrl(getString, gitProvider?.type as ConnectorInfoDTO['type'])
@@ -933,7 +931,7 @@ const SelectGitProviderRef = (
                               if (gitProvider?.type) {
                                 try {
                                   const { headers } = getRequestOptions()
-                                  const oauthRedirectEndpoint = `${OAUTH_REDIRECT_URL_PREFIX}?provider=${gitProvider.type.toLowerCase()}&accountId=${accountId}&orgId=${orgIdentifier}&projectId=${projectIdentifier}`
+                                  const oauthRedirectEndpoint = `${OAUTH_REDIRECT_URL_PREFIX}?provider=${gitProvider.type.toLowerCase()}&accountId=${accountId}`
                                   const response = await fetch(oauthRedirectEndpoint, {
                                     headers
                                   })

--- a/src/modules/75-ci/pages/get-started-with-ci/InfraProvisioningWizard/SelectRepository.tsx
+++ b/src/modules/75-ci/pages/get-started-with-ci/InfraProvisioningWizard/SelectRepository.tsx
@@ -31,6 +31,7 @@ import { Connectors } from '@connectors/constants'
 import type { ProjectPathProps } from '@common/interfaces/RouteInterfaces'
 import { ErrorHandler } from '@common/components/ErrorHandler/ErrorHandler'
 import { getFullRepoName } from '../../../utils/HostedBuildsUtils'
+import { ACCOUNT_SCOPE_PREFIX } from './Constants'
 
 import css from './InfraProvisioningWizard.module.scss'
 
@@ -135,7 +136,7 @@ const SelectRepositoryRef = (
           accountIdentifier: accountId,
           projectIdentifier,
           orgIdentifier,
-          connectorRef: `${connectorRef}`
+          connectorRef: `${ACCOUNT_SCOPE_PREFIX}${connectorRef}`
         }
       })
     }

--- a/src/modules/75-ci/utils/HostedBuildsUtils.ts
+++ b/src/modules/75-ci/utils/HostedBuildsUtils.ts
@@ -55,15 +55,11 @@ const OAuthConnectorPayload: ConnectorRequestBody = {
 export const getOAuthConnectorPayload = ({
   tokenRef,
   refreshTokenRef,
-  gitProviderType,
-  orgIdentifier,
-  projectIdentifier
+  gitProviderType
 }: {
   tokenRef: string
   refreshTokenRef?: string
   gitProviderType?: ConnectorInfoDTO['type']
-  orgIdentifier: string
-  projectIdentifier: string
 }): ConnectorRequestBody => {
   let updatedConnectorPayload: ConnectorRequestBody = {}
   updatedConnectorPayload = set(OAuthConnectorPayload, 'connector.name', `${gitProviderType} OAuth`)
@@ -72,8 +68,6 @@ export const getOAuthConnectorPayload = ({
     'connector.identifier',
     `${gitProviderType}_OAuth_${new Date().getTime()}`
   )
-  updatedConnectorPayload = set(OAuthConnectorPayload, 'connector.orgIdentifier', orgIdentifier)
-  updatedConnectorPayload = set(OAuthConnectorPayload, 'connector.projectIdentifier', projectIdentifier)
   updatedConnectorPayload = set(OAuthConnectorPayload, 'connector.type', gitProviderType)
   switch (gitProviderType) {
     case Connectors.GITHUB:

--- a/src/modules/75-ci/utils/__test__/HostedBuildsUtils.test.ts
+++ b/src/modules/75-ci/utils/__test__/HostedBuildsUtils.test.ts
@@ -39,9 +39,7 @@ describe('Test HostedBuildsUtils methods', () => {
   test('Test getOAuthConnectorPayload method', () => {
     const oAuthConnectorPayloadForGithub = getOAuthConnectorPayload({
       tokenRef: 'secret-token',
-      gitProviderType: 'Github',
-      orgIdentifier: 'default',
-      projectIdentifier: 'defaultproject'
+      gitProviderType: 'Github'
     })
     expect(get(oAuthConnectorPayloadForGithub, 'connector.name')).toBe('Github OAuth')
     expect(get(oAuthConnectorPayloadForGithub, 'connector.identifier')).toBe('Github_OAuth_1585699200000')
@@ -52,9 +50,7 @@ describe('Test HostedBuildsUtils methods', () => {
     const oAuthConnectorPayloadForGitlab = getOAuthConnectorPayload({
       tokenRef: 'secret-token',
       refreshTokenRef: 'secret-refresh-token',
-      gitProviderType: 'Gitlab',
-      orgIdentifier: 'default',
-      projectIdentifier: 'defaultproject'
+      gitProviderType: 'Gitlab'
     })
     expect(get(oAuthConnectorPayloadForGitlab, 'connector.name')).toBe('Gitlab OAuth')
     expect(get(oAuthConnectorPayloadForGitlab, 'connector.identifier')).toBe('Gitlab_OAuth_1585699200000')
@@ -71,9 +67,7 @@ describe('Test HostedBuildsUtils methods', () => {
     const oAuthConnectorPayloadForBitbucket = getOAuthConnectorPayload({
       tokenRef: 'secret-token',
       refreshTokenRef: 'secret-refresh-token',
-      gitProviderType: 'Bitbucket',
-      orgIdentifier: 'default',
-      projectIdentifier: 'defaultproject'
+      gitProviderType: 'Bitbucket'
     })
     expect(get(oAuthConnectorPayloadForBitbucket, 'connector.name')).toBe('Bitbucket OAuth')
     expect(get(oAuthConnectorPayloadForBitbucket, 'connector.identifier')).toBe('Bitbucket_OAuth_1585699200000')


### PR DESCRIPTION
### Summary

support for oauth connector at project and org scope

#### Screenshots


<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
