### PR TITLE
fix: [CDS-48188]: generic tag fix for custom deployment and validations fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nextgenui",
   "description": "Harness Inc",
-  "version": "0.333.9",
+  "version": "0.333.10",
   "author": "Harness Inc",
   "license": "Harness Inc",
   "homepage": "https://app.harness.io/",

--- a/src/modules/70-pipeline/utils/stageHelpers.ts
+++ b/src/modules/70-pipeline/utils/stageHelpers.ts
@@ -381,6 +381,14 @@ export const isAzureWebAppOrSshWinrmGenericDeploymentType = (
 
   return false
 }
+export const isCustomDTGenericDeploymentType = (deploymentType: string, repo: string | undefined): boolean => {
+  if (isCustomDeploymentType(deploymentType)) {
+    // default repository format should be Generic if none is previously selected
+    return repo ? repo === RepositoryFormatTypes.Generic : true
+  }
+
+  return false
+}
 
 export const detailsHeaderName: Record<string, string> = {
   [ServiceDeploymentType.ServerlessAwsLambda]: 'Amazon Web Services Details',

--- a/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/ArtifactSource/ArtifactoryArtifactSource/ArtifactoryArtifactSource.tsx
+++ b/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/ArtifactSource/ArtifactoryArtifactSource/ArtifactoryArtifactSource.tsx
@@ -33,7 +33,9 @@ import {
   SidecarArtifact,
   useGetBuildDetailsForArtifactoryArtifactWithYaml,
   useGetImagePathsForArtifactoryV2,
-  useGetService
+  useGetService,
+  ArtifactSource,
+  ArtifactListConfig
 } from 'services/cd-ng'
 
 import { ArtifactToConnectorMap, ENABLED_ARTIFACT_TYPES } from '@pipeline/components/ArtifactsSelection/ArtifactHelper'
@@ -44,6 +46,7 @@ import { useVariablesExpression } from '@pipeline/components/PipelineStudio/Pipl
 import {
   getHelpeTextForTags,
   isAzureWebAppGenericDeploymentType,
+  isCustomDTGenericDeploymentType,
   isServerlessDeploymentType,
   ServiceDeploymentType
 } from '@pipeline/utils/stageHelpers'
@@ -272,9 +275,29 @@ const Content = (props: ArtifactoryRenderContent): JSX.Element => {
     return false
   }, [service, artifactPath, selectedDeploymentType, initialValues, artifact])
 
+  const isCustomDeploymentGenericSelected = useMemo(() => {
+    /* istanbul ignore else */
+    if (service) {
+      const parsedService = service?.data?.yaml && parse(service?.data?.yaml)
+      // to be refactored for some fields once generic dependency is resolved via V2
+      const artifactsInfo = get(parsedService, `service.serviceDefinition.spec.artifacts`) as ArtifactListConfig
+      artifactsInfo?.primary?.sources?.map(artifactInfo => {
+        if (artifactInfo?.identifier === (artifact as ArtifactSource)?.identifier) {
+          repoFormat = artifactInfo?.spec?.repositoryFormat
+        }
+      })
+    }
+
+    if (repoFormat) {
+      return isCustomDTGenericDeploymentType(selectedDeploymentType, repoFormat)
+    }
+
+    return false
+  }, [service, artifactPath, selectedDeploymentType, initialValues, artifact])
+
   const isGenericArtifactory = React.useMemo(() => {
-    return isServerlessOrSshOrWinRmSelected || isAzureWebAppGenericSelected
-  }, [isServerlessOrSshOrWinRmSelected, isAzureWebAppGenericSelected])
+    return isServerlessOrSshOrWinRmSelected || isAzureWebAppGenericSelected || isCustomDeploymentGenericSelected
+  }, [isServerlessOrSshOrWinRmSelected, isAzureWebAppGenericSelected, isCustomDeploymentGenericSelected])
 
   const connectorRef = getDefaultQueryParam(
     getValidInitialValuePath(get(artifacts, `${artifactPath}.spec.connectorRef`, ''), artifact?.spec?.connectorRef),
@@ -299,7 +322,7 @@ const Content = (props: ArtifactoryRenderContent): JSX.Element => {
     },
     queryParams: {
       repository: getFinalQueryParamValue(repositoryValue),
-      connectorRef,
+      connectorRef: getFinalQueryParamValue(connectorRef),
       accountIdentifier: accountId,
       orgIdentifier,
       projectIdentifier,


### PR DESCRIPTION
### Summary

- `isGenericArtifactory` check was missing for customDeployment which is being used to render artifactoryDirectory, tags field, and to fetch repositories list based on repository format.

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
