### PR TITLE
feat: [FFM-5391]: remove additional step added to FF Onboarding flow

### DIFF
--- a/src/modules/75-cf/pages/onboarding/OnboardingDetailPage.tsx
+++ b/src/modules/75-cf/pages/onboarding/OnboardingDetailPage.tsx
@@ -29,14 +29,12 @@ import { Category, FeatureActions } from '@common/constants/TrackingConstants'
 import { CreateAFlagView } from './views/CreateAFlagView'
 import { OnboardingSelectedFlag } from './OnboardingSelectedFlag'
 import { SetUpYourApplicationView } from './views/SetUpYourApplicationView'
-import { SetUpYourCodeView } from './views/SetUpYourCodeView'
 import { ValidateYourFlagView } from './views/ValidatingYourFlagView'
 import css from './OnboardingDetailPage.module.scss'
 
 enum STEP {
   CREATE_A_FLAG,
   SELECT_ENV_SDK,
-  SET_UP_CODE,
   VALIDATE_FLAG
 }
 
@@ -91,15 +89,6 @@ export const OnboardingDetailPage: React.FC = () => {
   const thirdStepStatus = useMemo<StepStatus>(() => {
     if (currentStep === 3) {
       return StepStatus.INPROGRESS
-    } else if (currentStep > 3) {
-      return StepStatus.SUCCESS
-    }
-    return StepStatus.TODO
-  }, [currentStep])
-
-  const fourthStepStatus = useMemo<StepStatus>(() => {
-    if (currentStep === 4) {
-      return StepStatus.INPROGRESS
     }
     return StepStatus.TODO
   }, [currentStep])
@@ -110,8 +99,6 @@ export const OnboardingDetailPage: React.FC = () => {
       case 2:
         return STEP.SELECT_ENV_SDK
       case 3:
-        return STEP.SET_UP_CODE
-      case 4:
         return STEP.VALIDATE_FLAG
       default:
         // first step/tab
@@ -137,8 +124,7 @@ export const OnboardingDetailPage: React.FC = () => {
             new Map([
               [0, { StepStatus: firstStepStatus }],
               [1, { StepStatus: secondStepStatus }],
-              [2, { StepStatus: thirdStepStatus }],
-              [3, { StepStatus: fourthStepStatus }]
+              [2, { StepStatus: thirdStepStatus }]
             ])
           }
         />
@@ -153,8 +139,8 @@ export const OnboardingDetailPage: React.FC = () => {
               {getString('cf.onboarding.createFlag')}
             </Heading>
 
-            {selectedFlag && (selectedStep === STEP.SELECT_ENV_SDK || selectedStep === STEP.SET_UP_CODE) && (
-              <Layout.Vertical margin={{ top: 'medium', bottom: 'medium' }} spacing="medium">
+            {selectedFlag && selectedStep === STEP.SELECT_ENV_SDK && (
+              <Layout.Vertical spacing="medium">
                 <OnboardingSelectedFlag selectedFlag={selectedFlag} />
                 <Divider />
               </Layout.Vertical>
@@ -170,8 +156,9 @@ export const OnboardingDetailPage: React.FC = () => {
           <CreateAFlagView selectedFlag={selectedFlag} setSelectedFlag={setSelectedFlag} />
         )}
 
-        {selectedStep === STEP.SELECT_ENV_SDK && (
+        {selectedStep === STEP.SELECT_ENV_SDK && selectedFlag && (
           <SetUpYourApplicationView
+            flagInfo={selectedFlag}
             language={language}
             setLanguage={setLanguage}
             apiKey={apiKey}
@@ -181,16 +168,7 @@ export const OnboardingDetailPage: React.FC = () => {
           />
         )}
 
-        {selectedStep === STEP.SET_UP_CODE && language && selectedFlag && apiKey && selectedEnvironment && (
-          <SetUpYourCodeView
-            apiKey={apiKey}
-            language={language}
-            flagName={selectedFlag?.name}
-            environment={selectedEnvironment}
-          />
-        )}
-
-        {selectedStep === STEP.VALIDATE_FLAG && selectedEnvironment && (
+        {selectedStep === STEP.VALIDATE_FLAG && selectedFlag && selectedEnvironment && (
           <ValidateYourFlagView
             flagInfo={selectedFlag as Feature}
             language={language as PlatformEntry}
@@ -221,10 +199,6 @@ export const OnboardingDetailPage: React.FC = () => {
           disabled={disableNext}
           onClick={() => {
             if (selectedStep === STEP.SELECT_ENV_SDK) {
-              trackEvent(FeatureActions.SetUpYourApplicationVerify, {
-                category: Category.FEATUREFLAG
-              })
-            } else if (selectedStep === STEP.SET_UP_CODE) {
               trackEvent(FeatureActions.SetUpYourApplicationVerify, {
                 category: Category.FEATUREFLAG
               })

--- a/src/modules/75-cf/pages/onboarding/__test__/SetUpYourApplicationView.test.tsx
+++ b/src/modules/75-cf/pages/onboarding/__test__/SetUpYourApplicationView.test.tsx
@@ -25,6 +25,21 @@ const renderComponent = (props?: Partial<SetUpYourApplicationViewProps>): Render
       pathParams={{ accountId: 'dummy', orgIdentifier: 'dummy', projectIdentifier: 'dummy' }}
     >
       <SetUpYourApplicationView
+        flagInfo={{
+          project: 'dummy',
+          createdAt: 1662647079713,
+          name: 'hello world',
+          identifier: 'hello_world',
+          kind: 'boolean',
+          archived: false,
+          variations: [
+            { identifier: 'true', name: 'True', value: 'true' },
+            { identifier: 'false', name: 'False', value: 'false' }
+          ],
+          defaultOnVariation: 'true',
+          defaultOffVariation: 'false',
+          permanent: false
+        }}
         language={undefined}
         setLanguage={setLanguage}
         apiKey={{

--- a/src/modules/75-cf/pages/onboarding/__test__/SetUpYourApplicationView.test.tsx
+++ b/src/modules/75-cf/pages/onboarding/__test__/SetUpYourApplicationView.test.tsx
@@ -158,4 +158,11 @@ describe('SetUpYourApplicationView', () => {
     })
     expect(document.querySelector('input[name="environmentSelectEl"]')).toHaveValue('QB')
   })
+
+  test('It should render the readme when environment, language & api key are set', () => {
+    const javaLang = SupportPlatforms.find(lang => lang.name === 'Java') as any
+    renderComponent({ language: javaLang, selectedEnvironment: { identifier: 'foobar' } })
+
+    expect(screen.getByText('cf.onboarding.setUpYourCode')).toBeVisible()
+  })
 })

--- a/src/modules/75-cf/pages/onboarding/__test__/SetUpYourCodeView.test.tsx
+++ b/src/modules/75-cf/pages/onboarding/__test__/SetUpYourCodeView.test.tsx
@@ -28,7 +28,6 @@ const renderComponent = (props?: Partial<SetUpYourCodeViewProps>): RenderResult 
           type: 'server'
         }}
         flagName="foobar"
-        environment={{ identifier: 'foobar_env', name: 'foobar env' }}
         {...props}
       />
     </TestWrapper>

--- a/src/modules/75-cf/pages/onboarding/views/SetUpYourApplicationView.tsx
+++ b/src/modules/75-cf/pages/onboarding/views/SetUpYourApplicationView.tsx
@@ -9,13 +9,15 @@ import React, { useEffect } from 'react'
 import { Container, Heading, Layout, Text } from '@harness/uicore'
 import { Color, FontVariation } from '@harness/design-system'
 import { useStrings } from 'framework/strings'
-import type { ApiKey } from 'services/cf'
+import type { ApiKey, Feature } from 'services/cf'
 import type { EnvironmentResponseDTO } from 'services/cd-ng'
 import { LanguageSelection, PlatformEntry } from '@cf/components/LanguageSelection/LanguageSelection'
 import { useTelemetry } from '@common/hooks/useTelemetry'
 import { Category, FeatureActions } from '@common/constants/TrackingConstants'
 import { SelectEnvironmentView } from './SelectEnvironmentView'
+import { SetUpYourCodeView } from './SetUpYourCodeView'
 export interface SetUpYourApplicationViewProps {
+  flagInfo: Feature
   language?: PlatformEntry
   setLanguage: (language: PlatformEntry | undefined) => void
   apiKey?: ApiKey
@@ -25,6 +27,7 @@ export interface SetUpYourApplicationViewProps {
 }
 
 export const SetUpYourApplicationView: React.FC<SetUpYourApplicationViewProps> = ({
+  flagInfo,
   language,
   setLanguage,
   apiKey,
@@ -43,8 +46,8 @@ export const SetUpYourApplicationView: React.FC<SetUpYourApplicationViewProps> =
   }, [])
 
   return (
-    <Layout.Vertical padding={{ top: 'medium', bottom: 'medium' }}>
-      <Layout.Horizontal margin={{ top: 'medium' }}>
+    <Layout.Vertical padding={{ top: 'small', bottom: 'small' }}>
+      <Layout.Horizontal margin={{ top: 'small' }}>
         <Heading level={4} font={{ variation: FontVariation.H4 }}>
           {getString('cf.onboarding.selectEnvAndSdk')}
         </Heading>
@@ -67,7 +70,6 @@ export const SetUpYourApplicationView: React.FC<SetUpYourApplicationViewProps> =
           />
         </Container>
       </Layout.Vertical>
-
       {language && (
         <SelectEnvironmentView
           apiKey={apiKey}
@@ -76,6 +78,10 @@ export const SetUpYourApplicationView: React.FC<SetUpYourApplicationViewProps> =
           setSelectedEnvironment={setSelectedEnvironment}
           language={language}
         />
+      )}
+
+      {selectedEnvironment && language && apiKey && (
+        <SetUpYourCodeView apiKey={apiKey} language={language} flagName={flagInfo.name} />
       )}
     </Layout.Vertical>
   )

--- a/src/modules/75-cf/pages/onboarding/views/SetUpYourCodeView.tsx
+++ b/src/modules/75-cf/pages/onboarding/views/SetUpYourCodeView.tsx
@@ -6,24 +6,21 @@
  */
 
 import React, { useState } from 'react'
-import { Container, Layout, Text, RadioButtonGroup, Heading } from '@harness/uicore'
-import { Color, FontVariation } from '@harness/design-system'
+import { Container, Layout, RadioButtonGroup, Heading } from '@harness/uicore'
+import { FontVariation } from '@harness/design-system'
 import { Divider } from '@blueprintjs/core'
-import { String, useStrings } from 'framework/strings'
+import { useStrings } from 'framework/strings'
 import type { ApiKey } from 'services/cf'
 import type { PlatformEntry } from '@cf/components/LanguageSelection/LanguageSelection'
-import { IdentifierText } from '@cf/components/IdentifierText/IdentifierText'
 import { MarkdownViewer } from '@common/components/MarkdownViewer/MarkdownViewer'
 import type { StringKeys } from 'framework/strings'
-import type { EnvironmentResponseDTO } from 'services/cd-ng'
 export interface SetUpYourCodeViewProps {
   language: PlatformEntry
   apiKey: ApiKey
   flagName: string
-  environment: EnvironmentResponseDTO
 }
 
-export const SetUpYourCodeView: React.FC<SetUpYourCodeViewProps> = ({ language, apiKey, flagName, environment }) => {
+export const SetUpYourCodeView: React.FC<SetUpYourCodeViewProps> = ({ language, apiKey, flagName }) => {
   const { getString } = useStrings()
   const [currentReadme, setCurrentReadme] = useState<StringKeys>(language.readmeStringId)
   const [xamarinOption, setXamarinOption] = useState<StringKeys | undefined>(
@@ -31,36 +28,8 @@ export const SetUpYourCodeView: React.FC<SetUpYourCodeViewProps> = ({ language, 
   )
 
   return (
-    <Container margin={{ top: 'large' }}>
-      <Layout.Vertical margin={{ top: 'medium', bottom: 'medium' }} spacing="medium">
-        <Heading level={4} font={{ variation: FontVariation.H4 }} margin={{ bottom: 'large' }}>
-          {getString('cf.onboarding.selectEnvAndSdk')}
-        </Heading>
-
-        <Layout.Horizontal spacing="xsmall">
-          <Text font={{ variation: FontVariation.BODY }} color={Color.GREY_600}>
-            {getString('cf.onboarding.youveSelected')}
-          </Text>
-          {language?.icon && <img src={language.icon} width="20px" height="20px" />}
-          <Text font={{ variation: FontVariation.BODY }} color={Color.GREY_600}>
-            <String
-              useRichText
-              stringID="cf.onboarding.selectedLanguageAndEnv"
-              vars={{ language: language.name, env: environment.name }}
-              color={Color.GREY_600}
-              tagName="div"
-            />
-          </Text>
-        </Layout.Horizontal>
-        <Text font={{ variation: FontVariation.BODY }} color={Color.GREY_600}>
-          <String
-            useRichText
-            stringID="cf.onboarding.keyGeneratedBelow"
-            vars={{ langType: language.type }}
-            color={Color.GREY_600}
-          />
-        </Text>
-        <IdentifierText identifier={apiKey.apiKey} allowCopy lineClamp={1} hideLabel />
+    <Container margin={{ top: 'small' }}>
+      <Layout.Vertical margin={{ top: 'small', bottom: 'small' }} spacing="medium">
         <Divider />
       </Layout.Vertical>
       <Layout.Vertical spacing="xsmall">

--- a/src/modules/75-cf/pages/onboarding/views/ValidatingYourFlagView.module.scss
+++ b/src/modules/75-cf/pages/onboarding/views/ValidatingYourFlagView.module.scss
@@ -6,7 +6,6 @@
  */
 
 .listenToEventContainer {
-  padding: var(--spacing-huge) !important;
   overflow: auto !important;
   align-items: flex-start;
 }


### PR DESCRIPTION
### Summary

Step was added for Set Up Your Code (readme), undo this and put content back under SDK Key creation in step 2
JIRA: https://harness.atlassian.net/browse/FFM-5391

- put content back in SetUpYourApplicationView
- remove step from stepper at top of page
- update unit tests

#### Screenshots
<img width="1335" alt="image" src="https://user-images.githubusercontent.com/5584348/202774751-0655c84d-e542-4141-aa44-e8fd24d2ca8c.png">

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
