### PR TITLE
fix: [CDS-48142]: Support added for showing advanced section for vari…

### DIFF
--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/CustomVariables/CustomVariableEditable.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/CustomVariables/CustomVariableEditable.tsx
@@ -337,6 +337,7 @@ export function CustomVariableEditable(props: CustomVariableEditableProps): Reac
                                 type={variable.type || /* istanbul ignore next */ 'String'}
                                 variableName={variable.name || /* istanbul ignore next */ ''}
                                 hideExecutionTimeField={hideExecutionTimeField}
+                                showAdvanced={true}
                                 onChange={(value, defaultValue) => {
                                   setFieldValue(`variables[${index}].value`, value)
                                   setFieldValue(

--- a/src/modules/75-cd/components/PipelineSteps/DeployServiceEntityStep/DeployServiceEntityInputStep.tsx
+++ b/src/modules/75-cd/components/PipelineSteps/DeployServiceEntityStep/DeployServiceEntityInputStep.tsx
@@ -281,6 +281,7 @@ export function DeployServiceEntityInputStep({
               onChange={value => {
                 formik.setFieldValue(`${localPathPrefix}serviceRef`, value)
               }}
+              isReadonly={inputSetData?.readonly}
             />
           )}
         </div>


### PR DESCRIPTION
…ables and readonly mode for service ref input

### Summary

<!-- ✍️ A clear and concise description...-->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->
<img width="1792" alt="Screenshot 2022-12-10 at 12 19 18 AM" src="https://user-images.githubusercontent.com/96409598/206875188-34f11c4d-6c34-4fd5-929c-9500916264ea.png">
<img width="1792" alt="Screenshot 2022-12-10 at 12 20 07 AM" src="https://user-images.githubusercontent.com/96409598/206875195-492ef30a-7905-438d-8c32-5d059934d4f1.png">
<img width="1792" alt="Screenshot 2022-12-10 at 2 00 36 AM" src="https://user-images.githubusercontent.com/96409598/206875197-07695c38-e45b-4c13-b934-44768bc25309.png">



#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
