### PR TITLE
fix: [PIE-7617]: pass parentEntityConnectorRef and parentEntityRepoName to inputSets/merge API 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nextgenui",
   "description": "Harness Inc",
-  "version": "0.337.2",
+  "version": "0.337.3",
   "author": "Harness Inc",
   "license": "Harness Inc",
   "homepage": "https://app.harness.io/",

--- a/src/modules/70-pipeline/components/CommonPipelineStages/PipelineStage/PipelineStageInputSection.tsx
+++ b/src/modules/70-pipeline/components/CommonPipelineStages/PipelineStage/PipelineStageInputSection.tsx
@@ -56,15 +56,15 @@ import css from './PipelineStageAdvancedSpecifications.module.scss'
 const memoizedParse = memoize(parse)
 
 function PipelineInputSetFormBasic(): React.ReactElement {
-  const { accountId, branch, repoIdentifier, connectorRef } = useParams<
+  const { accountId } = useParams<
     PipelineType<{
       orgIdentifier: string
       projectIdentifier: string
       pipelineIdentifier: string
       accountId: string
-    }> &
-      GitQueryParams
+    }>
   >()
+  const { connectorRef, repoIdentifier, repoName, branch } = useQueryParams<GitQueryParams>()
   const {
     state: {
       selectionState: { selectedStageId = '' }
@@ -175,7 +175,7 @@ function PipelineInputSetFormBasic(): React.ReactElement {
         branch,
         getDefaultFromOtherRepo: true,
         parentEntityConnectorRef: connectorRef,
-        parentEntityRepoName: repoIdentifier
+        parentEntityRepoName: repoName
       }
     }
   )

--- a/src/modules/70-pipeline/components/InputSetForm/InputSetForm.tsx
+++ b/src/modules/70-pipeline/components/InputSetForm/InputSetForm.tsx
@@ -227,7 +227,7 @@ function InputSetForm(props: InputSetFormProps): React.ReactElement {
       repoIdentifier: isGitSyncEnabled ? inputSetRepoIdentifier : repoName,
       branch: isGitSyncEnabled ? inputSetBranch : branch,
       parentEntityConnectorRef: connectorRef,
-      parentEntityRepoName: repoIdentifier
+      parentEntityRepoName: repoName
     }
   })
 

--- a/src/modules/70-pipeline/components/OverlayInputSetForm/OverlayInputSetForm.tsx
+++ b/src/modules/70-pipeline/components/OverlayInputSetForm/OverlayInputSetForm.tsx
@@ -276,7 +276,7 @@ export function OverlayInputSetForm({
         repoIdentifier,
         branch,
         parentEntityConnectorRef: connectorRef,
-        parentEntityRepoName: repoIdentifier
+        parentEntityRepoName: repoName
       }
     })
 

--- a/src/modules/72-triggers/components/steps/ArtifactTriggerInputPanel/ArtifactTriggerInputPanel.tsx
+++ b/src/modules/72-triggers/components/steps/ArtifactTriggerInputPanel/ArtifactTriggerInputPanel.tsx
@@ -119,7 +119,9 @@ function ArtifactTriggerInputPanelForm({
       projectIdentifier,
       orgIdentifier,
       pipelineIdentifier,
-      branch: isNewGitSyncRemotePipeline ? inputSetSelectedBranch : branch
+      branch: isNewGitSyncRemotePipeline ? inputSetSelectedBranch : branch,
+      parentEntityConnectorRef: connectorRef,
+      parentEntityRepoName: repoName
     }
   })
 

--- a/src/modules/72-triggers/components/steps/ManifestPipelineInputPanel/ManifestPipelineInputPanel.tsx
+++ b/src/modules/72-triggers/components/steps/ManifestPipelineInputPanel/ManifestPipelineInputPanel.tsx
@@ -119,7 +119,9 @@ function ManifestTriggerInputPanelForm({
       projectIdentifier,
       orgIdentifier,
       pipelineIdentifier,
-      branch: isNewGitSyncRemotePipeline ? inputSetSelectedBranch : branch
+      branch: isNewGitSyncRemotePipeline ? inputSetSelectedBranch : branch,
+      parentEntityConnectorRef: connectorRef,
+      parentEntityRepoName: repoName
     }
   })
 

--- a/src/modules/72-triggers/components/steps/WebhookPipelineInputPanel/WebhookPipelineInputPanel.tsx
+++ b/src/modules/72-triggers/components/steps/WebhookPipelineInputPanel/WebhookPipelineInputPanel.tsx
@@ -123,7 +123,9 @@ function WebhookPipelineInputPanelForm({
       projectIdentifier,
       orgIdentifier,
       pipelineIdentifier,
-      branch: isNewGitSyncRemotePipeline ? inputSetSelectedBranch : branch
+      branch: isNewGitSyncRemotePipeline ? inputSetSelectedBranch : branch,
+      parentEntityConnectorRef: connectorRef,
+      parentEntityRepoName: repoName
     }
   })
 

--- a/src/modules/72-triggers/pages/triggers/views/WebhookPipelineInputPanel.tsx
+++ b/src/modules/72-triggers/pages/triggers/views/WebhookPipelineInputPanel.tsx
@@ -209,7 +209,9 @@ function WebhookPipelineInputPanelForm({
       projectIdentifier,
       orgIdentifier,
       pipelineIdentifier,
-      branch: gitAwareForTriggerEnabled ? inputSetSelectedBranch : branch
+      branch: gitAwareForTriggerEnabled ? inputSetSelectedBranch : branch,
+      parentEntityConnectorRef: connectorRef,
+      parentEntityRepoName: repoName
     }
   })
 


### PR DESCRIPTION
### Summary
- pass parentEntityConnectorRef and parentEntityRepoName to inputSets/merge API that is called from triggers input panel

#### Screenshots
<img width="1792" alt="Screenshot 2023-01-12 at 4 21 25 PM" src="https://user-images.githubusercontent.com/81295223/212047885-b1892555-0fa4-4647-96bf-c37ee42fa0de.png">

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
