### PR TITLE
fix: [BG-578]: added optional check when parentElement is not present in DOM

### DIFF
--- a/src/modules/70-pipeline/components/PipelineDiagram/PipelineGraph/PipelineGraphUtils.ts
+++ b/src/modules/70-pipeline/components/PipelineDiagram/PipelineGraph/PipelineGraphUtils.ts
@@ -881,7 +881,7 @@ export interface RelativeBounds {
 }
 
 const getRelativeBounds = (parentElement: HTMLElement, targetElement: HTMLElement): RelativeBounds => {
-  const parentPos = parentElement.getBoundingClientRect()
+  const parentPos = parentElement?.getBoundingClientRect()
   const childPos = targetElement.getBoundingClientRect()
   const relativePos: RelativeBounds = { top: 0, right: 0, bottom: 0, left: 0 }
 


### PR DESCRIPTION

### Summary

<!-- ✍️ A clear and concise description...-->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
