### PR TITLE
fix: [PIE-6467]: fix inconsistent field widths

### DIFF
--- a/src/modules/10-common/components/MultiTypeFieldSelector/MultiTypeFieldSelector.tsx
+++ b/src/modules/10-common/components/MultiTypeFieldSelector/MultiTypeFieldSelector.tsx
@@ -146,7 +146,7 @@ export function MultiTypeFieldSelector(props: ConnectedMultiTypeFieldSelectorPro
       ) : type === MultiTypeInputType.EXPRESSION && typeof expressionRender === 'function' ? (
         expressionRender()
       ) : isMultiTypeRuntime(type) && typeof value === 'string' ? (
-        <Layout.Horizontal spacing={'medium'}>
+        <Layout.Horizontal>
           <FormInput.Text style={{ flexGrow: 1 }} className={css.runtimeDisabled} name={name} disabled label="" />
           {enableConfigureOptions && (
             <ConfigureOptions

--- a/src/modules/10-common/components/ReferenceSelect/ReferenceSelect.tsx
+++ b/src/modules/10-common/components/ReferenceSelect/ReferenceSelect.tsx
@@ -5,7 +5,7 @@
  * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
  */
 
-import React, { FC, ReactNode, useMemo, useRef, useState } from 'react'
+import React, { CSSProperties, FC, ReactNode, useMemo, useRef, useState } from 'react'
 import {
   Button,
   ExpressionAndRuntimeTypeProps,
@@ -67,7 +67,7 @@ export interface ReferenceSelectProps<T extends MinimalObject>
   hideModal?: boolean
   selectedRenderer?: JSX.Element
   editRenderer?: JSX.Element
-  width?: number
+  width?: CSSProperties['width']
   isNewConnectorLabelVisible?: boolean
   onChange: (record: T, scope: Scope) => void
   disabled?: boolean

--- a/src/modules/35-connectors/components/ConnectorReferenceField/ConnectorReferenceField.tsx
+++ b/src/modules/35-connectors/components/ConnectorReferenceField/ConnectorReferenceField.tsx
@@ -5,7 +5,7 @@
  * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
  */
 
-import React, { useState } from 'react'
+import React, { CSSProperties, useState } from 'react'
 import { FormGroup, IFormGroupProps, Intent, PopoverInteractionKind } from '@blueprintjs/core'
 import {
   Layout,
@@ -119,7 +119,7 @@ export interface ConnectorReferenceFieldProps extends Omit<IFormGroupProps, 'lab
   orgIdentifier?: string
   gitScope?: GitFilterScope
   defaultScope?: Scope
-  width?: number
+  width?: CSSProperties['width']
   type?: ConnectorInfoDTO['type'] | ConnectorInfoDTO['type'][]
   category?: GetConnectorListQueryParams['category']
   error?: string

--- a/src/modules/35-connectors/components/ConnectorReferenceField/FormMultiTypeConnectorField.tsx
+++ b/src/modules/35-connectors/components/ConnectorReferenceField/FormMultiTypeConnectorField.tsx
@@ -518,7 +518,6 @@ export const MultiTypeConnectorField = (props: MultiTypeConnectorFieldProps): Re
                 formik?.setFieldValue(name, val)
                 onChange?.(val, MultiTypeInputValue.STRING, MultiTypeInputType.RUNTIME)
               }}
-              style={{ marginLeft: 'var(--spacing-medium)' }}
               {...configureOptionsProps}
               isReadonly={props.disabled}
               connectorReferenceFieldProps={{

--- a/src/modules/70-pipeline/components/ArtifactsSelection/ArtifactRepository/ArtifactConnector.tsx
+++ b/src/modules/70-pipeline/components/ArtifactsSelection/ArtifactRepository/ArtifactConnector.tsx
@@ -110,7 +110,6 @@ export function ArtifactConnector(props: StepProps<ConnectorConfigDTO> & Artifac
           <FormikForm>
             <div className={css.connectorForm}>
               <Layout.Horizontal
-                spacing={'medium'}
                 flex={{ alignItems: 'flex-start', justifyContent: 'flex-start' }}
                 className={css.connectorContainer}
               >

--- a/src/modules/70-pipeline/components/InputSetView/InputSetView.module.scss
+++ b/src/modules/70-pipeline/components/InputSetView/InputSetView.module.scss
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+.fieldAndOptions {
+  display: grid;
+  grid-template-columns: minmax(min-content, 320px) 42px;
+}

--- a/src/modules/70-pipeline/components/InputSetView/InputSetView.module.scss.d.ts
+++ b/src/modules/70-pipeline/components/InputSetView/InputSetView.module.scss.d.ts
@@ -7,10 +7,6 @@
  **/
 // this is an auto-generated file, do not update this manually
 declare const styles: {
-  readonly connector: string
-  readonly connectorLabel: string
-  readonly defaultFieldWidth: string
-  readonly marginTop: string
-  readonly tooltip: string
+  readonly fieldAndOptions: string
 }
 export default styles

--- a/src/modules/70-pipeline/components/InputSetView/SelectInputSetView/SelectInputSetView.tsx
+++ b/src/modules/70-pipeline/components/InputSetView/SelectInputSetView/SelectInputSetView.tsx
@@ -8,21 +8,16 @@
 import React from 'react'
 import { defaultTo, get } from 'lodash-es'
 import { connect } from 'formik'
-import {
-  DataTooltipInterface,
-  MultiTypeInputType,
-  Container,
-  FormInput,
-  getMultiTypeFromValue,
-  Layout
-} from '@harness/uicore'
+import { DataTooltipInterface, MultiTypeInputType, FormInput, getMultiTypeFromValue } from '@harness/uicore'
 import type { FormMultiTypeInputProps } from '@harness/uicore/dist/components/FormikForm/FormikForm'
 import type { FormikContextProps, FormikExtended } from '@harness/uicore/dist/components/FormikForm/utils'
 
+import classNames from 'classnames'
 import type { ConfigureOptionsProps } from '@common/components/ConfigureOptions/ConfigureOptions'
 import { SelectConfigureOptions } from '@common/components/ConfigureOptions/SelectConfigureOptions/SelectConfigureOptions'
 import { shouldRenderRunTimeInputViewWithAllowedValues } from '@pipeline/utils/CIUtils'
 import { useRenderMultiTypeInputWithAllowedValues } from '../utils/utils'
+import css from '../InputSetView.module.scss'
 
 interface SelectInputSetViewProps extends FormMultiTypeInputProps, FormikContextProps<any> {
   formik?: FormikExtended<any>
@@ -54,37 +49,34 @@ export function SelectInputSet(props: SelectInputSetViewProps): JSX.Element {
     allowedTypes: defaultTo(multiTypeInputProps?.allowableTypes, [MultiTypeInputType.FIXED]),
     template,
     readonly: disabled,
-    tooltipProps,
-    className
+    tooltipProps
   })
 
   const inputField = shouldRenderRunTimeInputViewWithAllowedValues(fieldPath, template) ? (
     getMultiTypeInputWithAllowedValues()
   ) : (
-    <FormInput.MultiTypeInput style={{ flexGrow: 1 }} {...rest} />
+    <FormInput.MultiTypeInput {...rest} />
   )
 
   return (
-    <Container className={className}>
-      <Layout.Horizontal>
-        {inputField}
-        {enableConfigureOptions && getMultiTypeFromValue(value) === MultiTypeInputType.RUNTIME && (
-          <SelectConfigureOptions
-            options={selectItems}
-            value={value}
-            type={'String'}
-            variableName={name}
-            showRequiredField={false}
-            showDefaultField={false}
-            showAdvanced={true}
-            onChange={val => formik?.setFieldValue(name, val)}
-            style={label ? { marginTop: 'var(--spacing-6)' } : undefined}
-            {...configureOptionsProps}
-            isReadonly={disabled}
-          />
-        )}
-      </Layout.Horizontal>
-    </Container>
+    <div className={classNames(css.fieldAndOptions, className)}>
+      {inputField}
+      {enableConfigureOptions && getMultiTypeFromValue(value) === MultiTypeInputType.RUNTIME && (
+        <SelectConfigureOptions
+          options={selectItems}
+          value={value}
+          type={'String'}
+          variableName={name}
+          showRequiredField={false}
+          showDefaultField={false}
+          showAdvanced={true}
+          onChange={val => formik?.setFieldValue(name, val)}
+          style={label ? { marginTop: 'var(--spacing-6)' } : undefined}
+          {...configureOptionsProps}
+          isReadonly={disabled}
+        />
+      )}
+    </div>
   )
 }
 

--- a/src/modules/70-pipeline/components/InputSetView/TextFieldInputSetView/TextFieldInputSetView.tsx
+++ b/src/modules/70-pipeline/components/InputSetView/TextFieldInputSetView/TextFieldInputSetView.tsx
@@ -7,14 +7,8 @@
 
 import React from 'react'
 import { defaultTo, get } from 'lodash-es'
-import {
-  MultiTypeInputType,
-  Container,
-  DataTooltipInterface,
-  FormInput,
-  getMultiTypeFromValue,
-  Layout
-} from '@harness/uicore'
+import classNames from 'classnames'
+import { MultiTypeInputType, DataTooltipInterface, FormInput, getMultiTypeFromValue } from '@harness/uicore'
 import type { FormMultiTextTypeInputProps } from '@harness/uicore/dist/components/FormikForm/FormikForm'
 import type { FormikContextType } from 'formik'
 import { connect } from 'formik'
@@ -25,6 +19,7 @@ import {
   ConfigureOptionsProps
 } from '@common/components/ConfigureOptions/ConfigureOptions'
 import { useRenderMultiTypeInputWithAllowedValues } from '../utils/utils'
+import css from '../InputSetView.module.scss'
 
 interface TextFieldInputSetView extends FormMultiTextTypeInputProps {
   formik?: FormikContextType<any>
@@ -58,37 +53,34 @@ function TextFieldInputSet(props: TextFieldInputSetView): JSX.Element {
     allowedTypes: defaultTo(multiTextInputProps?.allowableTypes, [MultiTypeInputType.FIXED]),
     template,
     readonly: disabled,
-    tooltipProps,
-    className
+    tooltipProps
   })
 
   const inputField = shouldRenderRunTimeInputViewWithAllowedValues(fieldPath, template) ? (
     getMultiTypeInputWithAllowedValues()
   ) : (
-    <FormInput.MultiTextInput style={{ flexGrow: 1 }} {...rest} />
+    <FormInput.MultiTextInput {...rest} />
   )
 
   return (
-    <Container className={className}>
-      <Layout.Horizontal spacing={'medium'}>
-        {inputField}
-        {enableConfigureOptions && getMultiTypeFromValue(value) === MultiTypeInputType.RUNTIME && (
-          <ConfigureOptions
-            value={value}
-            type={'String'}
-            variableName={variableName}
-            showRequiredField={false}
-            showDefaultField={false}
-            showAdvanced={true}
-            onChange={val => formik?.setFieldValue(name, val)}
-            style={label ? { marginTop: 'var(--spacing-6)' } : undefined}
-            allowedValuesType={ALLOWED_VALUES_TYPE.TEXT}
-            {...configureOptionsProps}
-            isReadonly={disabled}
-          />
-        )}
-      </Layout.Horizontal>
-    </Container>
+    <div className={classNames(css.fieldAndOptions, className)}>
+      {inputField}
+      {enableConfigureOptions && getMultiTypeFromValue(value) === MultiTypeInputType.RUNTIME && (
+        <ConfigureOptions
+          value={value}
+          type={'String'}
+          variableName={variableName}
+          showRequiredField={false}
+          showDefaultField={false}
+          showAdvanced={true}
+          onChange={val => formik?.setFieldValue(name, val)}
+          style={label ? { marginTop: 'var(--spacing-6)' } : undefined}
+          allowedValuesType={ALLOWED_VALUES_TYPE.TEXT}
+          {...configureOptionsProps}
+          isReadonly={disabled}
+        />
+      )}
+    </div>
   )
 }
 

--- a/src/modules/70-pipeline/components/InputSetView/TimeoutFieldInputSetView/TimeoutFieldInputSetView.tsx
+++ b/src/modules/70-pipeline/components/InputSetView/TimeoutFieldInputSetView/TimeoutFieldInputSetView.tsx
@@ -6,8 +6,9 @@
  */
 
 import React from 'react'
-import { MultiTypeInputType, Container, getMultiTypeFromValue, Layout } from '@harness/uicore'
+import { MultiTypeInputType, getMultiTypeFromValue } from '@harness/uicore'
 import { defaultTo, get } from 'lodash-es'
+import classNames from 'classnames'
 import {
   FormMultiTypeDurationField,
   FormMultiTypeDurationProps
@@ -15,6 +16,7 @@ import {
 import { shouldRenderRunTimeInputViewWithAllowedValues } from '@pipeline/utils/CIUtils'
 import { ALLOWED_VALUES_TYPE, ConfigureOptions } from '@common/components/ConfigureOptions/ConfigureOptions'
 import { useRenderMultiTypeInputWithAllowedValues } from '../utils/utils'
+import css from '../InputSetView.module.scss'
 
 interface TimeoutFieldInputSetViewProps extends Omit<FormMultiTypeDurationProps, 'label'> {
   label: string
@@ -36,35 +38,32 @@ export function TimeoutFieldInputSetView(props: TimeoutFieldInputSetViewProps): 
     allowedTypes: defaultTo(multiTypeDurationProps?.allowableTypes, [MultiTypeInputType.FIXED]),
     template: template,
     readonly: disabled,
-    tooltipProps: tooltipProps,
-    className
+    tooltipProps: tooltipProps
   })
 
   if (shouldRenderRunTimeInputViewWithAllowedValues(fieldPath, template)) {
     return (
-      <Container className={className}>
-        <Layout.Horizontal spacing={'medium'}>
-          {getMultiTypeInputWithAllowedValues()}
-          {enableConfigureOptions && getMultiTypeFromValue(value) === MultiTypeInputType.RUNTIME && (
-            <ConfigureOptions
-              value={value}
-              type={'String'}
-              variableName={name}
-              showRequiredField={false}
-              showDefaultField={false}
-              showAdvanced={true}
-              onChange={val => formik?.setFieldValue(name, val)}
-              allowedValuesType={ALLOWED_VALUES_TYPE.TIME}
-              style={label ? { marginTop: 'var(--spacing-6)' } : undefined}
-              {...configureOptionsProps}
-              isExecutionTimeFieldDisabled
-              isReadonly={disabled}
-            />
-          )}
-        </Layout.Horizontal>
-      </Container>
+      <div className={classNames(css.fieldAndOptions, className)}>
+        {getMultiTypeInputWithAllowedValues()}
+        {enableConfigureOptions && getMultiTypeFromValue(value) === MultiTypeInputType.RUNTIME && (
+          <ConfigureOptions
+            value={value}
+            type={'String'}
+            variableName={name}
+            showRequiredField={false}
+            showDefaultField={false}
+            showAdvanced={true}
+            onChange={val => formik?.setFieldValue(name, val)}
+            allowedValuesType={ALLOWED_VALUES_TYPE.TIME}
+            style={label ? { marginTop: 'var(--spacing-6)' } : undefined}
+            {...configureOptionsProps}
+            isExecutionTimeFieldDisabled
+            isReadonly={disabled}
+          />
+        )}
+      </div>
     )
   }
 
-  return <FormMultiTypeDurationField {...rest} />
+  return <FormMultiTypeDurationField {...rest} style={{ ...rest.style, width: '320px' }} />
 }

--- a/src/modules/70-pipeline/components/InputSetView/utils/utils.tsx
+++ b/src/modules/70-pipeline/components/InputSetView/utils/utils.tsx
@@ -29,7 +29,6 @@ interface UseRenderMultiTypeInputWithAllowedValuesArgs {
   allowedTypes: AllowedTypes
   template: any
   readonly?: boolean
-  className?: string
 }
 
 export const useRenderMultiTypeInputWithAllowedValues = ({
@@ -40,8 +39,7 @@ export const useRenderMultiTypeInputWithAllowedValues = ({
   fieldPath,
   allowedTypes,
   template,
-  readonly,
-  className
+  readonly
 }: UseRenderMultiTypeInputWithAllowedValuesArgs): { getMultiTypeInputWithAllowedValues: () => JSX.Element } => {
   const { expressions } = useVariablesExpression()
 
@@ -61,8 +59,6 @@ export const useRenderMultiTypeInputWithAllowedValues = ({
         }}
         disabled={readonly}
         tooltipProps={tooltipProps}
-        className={className}
-        style={{ flexGrow: 1 }}
       />
     )
   }

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/Approval/HarnessApprovalDeploymentMode.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/Approval/HarnessApprovalDeploymentMode.tsx
@@ -42,7 +42,6 @@ export default function HarnessApprovalDeploymentMode(props: HarnessApprovalDepl
         <TimeoutFieldInputSetView
           name={`${prefix}timeout`}
           label={getString('pipelineSteps.timeoutLabel')}
-          className={css.deploymentViewMedium}
           multiTypeDurationProps={{
             configureOptionsProps: {
               isExecutionTimeFieldDisabled: isExecutionTimeFieldDisabled(stepViewType)
@@ -115,7 +114,6 @@ export default function HarnessApprovalDeploymentMode(props: HarnessApprovalDepl
             isExecutionTimeFieldDisabled: isExecutionTimeFieldDisabled(stepViewType),
             allowedValuesType: ALLOWED_VALUES_TYPE.NUMBER
           }}
-          className={css.deploymentViewMedium}
           fieldPath="spec.approvers.minimumCount"
           template={template}
         />

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraApproval/JiraApproval.module.scss
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraApproval/JiraApproval.module.scss
@@ -20,8 +20,8 @@
   padding-bottom: 0 !important;
 }
 
-.deploymentViewMedium {
-  width: 50%;
+.defaultFieldWidth {
+  width: 320px;
 }
 .marginTop {
   margin-top: -10px !important;

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraApproval/JiraApproval.module.scss
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraApproval/JiraApproval.module.scss
@@ -20,8 +20,8 @@
   padding-bottom: 0 !important;
 }
 
-.defaultFieldWidth {
-  width: 320px;
+.deploymentViewMedium {
+  width: 50%;
 }
 .marginTop {
   margin-top: -10px !important;

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraApproval/JiraApproval.module.scss.d.ts
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraApproval/JiraApproval.module.scss.d.ts
@@ -9,7 +9,7 @@
 declare const styles: {
   readonly connector: string
   readonly connectorLabel: string
-  readonly defaultFieldWidth: string
+  readonly deploymentViewMedium: string
   readonly marginTop: string
   readonly tooltip: string
 }

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraApproval/JiraApprovalDeploymentMode.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraApproval/JiraApprovalDeploymentMode.tsx
@@ -44,7 +44,6 @@ function FormContent(formContentProps: JiraApprovalDeploymentModeProps) {
         <TimeoutFieldInputSetView
           name={`${prefix}timeout`}
           label={getString('pipelineSteps.timeoutLabel')}
-          className={css.deploymentViewMedium}
           multiTypeDurationProps={{
             configureOptionsProps: {
               isExecutionTimeFieldDisabled: isExecutionTimeFieldDisabled(stepViewType)
@@ -68,7 +67,7 @@ function FormContent(formContentProps: JiraApprovalDeploymentModeProps) {
           accountIdentifier={accountId}
           projectIdentifier={projectIdentifier}
           orgIdentifier={orgIdentifier}
-          width={385}
+          width={320}
           setRefValue
           disabled={isApprovalStepFieldDisabled(readonly)}
           multiTypeProps={{
@@ -99,7 +98,6 @@ function FormContent(formContentProps: JiraApprovalDeploymentModeProps) {
           configureOptionsProps={{
             isExecutionTimeFieldDisabled: isExecutionTimeFieldDisabled(stepViewType)
           }}
-          className={css.deploymentViewMedium}
           fieldPath="spec.issueKey"
           template={template}
         />
@@ -107,7 +105,7 @@ function FormContent(formContentProps: JiraApprovalDeploymentModeProps) {
 
       {getMultiTypeFromValue(template?.spec?.approvalCriteria?.spec?.expression) === MultiTypeInputType.RUNTIME ? (
         <FormMultiTypeTextAreaField
-          className={css.deploymentViewMedium}
+          className={css.defaultFieldWidth}
           label={getString('pipeline.approvalCriteria.jexlExpressionLabelApproval')}
           name={`${prefix}spec.approvalCriteria.spec.expression`}
           disabled={isApprovalStepFieldDisabled(readonly)}
@@ -123,7 +121,7 @@ function FormContent(formContentProps: JiraApprovalDeploymentModeProps) {
 
       {getMultiTypeFromValue(template?.spec?.rejectionCriteria?.spec?.expression) === MultiTypeInputType.RUNTIME ? (
         <FormMultiTypeTextAreaField
-          className={css.deploymentViewMedium}
+          className={css.defaultFieldWidth}
           label={getString('pipeline.approvalCriteria.jexlExpressionLabelRejection')}
           name={`${prefix}spec.rejectionCriteria.spec.expression`}
           disabled={isApprovalStepFieldDisabled(readonly)}

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraApproval/JiraApprovalDeploymentMode.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraApproval/JiraApprovalDeploymentMode.tsx
@@ -44,7 +44,6 @@ function FormContent(formContentProps: JiraApprovalDeploymentModeProps) {
         <TimeoutFieldInputSetView
           name={`${prefix}timeout`}
           label={getString('pipelineSteps.timeoutLabel')}
-          className={css.deploymentViewMedium}
           multiTypeDurationProps={{
             configureOptionsProps: {
               isExecutionTimeFieldDisabled: isExecutionTimeFieldDisabled(stepViewType)
@@ -99,7 +98,6 @@ function FormContent(formContentProps: JiraApprovalDeploymentModeProps) {
           configureOptionsProps={{
             isExecutionTimeFieldDisabled: isExecutionTimeFieldDisabled(stepViewType)
           }}
-          className={css.deploymentViewMedium}
           fieldPath="spec.issueKey"
           template={template}
         />

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraApproval/JiraApprovalDeploymentMode.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraApproval/JiraApprovalDeploymentMode.tsx
@@ -44,6 +44,7 @@ function FormContent(formContentProps: JiraApprovalDeploymentModeProps) {
         <TimeoutFieldInputSetView
           name={`${prefix}timeout`}
           label={getString('pipelineSteps.timeoutLabel')}
+          className={css.deploymentViewMedium}
           multiTypeDurationProps={{
             configureOptionsProps: {
               isExecutionTimeFieldDisabled: isExecutionTimeFieldDisabled(stepViewType)
@@ -67,7 +68,7 @@ function FormContent(formContentProps: JiraApprovalDeploymentModeProps) {
           accountIdentifier={accountId}
           projectIdentifier={projectIdentifier}
           orgIdentifier={orgIdentifier}
-          width={320}
+          width={385}
           setRefValue
           disabled={isApprovalStepFieldDisabled(readonly)}
           multiTypeProps={{
@@ -98,6 +99,7 @@ function FormContent(formContentProps: JiraApprovalDeploymentModeProps) {
           configureOptionsProps={{
             isExecutionTimeFieldDisabled: isExecutionTimeFieldDisabled(stepViewType)
           }}
+          className={css.deploymentViewMedium}
           fieldPath="spec.issueKey"
           template={template}
         />
@@ -105,7 +107,7 @@ function FormContent(formContentProps: JiraApprovalDeploymentModeProps) {
 
       {getMultiTypeFromValue(template?.spec?.approvalCriteria?.spec?.expression) === MultiTypeInputType.RUNTIME ? (
         <FormMultiTypeTextAreaField
-          className={css.defaultFieldWidth}
+          className={css.deploymentViewMedium}
           label={getString('pipeline.approvalCriteria.jexlExpressionLabelApproval')}
           name={`${prefix}spec.approvalCriteria.spec.expression`}
           disabled={isApprovalStepFieldDisabled(readonly)}
@@ -121,7 +123,7 @@ function FormContent(formContentProps: JiraApprovalDeploymentModeProps) {
 
       {getMultiTypeFromValue(template?.spec?.rejectionCriteria?.spec?.expression) === MultiTypeInputType.RUNTIME ? (
         <FormMultiTypeTextAreaField
-          className={css.defaultFieldWidth}
+          className={css.deploymentViewMedium}
           label={getString('pipeline.approvalCriteria.jexlExpressionLabelRejection')}
           name={`${prefix}spec.rejectionCriteria.spec.expression`}
           disabled={isApprovalStepFieldDisabled(readonly)}

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraCreate/JiraCreateDeploymentMode.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraCreate/JiraCreateDeploymentMode.tsx
@@ -206,7 +206,6 @@ function FormContent(formContentProps: JiraCreateDeploymentModeFormContentInterf
         <TimeoutFieldInputSetView
           name={`${isEmpty(inputSetData?.path) ? '' : `${inputSetData?.path}.`}timeout`}
           label={getString('pipelineSteps.timeoutLabel')}
-          className={css.deploymentViewMedium}
           multiTypeDurationProps={{
             configureOptionsProps: {
               isExecutionTimeFieldDisabled: isExecutionTimeFieldDisabled(stepViewType)
@@ -230,7 +229,7 @@ function FormContent(formContentProps: JiraCreateDeploymentModeFormContentInterf
           accountIdentifier={accountId}
           projectIdentifier={projectIdentifier}
           orgIdentifier={orgIdentifier}
-          width={385}
+          width={320}
           setRefValue
           disabled={isApprovalStepFieldDisabled(readonly)}
           multiTypeProps={{
@@ -247,7 +246,6 @@ function FormContent(formContentProps: JiraCreateDeploymentModeFormContentInterf
       {getMultiTypeFromValue(template?.spec?.projectKey) === MultiTypeInputType.RUNTIME ? (
         <SelectInputSetView
           selectItems={projectOptions}
-          className={css.deploymentViewMedium}
           label={getString('pipeline.jiraApprovalStep.project')}
           name={`${prefix}spec.projectKey`}
           useValue
@@ -278,7 +276,6 @@ function FormContent(formContentProps: JiraCreateDeploymentModeFormContentInterf
       {getMultiTypeFromValue(template?.spec?.issueType) === MultiTypeInputType.RUNTIME ? (
         <SelectInputSetView
           selectItems={setIssueTypeOptions(projectMetadata?.issuetypes)}
-          className={css.deploymentViewMedium}
           placeholder={
             fetchingProjectMetadata
               ? getString('pipeline.jiraApprovalStep.fetchingIssueTypePlaceholder')

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraUpdate/JiraUpdateDeploymentMode.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraUpdate/JiraUpdateDeploymentMode.tsx
@@ -27,7 +27,6 @@ import { isExecutionTimeFieldDisabled } from '@pipeline/utils/runPipelineUtils'
 import { isApprovalStepFieldDisabled } from '../Common/ApprovalCommons'
 import { getGenuineValue } from '../JiraApproval/helper'
 import type { JiraUpdateDeploymentModeFormContentInterface, JiraUpdateDeploymentModeProps } from './types'
-import css from '../JiraCreate/JiraCreate.module.scss'
 
 function FormContent(formContentProps: JiraUpdateDeploymentModeFormContentInterface): React.ReactElement {
   const {
@@ -102,7 +101,6 @@ function FormContent(formContentProps: JiraUpdateDeploymentModeFormContentInterf
         <TimeoutFieldInputSetView
           name={`${isEmpty(inputSetData?.path) ? '' : `${inputSetData?.path}.`}timeout`}
           label={getString('pipelineSteps.timeoutLabel')}
-          className={css.deploymentViewMedium}
           multiTypeDurationProps={{
             configureOptionsProps: {
               isExecutionTimeFieldDisabled: isExecutionTimeFieldDisabled(stepViewType)
@@ -126,7 +124,7 @@ function FormContent(formContentProps: JiraUpdateDeploymentModeFormContentInterf
           accountIdentifier={accountId}
           projectIdentifier={projectIdentifier}
           orgIdentifier={orgIdentifier}
-          width={385}
+          width={320}
           setRefValue
           disabled={isApprovalStepFieldDisabled(readonly)}
           multiTypeProps={{
@@ -144,7 +142,6 @@ function FormContent(formContentProps: JiraUpdateDeploymentModeFormContentInterf
       {getMultiTypeFromValue(template?.spec?.issueKey) === MultiTypeInputType.RUNTIME ? (
         <TextFieldInputSetView
           label={getString('pipeline.jiraApprovalStep.issueKey')}
-          className={css.deploymentViewMedium}
           name={`${prefix}spec.issueKey`}
           disabled={isApprovalStepFieldDisabled(readonly)}
           placeholder={getString('pipeline.jiraApprovalStep.issueKeyPlaceholder')}
@@ -160,7 +157,6 @@ function FormContent(formContentProps: JiraUpdateDeploymentModeFormContentInterf
       {getMultiTypeFromValue(template?.spec?.transitionTo?.status) === MultiTypeInputType.RUNTIME ? (
         <SelectInputSetView
           selectItems={statusOptions}
-          className={css.deploymentViewMedium}
           label={getString('status')}
           name={`${prefix}spec.transitionTo.status`}
           disabled={isApprovalStepFieldDisabled(readonly)}
@@ -192,7 +188,6 @@ function FormContent(formContentProps: JiraUpdateDeploymentModeFormContentInterf
         <TextFieldInputSetView
           placeholder={getString('pipeline.jiraUpdateStep.transitionPlaceholder')}
           label={getString('pipeline.jiraUpdateStep.transitionLabel')}
-          className={css.deploymentViewMedium}
           name={`${prefix}spec.transitionTo.transitionName`}
           disabled={isApprovalStepFieldDisabled(readonly)}
           multiTextInputProps={{ expressions, allowableTypes }}
@@ -212,7 +207,6 @@ function FormContent(formContentProps: JiraUpdateDeploymentModeFormContentInterf
             disabled={isApprovalStepFieldDisabled(readonly)}
             name={`${prefix}spec.fields[${index}].value`}
             placeholder={field.name}
-            className={css.deploymentViewMedium}
             multiTextInputProps={{
               allowableTypes: [MultiTypeInputType.FIXED, MultiTypeInputType.EXPRESSION],
               expressions

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/ServiceNowApprovalDeploymentMode.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/ServiceNowApprovalDeploymentMode.tsx
@@ -123,7 +123,6 @@ function FormContent(formContentProps: SnowApprovalDeploymentModeProps): JSX.Ele
         <TimeoutFieldInputSetView
           name={`${prefix}timeout`}
           label={getString('pipelineSteps.timeoutLabel')}
-          className={css.deploymentViewMedium}
           multiTypeDurationProps={{
             configureOptionsProps: {
               isExecutionTimeFieldDisabled: isExecutionTimeFieldDisabled(stepViewType)
@@ -215,7 +214,6 @@ function FormContent(formContentProps: SnowApprovalDeploymentModeProps): JSX.Ele
           configureOptionsProps={{
             isExecutionTimeFieldDisabled: isExecutionTimeFieldDisabled(stepViewType)
           }}
-          className={css.deploymentViewMedium}
           fieldPath="spec.ticketNumber"
           template={template}
         />

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowCreate/ServiceNowCreateDeploymentMode.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowCreate/ServiceNowCreateDeploymentMode.tsx
@@ -159,7 +159,6 @@ function FormContent(formContentProps: ServiceNowCreateDeploymentModeFormContent
         <TimeoutFieldInputSetView
           name={`${isEmpty(inputSetData?.path) ? '' : `${inputSetData?.path}.`}timeout`}
           label={getString('pipelineSteps.timeoutLabel')}
-          className={css.deploymentViewMedium}
           multiTypeDurationProps={{
             configureOptionsProps: {
               isExecutionTimeFieldDisabled: isExecutionTimeFieldDisabled(stepViewType)
@@ -281,7 +280,6 @@ function FormContent(formContentProps: ServiceNowCreateDeploymentModeFormContent
             allowableTypes: allowableTypes
           }}
           configureOptionsProps={{ isExecutionTimeFieldDisabled: isExecutionTimeFieldDisabled(stepViewType) }}
-          className={css.deploymentViewMedium}
           fieldPath={'spec.templateName'}
           template={template}
         />

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowImportSet/ServiceNowImportSetDeploymentMode.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowImportSet/ServiceNowImportSetDeploymentMode.tsx
@@ -91,7 +91,6 @@ export default function ServiceNowImportSetDeploymentMode(props: ServiceNowImpor
         <TimeoutFieldInputSetView
           name={`${prefix}timeout`}
           label={getString('pipelineSteps.timeoutLabel')}
-          className={css.deploymentViewMedium}
           multiTypeDurationProps={{
             configureOptionsProps: {
               isExecutionTimeFieldDisabled: isExecutionTimeFieldDisabled(stepViewType)

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowUpdate/ServiceNowUpdateDeploymentMode.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowUpdate/ServiceNowUpdateDeploymentMode.tsx
@@ -165,7 +165,6 @@ function FormContent(formContentProps: ServiceNowUpdateDeploymentModeFormContent
         <TimeoutFieldInputSetView
           name={`${prefix}timeout`}
           label={getString('pipelineSteps.timeoutLabel')}
-          className={css.deploymentViewMedium}
           multiTypeDurationProps={{
             configureOptionsProps: {
               isExecutionTimeFieldDisabled: isExecutionTimeFieldDisabled(stepViewType)
@@ -306,7 +305,6 @@ function FormContent(formContentProps: ServiceNowUpdateDeploymentModeFormContent
             allowableTypes: allowableTypes
           }}
           configureOptionsProps={{ isExecutionTimeFieldDisabled: isExecutionTimeFieldDisabled(stepViewType) }}
-          className={css.deploymentViewMedium}
           fieldPath={'spec.templateName'}
           template={template}
         />

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/Steps.module.scss
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/Steps.module.scss
@@ -45,7 +45,7 @@
 
 .formGroup {
   display: grid;
-  grid-template-columns: 1fr 30px;
+  grid-template-columns: 1fr 42px;
   align-items: center;
   width: 100%;
 

--- a/src/modules/75-cd/components/PipelineSteps/Common/GenericServiceSpec/GenericServiceSpec.module.scss
+++ b/src/modules/75-cd/components/PipelineSteps/Common/GenericServiceSpec/GenericServiceSpec.module.scss
@@ -63,12 +63,15 @@
 .custom-variables {
   padding: 0 var(--spacing-large);
 }
+
 .padSmall {
   padding: var(--spacing-small);
 }
+
 .inputWidth {
-  width: 50% !important;
+  width: 362px !important; // field width (320px) + configure options button width (42px)
 }
+
 .nested-accordions {
   box-shadow: none !important;
 
@@ -226,9 +229,10 @@
 .artifactsAccordion {
   margin-top: var(--spacing-medium) !important;
 }
+
 .inputFieldLayout {
   display: grid;
-  grid-template-columns: 400px 20px;
+  grid-template-columns: 320px 42px;
   margin-top: var(--spacing-large);
   .configureOptions {
     position: relative;

--- a/src/modules/75-cd/components/PipelineSteps/Common/GenericServiceSpec/GenericServiceSpec.module.scss
+++ b/src/modules/75-cd/components/PipelineSteps/Common/GenericServiceSpec/GenericServiceSpec.module.scss
@@ -69,7 +69,8 @@
 }
 
 .inputWidth {
-  width: 362px !important; // field width (320px) + configure options button width (42px)
+  /* field width (320px) + configure options button width (42px) */
+  width: 362px !important;
 }
 
 .nested-accordions {

--- a/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/ArtifactSource/DockerArtifactSource/DockerArtifactSource.tsx
+++ b/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/ArtifactSource/DockerArtifactSource/DockerArtifactSource.tsx
@@ -208,7 +208,7 @@ const Content = (props: DockerRenderContent): React.ReactElement => {
               projectIdentifier={projectIdentifier}
               configureOptionsProps={{ className: css.connectorConfigOptions }}
               orgIdentifier={orgIdentifier}
-              width={391}
+              width={320}
               setRefValue
               disabled={isFieldDisabled(`artifacts.${artifactPath}.spec.connectorRef`)}
               multiTypeProps={{

--- a/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/KubernetesManifests/KubernetesManifests.module.scss
+++ b/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/KubernetesManifests/KubernetesManifests.module.scss
@@ -24,8 +24,10 @@
 .manifestInfoTooltip {
   margin-left: var(--spacing-small);
 }
+
 .inputWidth {
-  width: 50% !important;
+  /* field width (320px) + configure options button width (42px) */
+  width: 362px !important;
 }
 
 .layoutVerticalSpacing {
@@ -44,7 +46,7 @@
 }
 .inputFieldLayout {
   display: grid;
-  grid-template-columns: 400px 20px;
+  grid-template-columns: 320px 42px;
   margin-top: var(--spacing-large);
   .configureOptions {
     position: relative;

--- a/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/ManifestSource/HelmChartManifestSource/HelmChartManifestSource.tsx
+++ b/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/ManifestSource/HelmChartManifestSource/HelmChartManifestSource.tsx
@@ -407,21 +407,19 @@ const Content = (props: ManifestSourceRenderProps): React.ReactElement => {
           />
         )}
       </div>
-      <div className={css.inputFieldLayout}>
-        {isFieldRuntime(`${manifestPath}.spec.store.spec.branch`, template) && (
-          <TextFieldInputSetView
-            disabled={isFieldDisabled(`${manifestPath}.spec.store.spec.branch`)}
-            name={`${path}.${manifestPath}.spec.store.spec.branch`}
-            multiTextInputProps={{
-              expressions,
-              allowableTypes
-            }}
-            label={getString('pipelineSteps.deploy.inputSet.branch')}
-            fieldPath={`${manifestPath}.spec.store.spec.branch`}
-            template={template}
-          />
-        )}
-      </div>
+      {isFieldRuntime(`${manifestPath}.spec.store.spec.branch`, template) && (
+        <TextFieldInputSetView
+          disabled={isFieldDisabled(`${manifestPath}.spec.store.spec.branch`)}
+          name={`${path}.${manifestPath}.spec.store.spec.branch`}
+          multiTextInputProps={{
+            expressions,
+            allowableTypes
+          }}
+          label={getString('pipelineSteps.deploy.inputSet.branch')}
+          fieldPath={`${manifestPath}.spec.store.spec.branch`}
+          template={template}
+        />
+      )}
       <div className={css.inputFieldLayout}>
         {isFieldRuntime(`${manifestPath}.spec.store.spec.commitId`, template) && (
           <div className={css.verticalSpacingInput}>

--- a/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/PrimaryArtifact/PrimaryArtifactRef.tsx
+++ b/src/modules/75-cd/components/PipelineSteps/K8sServiceSpec/PrimaryArtifact/PrimaryArtifactRef.tsx
@@ -163,7 +163,7 @@ function PrimaryArtifactRef({
   }
 
   return (
-    <Container width={391}>
+    <Container width={320}>
       {getMultiTypeFromValue(template?.artifacts?.primary?.primaryArtifactRef as string) ===
         MultiTypeInputType.RUNTIME && (
         <ExperimentalInput

--- a/src/modules/75-cd/components/PipelineSteps/ShellScriptStep/OptionalConfiguration.tsx
+++ b/src/modules/75-cd/components/PipelineSteps/ShellScriptStep/OptionalConfiguration.tsx
@@ -223,7 +223,6 @@ export default function OptionalConfiguration(props: {
                   showDefaultField={false}
                   showAdvanced={true}
                   onChange={value => setFieldValue('spec.executionTarget.host', value)}
-                  style={{ marginTop: 12 }}
                   isReadonly={readonly}
                 />
               )}
@@ -254,7 +253,6 @@ export default function OptionalConfiguration(props: {
                   onChange={value => {
                     setFieldValue('spec.executionTarget.connectorRef', value)
                   }}
-                  style={{ marginTop: 4 }}
                   isReadonly={readonly}
                 />
               )}


### PR DESCRIPTION
### Summary

Updates input set view components to prevent width change when configure options button becomes visible. 
Fixes inconsistent field widths.


#### Screenshots

<img width="913" alt="image" src="https://user-images.githubusercontent.com/52284933/209660284-a871a1a8-e777-4da8-b320-b445a9f04cb6.png">

<img width="895" alt="image" src="https://user-images.githubusercontent.com/52284933/209660386-d3b9c055-0193-42bd-861c-fcc1c6109d23.png">


#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)