### PR TITLE
fix: passing org in github version api

### DIFF
--- a/src/modules/70-pipeline/components/ArtifactsSelection/ArtifactRepository/ArtifactLastSteps/GithubPackageRegistry/GithubPackageRegistry.tsx
+++ b/src/modules/70-pipeline/components/ArtifactsSelection/ArtifactRepository/ArtifactLastSteps/GithubPackageRegistry/GithubPackageRegistry.tsx
@@ -114,7 +114,8 @@ function FormComponent({
       packageType: defaultTo(packageTypeValue, ''),
       packageName: defaultTo(packageNameValue, ''),
       connectorRef: defaultTo(connectorRefValue, ''),
-      versionRegex: '*'
+      versionRegex: '*',
+      org: orgValue
     }
   })
 
@@ -338,15 +339,7 @@ function FormComponent({
                   ) {
                     return
                   }
-                  refetchVersionDetails({
-                    queryParams: {
-                      ...commonParams,
-                      packageType: defaultTo(packageTypeValue, ''),
-                      packageName: defaultTo(packageNameValue, ''),
-                      connectorRef: defaultTo(connectorRefValue, ''),
-                      versionRegex: '*'
-                    }
-                  })
+                  refetchVersionDetails()
                 }
               }}
             />

--- a/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/ArtifactSource/GithubPackageRegistrySource/GithubPackageRegistrySource.tsx
+++ b/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/ArtifactSource/GithubPackageRegistrySource/GithubPackageRegistrySource.tsx
@@ -139,6 +139,7 @@ const Content = (props: JenkinsRenderContent): React.ReactElement => {
       packageName: defaultTo(packageNameValue, ''),
       connectorRef: defaultTo(connectorRefValue, ''),
       versionRegex: '*',
+      org: orgValue,
       pipelineIdentifier: defaultTo(pipelineIdentifier, formik?.values?.identifier),
       serviceId: isNewServiceEnvEntity(path as string) ? serviceIdentifier : undefined,
       fqnPath: getFqnPath(


### PR DESCRIPTION
### Summary

<!-- ✍️ A clear and concise description...-->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
