### PR TITLE
fix: [CDS-49511]: fix getStarted option appearing twice in nav menu 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nextgenui",
   "description": "Harness Inc",
-  "version": "0.335.0",
+  "version": "0.335.1",
   "author": "Harness Inc",
   "license": "Harness Inc",
   "homepage": "https://app.harness.io/",

--- a/src/modules/10-common/navigation/ProjectSetupMenu/ProjectSetupMenu.tsx
+++ b/src/modules/10-common/navigation/ProjectSetupMenu/ProjectSetupMenu.tsx
@@ -44,7 +44,7 @@ const ProjectSetupMenu: React.FC<ProjectSetupMenuProps> = ({ module, defaultExpa
     SRM_ET_EXPERIMENTAL,
     NEW_LEFT_NAVBAR_SETTINGS
   } = useFeatureFlags()
-  const { showGetStartedTabInMainMenu } = useSideNavContext()
+  const { showGetStartedTabInMainMenu, showGetStartedCDTabInMainMenu } = useSideNavContext()
   const { enabledHostedBuildsForFreeUsers } = useHostedBuilds()
   const { isGitSimplificationEnabled, isGitSyncEnabled, gitSyncEnabledOnlyForFF, selectedProject } = useAppStore()
   const { orgIdentifier = orgIdentifierFromParams, identifier: projectIdentifier = projectIdentifierFromParams } =
@@ -117,7 +117,7 @@ const ProjectSetupMenu: React.FC<ProjectSetupMenuProps> = ({ module, defaultExpa
           <SidebarLink label={getString('getStarted')} to={routes.toGetStartedWithCI({ ...params, module })} />
         )}
 
-        {CD_ONBOARDING_ENABLED && module === 'cd' && !showGetStartedTabInMainMenu && (
+        {CD_ONBOARDING_ENABLED && module === 'cd' && !showGetStartedCDTabInMainMenu && (
           <SidebarLink label={getString('getStarted')} to={routes.toGetStartedWithCD({ ...params, module })} />
         )}
 

--- a/src/modules/75-cd/pages/get-started-with-cd/DeployProvisioningWizard/DeployProvisioningWizard.tsx
+++ b/src/modules/75-cd/pages/get-started-with-cd/DeployProvisioningWizard/DeployProvisioningWizard.tsx
@@ -53,6 +53,7 @@ import {
 } from '../CDOnboardingUtils'
 import { useCDOnboardingContext } from '../CDOnboardingStore'
 import RunPipelineSummary from '../RunPipelineSummary/RunPipelineSummary'
+import commonCss from '../GetStartedWithCD.module.scss'
 import css from './DeployProvisioningWizard.module.scss'
 const WizardStepOrder = [
   DeployProvisiongWizardStepId.SelectDeploymentType,
@@ -543,7 +544,7 @@ export const DeployProvisioningWizard: React.FC<DeployProvisioningWizardProps> =
             icon="cross"
             iconProps={{ size: 18 }}
             onClick={showOnboaringExitWarning}
-            style={{ position: 'absolute', right: 'var(--spacing-large)', top: 'var(--spacing-large)' }}
+            className={commonCss.closeWizard}
             data-testid={'close-cd-onboarding-wizard'}
           />
         </Container>

--- a/src/modules/75-cd/pages/get-started-with-cd/GetStartedWithCD.module.scss
+++ b/src/modules/75-cd/pages/get-started-with-cd/GetStartedWithCD.module.scss
@@ -84,3 +84,9 @@
   margin: var(--spacing-xxlarge) var(--spacing-xxlarge) !important;
   opacity: 0.1;
 }
+
+.close-wizard {
+  position: absolute;
+  right: var(--spacing-large);
+  top: var(--spacing-large);
+}

--- a/src/modules/75-cd/pages/get-started-with-cd/GetStartedWithCD.module.scss.d.ts
+++ b/src/modules/75-cd/pages/get-started-with-cd/GetStartedWithCD.module.scss.d.ts
@@ -11,6 +11,7 @@ declare const styles: {
   readonly btn: string
   readonly buttonRow: string
   readonly centerAlign: string
+  readonly closeWizard: string
   readonly containerItemCss: string
   readonly iconPadding: string
   readonly iconPaddingSmall: string

--- a/src/modules/75-cd/pages/get-started-with-cd/GetStartedWithCD.tsx
+++ b/src/modules/75-cd/pages/get-started-with-cd/GetStartedWithCD.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react'
-import { Text, Icon, Layout, ButtonVariation, Container, ButtonSize } from '@harness/uicore'
+import { Text, Icon, Layout, ButtonVariation, Container, ButtonSize, Button } from '@harness/uicore'
 import { FontVariation } from '@harness/design-system'
 import { useHistory, useParams } from 'react-router-dom'
 import { useStrings } from 'framework/strings'
@@ -32,6 +32,14 @@ export default function GetStartedWithCD(): React.ReactElement {
   }
   return (
     <Layout.Vertical flex>
+      <Button
+        minimal
+        icon="cross"
+        iconProps={{ size: 20 }}
+        onClick={() => history.push(routes.toPipelines({ accountId, orgIdentifier, projectIdentifier, module: 'cd' }))}
+        className={css.closeWizard}
+        data-testid={'close-cd-onboarding-wizard'}
+      />
       <Container className={css.topPage}>
         <Layout.Horizontal flex margin="auto">
           <Layout.Vertical padding="xlarge" style={{ flex: 1, textAlign: 'center' }} className={css.centerAlign}>


### PR DESCRIPTION
### Summary

- Added a cross button to exit the onboarding screen
- Updated check to show GetStarted in the project setup section

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
