### PR TITLE
feat: [PL-30066]: cleanup ProjectSelector

### DIFF
--- a/src/modules/45-projects-orgs/components/ProjectSelector/ProjectSelector.tsx
+++ b/src/modules/45-projects-orgs/components/ProjectSelector/ProjectSelector.tsx
@@ -5,7 +5,7 @@
  * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
  */
 
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useMemo, useState } from 'react'
 import { Position, PopoverInteractionKind, Classes } from '@blueprintjs/core'
 import { useParams, useHistory } from 'react-router-dom'
 import cx from 'classnames'

--- a/src/modules/45-projects-orgs/components/ProjectSelector/ProjectSelector.tsx
+++ b/src/modules/45-projects-orgs/components/ProjectSelector/ProjectSelector.tsx
@@ -42,7 +42,6 @@ import css from './ProjectSelector.module.scss'
 
 export interface ProjectSelectorProps {
   onSelect: (project: Project) => void
-  moduleFilter?: Required<Project>['modules'][0]
 }
 
 const ProjectSelect: React.FC<ProjectSelectorProps> = ({ onSelect }) => {
@@ -220,17 +219,9 @@ const ProjectSelect: React.FC<ProjectSelectorProps> = ({ onSelect }) => {
     </Popover>
   )
 }
-export const ProjectSelector: React.FC<ProjectSelectorProps> = ({ onSelect, moduleFilter }) => {
-  const { selectedProject, updateAppStore } = useAppStore()
+export const ProjectSelector: React.FC<ProjectSelectorProps> = ({ onSelect }) => {
+  const { selectedProject } = useAppStore()
   const { getString } = useStrings()
-
-  useEffect(() => {
-    // deselect current project if user switches module
-    // and the new module isn't added on selected project
-    if (moduleFilter && !selectedProject?.modules?.includes(moduleFilter)) {
-      updateAppStore({ selectedProject: undefined })
-    }
-  }, [moduleFilter])
 
   return (
     <>

--- a/src/modules/45-projects-orgs/components/ProjectSelector/__test__/ProjectSelector.test.tsx
+++ b/src/modules/45-projects-orgs/components/ProjectSelector/__test__/ProjectSelector.test.tsx
@@ -25,7 +25,7 @@ describe('ProjectSelector', () => {
 
     const { container, getByText, getByTestId } = render(
       <TestWrapper path="/account/:accountId/cd/home" pathParams={{ accountId: 'dummy' }} projects={projects as any}>
-        <ProjectSelector onSelect={handleSelect} moduleFilter="CD" />
+        <ProjectSelector onSelect={handleSelect} />
       </TestWrapper>
     )
 

--- a/src/modules/60-code/components/SideNav/SideNav.tsx
+++ b/src/modules/60-code/components/SideNav/SideNav.tsx
@@ -12,7 +12,6 @@ import routes from '@common/RouteDefinitions'
 import { ProjectSelector, ProjectSelectorProps } from '@projects-orgs/components/ProjectSelector/ProjectSelector'
 import type { CODEPathProps } from '@common/interfaces/RouteInterfaces'
 import { SidebarLink } from '@common/navigation/SideNav/SideNav'
-import { ModuleName } from 'framework/types/ModuleName'
 import { useStrings } from 'framework/strings'
 import { useAppStore } from 'framework/AppStore/AppStoreContext'
 import { codePathProps } from '@common/utils/routeUtils'
@@ -37,10 +36,7 @@ export default function SCMSideNav(): React.ReactElement {
 
   return (
     <Layout.Vertical spacing="small">
-      <ProjectSelector
-        moduleFilter={ModuleName.CODE as ProjectSelectorProps['moduleFilter']}
-        onSelect={projectSelectHandler}
-      />
+      <ProjectSelector onSelect={projectSelectHandler} />
       {projectIdentifier && orgIdentifier && (
         <>
           <SidebarLink

--- a/src/modules/60-scm/components/SideNav/SideNav.tsx
+++ b/src/modules/60-scm/components/SideNav/SideNav.tsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import React from 'react'
+import { useParams, useHistory } from 'react-router-dom'
+import { Layout } from '@harness/uicore'
+import routes from '@common/RouteDefinitions'
+import { ProjectSelector, ProjectSelectorProps } from '@projects-orgs/components/ProjectSelector/ProjectSelector'
+import type { SCMPathProps } from '@common/interfaces/RouteInterfaces'
+import { SidebarLink } from '@common/navigation/SideNav/SideNav'
+import { useStrings } from 'framework/strings'
+import { useAppStore } from 'framework/AppStore/AppStoreContext'
+
+export default function SCMSideNav(): React.ReactElement {
+  const { getString } = useStrings()
+  const { accountId, projectIdentifier, orgIdentifier } = useParams<SCMPathProps>()
+  const history = useHistory()
+  const { updateAppStore } = useAppStore()
+  const projectSelectHandler: ProjectSelectorProps['onSelect'] = data => {
+    updateAppStore({ selectedProject: data })
+
+    history.push(
+      routes.toSCMRepos({
+        accountId,
+        orgIdentifier: data.orgIdentifier as string,
+        projectIdentifier: data.identifier
+      })
+    )
+  }
+
+  return (
+    <Layout.Vertical spacing="small">
+      <ProjectSelector onSelect={projectSelectHandler} />
+      {projectIdentifier && orgIdentifier && (
+        <>
+          <SidebarLink
+            label={getString('repositories')}
+            to={routes.toSCMRepos({ accountId, orgIdentifier, projectIdentifier })}
+          />
+        </>
+      )}
+    </Layout.Vertical>
+  )
+}

--- a/src/modules/75-cd/components/CDSideNav/CDSideNav.tsx
+++ b/src/modules/75-cd/components/CDSideNav/CDSideNav.tsx
@@ -23,7 +23,6 @@ import type {
   UserPathProps
 } from '@common/interfaces/RouteInterfaces'
 import { SidebarLink } from '@common/navigation/SideNav/SideNav'
-import { ModuleName } from 'framework/types/ModuleName'
 import { useAppStore } from 'framework/AppStore/AppStoreContext'
 import { useStrings } from 'framework/strings'
 import { useQueryParams } from '@common/hooks'
@@ -111,7 +110,6 @@ export default function CDSideNav(): React.ReactElement {
   return (
     <Layout.Vertical spacing="small">
       <ProjectSelector
-        moduleFilter={ModuleName.CD}
         onSelect={data => {
           updateAppStore({ selectedProject: data })
           if (connectorId) {

--- a/src/modules/75-cf/components/SideNav/SideNav.tsx
+++ b/src/modules/75-cf/components/SideNav/SideNav.tsx
@@ -12,7 +12,6 @@ import routes from '@common/RouteDefinitions'
 import { ProjectSelector, ProjectSelectorProps } from '@projects-orgs/components/ProjectSelector/ProjectSelector'
 import type { PipelinePathProps } from '@common/interfaces/RouteInterfaces'
 import { SidebarLink } from '@common/navigation/SideNav/SideNav'
-import { ModuleName } from 'framework/types/ModuleName'
 import { useStrings } from 'framework/strings'
 import { useAppStore } from 'framework/AppStore/AppStoreContext'
 import { useQueryParams } from '@common/hooks'
@@ -62,7 +61,7 @@ export default function CFSideNav(): React.ReactElement {
 
   return (
     <Layout.Vertical spacing="small">
-      <ProjectSelector moduleFilter={ModuleName.CF} onSelect={projectSelectHandler} />
+      <ProjectSelector onSelect={projectSelectHandler} />
       {projectIdentifier && orgIdentifier && (
         <>
           <SidebarLink

--- a/src/modules/75-ci/components/CISideNav/CISideNav.tsx
+++ b/src/modules/75-ci/components/CISideNav/CISideNav.tsx
@@ -24,7 +24,6 @@ import type {
 } from '@common/interfaces/RouteInterfaces'
 import { SidebarLink } from '@common/navigation/SideNav/SideNav'
 import { useStrings } from 'framework/strings'
-import { ModuleName } from 'framework/types/ModuleName'
 import { useAppStore } from 'framework/AppStore/AppStoreContext'
 import { useQueryParams } from '@common/hooks'
 import { useFeatureFlags } from '@common/hooks/useFeatureFlag'
@@ -111,7 +110,6 @@ export default function CISideNav(): React.ReactElement {
   return (
     <Layout.Vertical spacing="small">
       <ProjectSelector
-        moduleFilter={ModuleName.CI}
         onSelect={data => {
           setShowGetStartedTabInMainMenu(false)
           updateAppStore({ selectedProject: data })

--- a/src/modules/85-cv/components/SideNav/SideNav.tsx
+++ b/src/modules/85-cv/components/SideNav/SideNav.tsx
@@ -16,7 +16,6 @@ import type { PipelinePathProps } from '@common/interfaces/RouteInterfaces'
 import { SidebarLink } from '@common/navigation/SideNav/SideNav'
 import { useStrings } from 'framework/strings'
 import { useAppStore } from 'framework/AppStore/AppStoreContext'
-import { ModuleName } from 'framework/types/ModuleName'
 import ProjectSetupMenu from '@common/navigation/ProjectSetupMenu/ProjectSetupMenu'
 import { useFeatureFlag } from '@common/hooks/useFeatureFlag'
 import { FeatureFlag } from '@common/featureFlags'
@@ -32,7 +31,6 @@ export default function CVSideNav(): React.ReactElement {
   return (
     <Layout.Vertical spacing="small">
       <ProjectSelector
-        moduleFilter={ModuleName.CV}
         onSelect={data => {
           updateAppStore({ selectedProject: data })
           // if a user is on a pipeline related page, redirect them to project dashboard


### PR DESCRIPTION
### Summary

`moduleFilter` is not required anymore for project selection because that's not a valid business usecase anymore.

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
