### PR TITLE
fix: [DEL-5259]: custom string nano id

### DIFF
--- a/src/modules/75-cd/pages/get-started-with-cd/CreateKubernetesDelegateWizard/CreateK8sDelegate.tsx
+++ b/src/modules/75-cd/pages/get-started-with-cd/CreateKubernetesDelegateWizard/CreateK8sDelegate.tsx
@@ -11,7 +11,7 @@ import { Button, Container, Layout, PageSpinner, Text, useToaster } from '@harne
 import { Color, FontVariation } from '@harness/design-system'
 import cx from 'classnames'
 import { get, isEmpty, set } from 'lodash-es'
-import { nanoid as nanoUuid } from 'nanoid'
+import { customAlphabet } from 'nanoid'
 import { StringUtils } from '@common/exports'
 import {
   DelegateType,
@@ -92,7 +92,8 @@ export const CreateK8sDelegate = ({
       showError(getString('somethingWentWrong'))
     } else {
       const delegateToken = get(delegateTokens, 'resource[0].name')
-      const delegateName1 = `del-${nanoUuid()}`
+      const nanoUuid = customAlphabet('0123456789-abcdefghijklmnopqrstuvwxyz')
+      const delegateName1 = `dl-${nanoUuid()}-spl`
       setDelegateName(delegateName1)
       delegateNameRef.current = delegateName1
       trackEvent(CDOnboardingActions.StartOnboardingDelegateCreation, {

--- a/src/modules/75-cd/pages/get-started-with-cd/__tests__/DelegateOnboarding.test.tsx
+++ b/src/modules/75-cd/pages/get-started-with-cd/__tests__/DelegateOnboarding.test.tsx
@@ -22,7 +22,13 @@ import {
   validateKubernetesYamlResponse
 } from './mocks'
 
-jest.mock('nanoid', () => ({ nanoid: () => 'hjhj87878' }))
+jest.mock('nanoid', () => ({
+  customAlphabet: () => {
+    const retnFn = () => 'bsadfd'
+    return retnFn
+  }
+}))
+
 jest.useFakeTimers()
 const mockGetCallFunction = jest.fn()
 jest.mock('services/cd-ng', () => ({
@@ -50,6 +56,7 @@ jest.mock('services/portal', () => ({
 }))
 global.URL.createObjectURL = jest.fn()
 jest.mock('@common/components/YAMLBuilder/YamlBuilder')
+
 describe('Test the initial flow for kubernetes delegate Creation', () => {
   test('initial render', async () => {
     const { getByText } = render(

--- a/src/modules/75-cd/pages/get-started-with-cd/__tests__/GetStartedWithCD.test.tsx
+++ b/src/modules/75-cd/pages/get-started-with-cd/__tests__/GetStartedWithCD.test.tsx
@@ -11,7 +11,12 @@ import { render } from '@testing-library/react'
 import { TestWrapper } from '@common/utils/testUtils'
 import GetStartedWithCD from '../GetStartedWithCD'
 
-jest.mock('nanoid', () => ({ nanoid: () => 'hjhj87878' }))
+jest.mock('nanoid', () => ({
+  customAlphabet: () => {
+    const retnFn = () => 'bsadfd'
+    return retnFn
+  }
+}))
 describe('Test Get Started With CD', () => {
   test('initial render', async () => {
     const { getByText } = render(


### PR DESCRIPTION
### Summary
delegate name with capitals is failing, so in order to get this corrected we are restricting the random id with numbers and  small case alphabet
collision probability 
![image](https://user-images.githubusercontent.com/73115842/203742686-5fb5070d-893d-473a-8870-2f9d5406b5df.png)
<!-- ✍️ A clear and concise description...-->

#### Screenshots
[screen-capture (7).webm](https://user-images.githubusercontent.com/73115842/203759183-b1fe8582-ad5a-4e51-ac59-58635149f344.webm)

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
