### PR TITLE
feat: [CCM-8563]: Migrate Cloud Integrations page to CCM MFE

### DIFF
--- a/src/microfrontends/package.json
+++ b/src/microfrontends/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/microfrontends",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "description": "",
   "types": "dist/microfrontends/index.d.ts",
   "main": "dist/microfrontends/index.js",
@@ -19,5 +19,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "keywords": []
+  "keywords": [],
+  "dependencies": {
+    "@harness/microfrontends": "file:.yalc/@harness/microfrontends"
+  }
 }

--- a/src/microfrontends/package.json
+++ b/src/microfrontends/package.json
@@ -19,8 +19,5 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "keywords": [],
-  "dependencies": {
-    "@harness/microfrontends": "file:.yalc/@harness/microfrontends"
-  }
+  "keywords": []
 }

--- a/src/modules/75-ce/RouteDestinations.tsx
+++ b/src/modules/75-ce/RouteDestinations.tsx
@@ -43,7 +43,6 @@ import { ConnectorReferenceField } from '@connectors/components/ConnectorReferen
 import FeatureWarningBanner from '@common/components/FeatureWarning/FeatureWarningBanner'
 import { FeatureWarningTooltip } from '@common/components/FeatureWarning/FeatureWarningWithTooltip'
 import useTestConnectionModal from '@connectors/common/useTestConnectionModal/useTestConnectionModal'
-import { ErrorHandler } from '@common/components/ErrorHandler/ErrorHandler'
 import CEHomePage from './pages/home/CEHomePage'
 import CECODashboardPage from './pages/co-dashboard/CECODashboardPage'
 import CECOCreateGatewayPage from './pages/co-create-gateway/CECOCreateGatewayPage'
@@ -874,8 +873,7 @@ const CERoutes: React.FC = () => {
                 ConnectorReferenceField,
                 GatewayListFilters,
                 FeatureWarningBanner,
-                FeatureWarningTooltip,
-                ErrorHandler
+                FeatureWarningTooltip
               }}
               customHooks={{
                 useTestConnectionModal

--- a/src/modules/75-ce/RouteDestinations.tsx
+++ b/src/modules/75-ce/RouteDestinations.tsx
@@ -41,6 +41,9 @@ import RecommendationFilters from '@ce/components/RecommendationFilters'
 import type { CCMUIAppCustomProps } from '@ce/interface/CCMUIApp.types'
 import { ConnectorReferenceField } from '@connectors/components/ConnectorReferenceField/ConnectorReferenceField'
 import FeatureWarningBanner from '@common/components/FeatureWarning/FeatureWarningBanner'
+import { FeatureWarningTooltip } from '@common/components/FeatureWarning/FeatureWarningWithTooltip'
+import useTestConnectionModal from '@connectors/common/useTestConnectionModal/useTestConnectionModal'
+import { ErrorHandler } from '@common/components/ErrorHandler/ErrorHandler'
 import CEHomePage from './pages/home/CEHomePage'
 import CECODashboardPage from './pages/co-dashboard/CECODashboardPage'
 import CECOCreateGatewayPage from './pages/co-create-gateway/CECOCreateGatewayPage'
@@ -684,6 +687,15 @@ const CENonMFERoutes = (
     >
       <CommitmentOrchestrationSetup />
     </RouteWithLayout>
+    <RouteWithLayout
+      licenseRedirectData={licenseRedirectData}
+      sidebarProps={CESideNavProps}
+      path={routes.toCECloudIntegration({ ...accountPathProps })}
+      pageName={PAGE_NAME.CECloudIntegration}
+      exact
+    >
+      <CloudIntegrationPage />
+    </RouteWithLayout>
   </>
 )
 
@@ -788,7 +800,8 @@ const CERoutes: React.FC = () => {
         routes.toCEGovernanceEnforcements({ ...accountPathProps }),
         routes.toCEGovernanceEvaluations({ ...accountPathProps }),
         routes.toCEGovernanceRuleEditor({ ...accountPathProps, ruleId: ':ruleId' }),
-        routes.toCECurrencyPreferences({ ...accountPathProps })
+        routes.toCECurrencyPreferences({ ...accountPathProps }),
+        routes.toCECloudIntegration({ ...accountPathProps })
       ]
     : []
 
@@ -846,15 +859,6 @@ const CERoutes: React.FC = () => {
         <RouteWithLayout
           licenseRedirectData={licenseRedirectData}
           sidebarProps={CESideNavProps}
-          path={routes.toCECloudIntegration({ ...accountPathProps })}
-          pageName={PAGE_NAME.CECloudIntegration}
-          exact
-        >
-          <CloudIntegrationPage />
-        </RouteWithLayout>
-        <RouteWithLayout
-          licenseRedirectData={licenseRedirectData}
-          sidebarProps={CESideNavProps}
           path={routes.toCEGovernance({ ...accountPathProps })}
           exact
         >
@@ -869,7 +873,12 @@ const CERoutes: React.FC = () => {
                 AnomaliesFilter,
                 ConnectorReferenceField,
                 GatewayListFilters,
-                FeatureWarningBanner
+                FeatureWarningBanner,
+                FeatureWarningTooltip,
+                ErrorHandler
+              }}
+              customHooks={{
+                useTestConnectionModal
               }}
               ChildApp={CcmMicroFrontendPath}
             />

--- a/src/modules/75-ce/interface/CCMUIApp.types.ts
+++ b/src/modules/75-ce/interface/CCMUIApp.types.ts
@@ -14,7 +14,6 @@ import type { GatewayListFiltersProps } from '@ce/components/COGatewayList/Gatew
 import type FeatureWarningBanner from '@common/components/FeatureWarning/FeatureWarningBanner'
 import type { FeatureWarningTooltip } from '@common/components/FeatureWarning/FeatureWarningWithTooltip'
 import type useTestConnectionModal from '@connectors/common/useTestConnectionModal/useTestConnectionModal'
-import type { ErrorHandler } from '@common/components/ErrorHandler/ErrorHandler'
 
 export interface CCMUIAppCustomProps {
   customComponents: {
@@ -25,7 +24,6 @@ export interface CCMUIAppCustomProps {
     GatewayListFilters: React.ComponentType<GatewayListFiltersProps>
     FeatureWarningBanner: typeof FeatureWarningBanner
     FeatureWarningTooltip: typeof FeatureWarningTooltip
-    ErrorHandler: typeof ErrorHandler
   }
   customHooks: {
     useTestConnectionModal: typeof useTestConnectionModal

--- a/src/modules/75-ce/interface/CCMUIApp.types.ts
+++ b/src/modules/75-ce/interface/CCMUIApp.types.ts
@@ -12,6 +12,9 @@ import type { AnomalyFiltersProps } from '@ce/components/AnomaliesFilter/Anomali
 import type { ConnectorReferenceFieldProps } from '@connectors/components/ConnectorReferenceField/ConnectorReferenceField'
 import type { GatewayListFiltersProps } from '@ce/components/COGatewayList/GatewayListFilters'
 import type FeatureWarningBanner from '@common/components/FeatureWarning/FeatureWarningBanner'
+import type { FeatureWarningTooltip } from '@common/components/FeatureWarning/FeatureWarningWithTooltip'
+import type useTestConnectionModal from '@connectors/common/useTestConnectionModal/useTestConnectionModal'
+import type { ErrorHandler } from '@common/components/ErrorHandler/ErrorHandler'
 
 export interface CCMUIAppCustomProps {
   customComponents: {
@@ -21,5 +24,10 @@ export interface CCMUIAppCustomProps {
     ConnectorReferenceField: React.ComponentType<ConnectorReferenceFieldProps>
     GatewayListFilters: React.ComponentType<GatewayListFiltersProps>
     FeatureWarningBanner: typeof FeatureWarningBanner
+    FeatureWarningTooltip: typeof FeatureWarningTooltip
+    ErrorHandler: typeof ErrorHandler
+  }
+  customHooks: {
+    useTestConnectionModal: typeof useTestConnectionModal
   }
 }


### PR DESCRIPTION
### Summary

This PR adds `FeatureWarningTooltip` and `useTestConnectionModal` to `CCMUIAppCustomProps` and adds the Cloud Integration page's route to CCM MFE.

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
