### PR TITLE
fix: [CDS-43861]: added datatooltip ids for nexus fields

### DIFF
--- a/src/modules/70-pipeline/components/ArtifactsSelection/ArtifactRepository/ArtifactLastSteps/NexusArtifact/NexusArtifact.tsx
+++ b/src/modules/70-pipeline/components/ArtifactsSelection/ArtifactRepository/ArtifactLastSteps/NexusArtifact/NexusArtifact.tsx
@@ -471,6 +471,9 @@ export function Nexus3Artifact({
                       ? [...k8sRepositoryFormatTypes, ...nexus2RepositoryFormatTypes]
                       : k8sRepositoryFormatTypes
                   }
+                  tooltipProps={{
+                    dataTooltipId: 'nexusRepositoryFormat'
+                  }}
                   onChange={value => {
                     if (value.value === RepositoryFormatTypes.Maven) {
                       const optionalValues: { extension?: string; classifier?: string } = {}
@@ -509,6 +512,9 @@ export function Nexus3Artifact({
                   disabled={isReadonly}
                   label={getString('repository')}
                   name="repository"
+                  tooltipProps={{
+                    dataTooltipId: 'nexusRepository'
+                  }}
                   placeholder={getString('pipeline.artifactsSelection.repositoryPlaceholder')}
                   useValue
                   multiTypeInputProps={{
@@ -569,6 +575,9 @@ export function Nexus3Artifact({
                     <FormInput.MultiTextInput
                       label={getString('pipeline.artifactsSelection.groupId')}
                       name="spec.groupId"
+                      tooltipProps={{
+                        dataTooltipId: 'nexusGroupId'
+                      }}
                       placeholder={getString('pipeline.artifactsSelection.groupIdPlaceholder')}
                       multiTextInputProps={{ expressions, allowableTypes }}
                     />
@@ -593,6 +602,9 @@ export function Nexus3Artifact({
                     <FormInput.MultiTextInput
                       label={getString('pipeline.artifactsSelection.artifactId')}
                       name="spec.artifactId"
+                      tooltipProps={{
+                        dataTooltipId: 'nexusArtifactId'
+                      }}
                       placeholder={getString('pipeline.artifactsSelection.artifactIdPlaceholder')}
                       multiTextInputProps={{ expressions, allowableTypes }}
                     />
@@ -617,6 +629,9 @@ export function Nexus3Artifact({
                     <FormInput.MultiTextInput
                       label={getString('pipeline.artifactsSelection.extension')}
                       name="spec.extension"
+                      tooltipProps={{
+                        dataTooltipId: 'nexusExtension'
+                      }}
                       placeholder={getString('pipeline.artifactsSelection.extensionPlaceholder')}
                       multiTextInputProps={{ expressions, allowableTypes }}
                     />
@@ -641,6 +656,9 @@ export function Nexus3Artifact({
                     <FormInput.MultiTextInput
                       label={getString('pipeline.artifactsSelection.classifier')}
                       name="spec.classifier"
+                      tooltipProps={{
+                        dataTooltipId: 'nexusClassifier'
+                      }}
                       placeholder={getString('pipeline.artifactsSelection.classifierPlaceholder')}
                       multiTextInputProps={{ expressions, allowableTypes }}
                     />
@@ -668,6 +686,9 @@ export function Nexus3Artifact({
                     <FormInput.MultiTextInput
                       label={getString('pipeline.artifactPathLabel')}
                       name="spec.artifactPath"
+                      tooltipProps={{
+                        dataTooltipId: 'nexusArtifactPath'
+                      }}
                       placeholder={getString('pipeline.artifactsSelection.artifactPathPlaceholder')}
                       multiTextInputProps={{ expressions, allowableTypes }}
                     />
@@ -691,6 +712,9 @@ export function Nexus3Artifact({
                   <div className={css.tagGroup}>
                     <FormInput.RadioGroup
                       name="spec.repositoryPortorRepositoryURL"
+                      tooltipProps={{
+                        dataTooltipId: 'nexusRepositoryURL'
+                      }}
                       radioGroup={{ inline: true }}
                       items={repositoryPortOrServer}
                       className={css.radioGroup}
@@ -734,6 +758,9 @@ export function Nexus3Artifact({
                       <FormInput.MultiTextInput
                         label={getString('pipeline.artifactsSelection.repositoryPort')}
                         name="spec.repositoryPort"
+                        tooltipProps={{
+                          dataTooltipId: 'nexusRepositoryPort'
+                        }}
                         placeholder={getString('pipeline.artifactsSelection.repositoryPortPlaceholder')}
                         multiTextInputProps={{
                           expressions,
@@ -791,6 +818,9 @@ export function Nexus3Artifact({
                   <FormInput.MultiTextInput
                     label={getString('pipeline.artifactsSelection.packageName')}
                     name="spec.packageName"
+                    tooltipProps={{
+                      dataTooltipId: 'nexusPackageName'
+                    }}
                     placeholder={getString('pipeline.manifestType.packagePlaceholder')}
                     multiTextInputProps={{ expressions, allowableTypes }}
                   />

--- a/src/modules/70-pipeline/components/ArtifactsSelection/ArtifactRepository/ArtifactLastSteps/NexusArtifact/__tests__/__snapshots__/NexusArtifact.test.tsx.snap
+++ b/src/modules/70-pipeline/components/ArtifactsSelection/ArtifactRepository/ArtifactLastSteps/NexusArtifact/__tests__/__snapshots__/NexusArtifact.test.tsx.snap
@@ -74,7 +74,7 @@ exports[`Nexus Artifact tests form renders correctly in Edit Case 1`] = `
                 >
                   <span
                     class="Tooltip--acenter"
-                    data-tooltip-id="imagePath_repositoryFormat"
+                    data-tooltip-id="nexusRepositoryFormat"
                   >
                     common.repositoryFormat
                   </span>
@@ -146,7 +146,7 @@ exports[`Nexus Artifact tests form renders correctly in Edit Case 1`] = `
                 >
                   <span
                     class="Tooltip--acenter"
-                    data-tooltip-id="imagePath_repository"
+                    data-tooltip-id="nexusRepository"
                   >
                     repository
                   </span>
@@ -250,7 +250,7 @@ exports[`Nexus Artifact tests form renders correctly in Edit Case 1`] = `
                 >
                   <span
                     class="Tooltip--acenter"
-                    data-tooltip-id="imagePath_spec.artifactPath"
+                    data-tooltip-id="nexusArtifactPath"
                   >
                     pipeline.artifactPathLabel
                   </span>
@@ -736,7 +736,7 @@ exports[`Nexus Artifact tests renders without crashing 1`] = `
                 >
                   <span
                     class="Tooltip--acenter"
-                    data-tooltip-id="imagePath_repositoryFormat"
+                    data-tooltip-id="nexusRepositoryFormat"
                   >
                     common.repositoryFormat
                   </span>
@@ -808,7 +808,7 @@ exports[`Nexus Artifact tests renders without crashing 1`] = `
                 >
                   <span
                     class="Tooltip--acenter"
-                    data-tooltip-id="imagePath_repository"
+                    data-tooltip-id="nexusRepository"
                   >
                     repository
                   </span>
@@ -912,7 +912,7 @@ exports[`Nexus Artifact tests renders without crashing 1`] = `
                 >
                   <span
                     class="Tooltip--acenter"
-                    data-tooltip-id="imagePath_spec.artifactPath"
+                    data-tooltip-id="nexusArtifactPath"
                   >
                     pipeline.artifactPathLabel
                   </span>
@@ -1398,7 +1398,7 @@ exports[`Nexus Artifact tests submits correctly with tagRegex data 1`] = `
                 >
                   <span
                     class="Tooltip--acenter"
-                    data-tooltip-id="imagePath_repositoryFormat"
+                    data-tooltip-id="nexusRepositoryFormat"
                   >
                     common.repositoryFormat
                   </span>
@@ -1470,7 +1470,7 @@ exports[`Nexus Artifact tests submits correctly with tagRegex data 1`] = `
                 >
                   <span
                     class="Tooltip--acenter"
-                    data-tooltip-id="imagePath_repository"
+                    data-tooltip-id="nexusRepository"
                   >
                     repository
                   </span>
@@ -1574,7 +1574,7 @@ exports[`Nexus Artifact tests submits correctly with tagRegex data 1`] = `
                 >
                   <span
                     class="Tooltip--acenter"
-                    data-tooltip-id="imagePath_spec.artifactPath"
+                    data-tooltip-id="nexusArtifactPath"
                   >
                     pipeline.artifactPathLabel
                   </span>


### PR DESCRIPTION
### Summary

<!-- ✍️ A clear and concise description...-->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
