### PR TITLE
feat: [CDS-49014]: take user to 2nd step in editMode of manifest and artifact wizards

### DIFF
--- a/src/modules/70-pipeline/components/ArtifactsSelection/ArtifactWizard/ArtifactWizard.tsx
+++ b/src/modules/70-pipeline/components/ArtifactsSelection/ArtifactWizard/ArtifactWizard.tsx
@@ -64,6 +64,7 @@ interface ArtifactWizardProps {
   allowableTypes: AllowedTypes
   showConnectorStep: boolean
   newConnectorProps: any
+  isEditMode?: boolean
 }
 
 function ArtifactWizard({
@@ -80,7 +81,8 @@ function ArtifactWizard({
   lastSteps,
   iconsProps,
   showConnectorStep,
-  isReadonly
+  isReadonly,
+  isEditMode
 }: ArtifactWizardProps): React.ReactElement {
   const { getString } = useStrings()
 
@@ -198,7 +200,12 @@ function ArtifactWizard({
   }
 
   return (
-    <StepWizard className={css.existingDocker} subtitle={renderSubtitle()} onStepChange={onStepChange}>
+    <StepWizard
+      className={css.existingDocker}
+      subtitle={renderSubtitle()}
+      onStepChange={onStepChange}
+      initialStep={isEditMode ? 2 : undefined}
+    >
       <ArtifactoryRepoType
         artifactTypes={types}
         name={getString('connectors.artifactRepoType')}

--- a/src/modules/70-pipeline/components/ArtifactsSelection/ArtifactsSelection.tsx
+++ b/src/modules/70-pipeline/components/ArtifactsSelection/ArtifactsSelection.tsx
@@ -397,6 +397,7 @@ export default function ArtifactsSelection({
   }
 
   const editArtifact = (viewType: number, type?: ArtifactType, index?: number): void => {
+    setIsEditMode(true)
     setModalContext(viewType)
     setConnectorView(false)
     setSelectedArtifact(type as ArtifactType)
@@ -545,6 +546,7 @@ export default function ArtifactsSelection({
     return (
       <div>
         <ArtifactWizard
+          isEditMode={isEditMode}
           artifactInitialValue={getArtifactInitialValues()}
           iconsProps={getIconProps()}
           types={allowedArtifactTypes[deploymentType]}

--- a/src/modules/70-pipeline/components/ArtifactsSelection/ServiceV2ArtifactsSelection.tsx
+++ b/src/modules/70-pipeline/components/ArtifactsSelection/ServiceV2ArtifactsSelection.tsx
@@ -504,6 +504,7 @@ export default function ServiceV2ArtifactsSelection({
 
     setArtifactContext(viewType)
     setEditIndex(index as number)
+    setIsEditMode(true)
 
     if (!isEmpty(artifactSourceTemplateNode?.template)) {
       setArtifactSourceConfigNode(artifactSourceTemplateNode)
@@ -679,6 +680,7 @@ export default function ServiceV2ArtifactsSelection({
   const renderExistingArtifact = (): JSX.Element => {
     return (
       <ArtifactWizard
+        isEditMode={isEditMode}
         artifactInitialValue={getArtifactInitialValues}
         iconsProps={getIconProps}
         types={allowedArtifactTypes[deploymentType]}

--- a/src/modules/70-pipeline/components/ManifestSelection/ManifestListView/ManifestListView.tsx
+++ b/src/modules/70-pipeline/components/ManifestSelection/ManifestListView/ManifestListView.tsx
@@ -163,6 +163,7 @@ function ManifestListView({
     setManifestStore(store)
     setConnectorView(false)
     setEditIndex(index)
+    setIsEditMode(true)
     showConnectorModal()
   }
 
@@ -469,6 +470,7 @@ function ManifestListView({
       <Dialog onClose={onClose} {...DIALOG_PROPS} className={cx(css.modal, Classes.DIALOG)}>
         <div className={css.createConnectorWizard}>
           <ManifestWizard
+            isEditMode={isEditMode}
             types={availableManifestTypes}
             manifestStoreTypes={ManifestTypetoStoreMap[selectedManifest as ManifestTypes]}
             labels={getLabels()}

--- a/src/modules/70-pipeline/components/ManifestSelection/ManifestWizard/ManifestWizard.tsx
+++ b/src/modules/70-pipeline/components/ManifestSelection/ManifestWizard/ManifestWizard.tsx
@@ -41,6 +41,7 @@ interface ManifestWizardStepsProps<T, U> {
   changeManifestType: (data: U | null) => void
   types: ManifestTypes[]
   listOfDisabledManifestTypes?: ManifestTypes[]
+  isEditMode?: boolean
 }
 
 const showManifestStoreStepDirectly = (selectedManifest: ManifestTypes | null): boolean => {
@@ -76,7 +77,8 @@ export function ManifestWizard<T, U>({
   changeManifestType,
   iconsProps,
   isReadonly,
-  listOfDisabledManifestTypes
+  listOfDisabledManifestTypes,
+  isEditMode
 }: ManifestWizardStepsProps<T, U>): React.ReactElement {
   const { getString } = useStrings()
   const onStepChange = (arg: StepChangeData<any>): void => {
@@ -117,7 +119,7 @@ export function ManifestWizard<T, U>({
       className={css.manifestWizard}
       subtitle={renderSubtitle()}
       onStepChange={onStepChange}
-      initialStep={showManifestStoreStepDirectly(selectedManifest) ? 2 : undefined}
+      initialStep={isEditMode || showManifestStoreStepDirectly(selectedManifest) ? 2 : undefined}
     >
       <ManifestRepoTypes
         manifestTypes={types}

--- a/src/modules/75-cd/components/EnvironmentsV2/EnvironmentDetails/ServiceOverrides/ServiceManifestOverride/ServiceManifestOverride.tsx
+++ b/src/modules/75-cd/components/EnvironmentsV2/EnvironmentDetails/ServiceOverrides/ServiceManifestOverride/ServiceManifestOverride.tsx
@@ -123,6 +123,7 @@ function ServiceManifestOverride({
     store: OverrideManifestStoresTypes,
     index: number
   ): void => {
+    setIsEditMode(true)
     setSelectedManifest(manifestType)
     setManifestStore(store)
     setEditIndex(index)
@@ -381,6 +382,7 @@ function ServiceManifestOverride({
       <Dialog onClose={onClose} {...DIALOG_PROPS}>
         <div className={css.createConnectorWizard}>
           <ManifestWizard
+            isEditMode={isEditMode}
             types={allowedOverrideManifestTypes}
             manifestStoreTypes={OverrideManifestStoreMap[selectedManifest as OverrideManifestTypes]}
             labels={getLabels()}

--- a/src/modules/75-cd/components/PipelineSteps/ECSRunTaskStep/TaskDefinitionModal.tsx
+++ b/src/modules/75-cd/components/PipelineSteps/ECSRunTaskStep/TaskDefinitionModal.tsx
@@ -280,6 +280,7 @@ export const TaskDefinitionModal = (props: TaskDefinitionModalProps): React.Reac
     >
       <div className={css.createConnectorWizard}>
         <ManifestWizard
+          isEditMode={isEditMode}
           types={availableManifestTypes}
           manifestStoreTypes={ManifestTypetoStoreMap[selectedManifest]}
           labels={getLabels()}

--- a/src/modules/75-cd/components/PipelineSteps/K8sApply/K8sOverrideValuesListView.tsx
+++ b/src/modules/75-cd/components/PipelineSteps/K8sApply/K8sOverrideValuesListView.tsx
@@ -115,6 +115,7 @@ function K8sOverrideValuesListView({
   }
 
   const editManifest = (manifestType: K8sManifestTypes, store: K8sManifestStores, index: number): void => {
+    setIsEditMode(true)
     setSelectedManifest(manifestType)
     setManifestStore(store)
     setConnectorView(false)
@@ -367,6 +368,7 @@ function K8sOverrideValuesListView({
       <Dialog onClose={onClose} {...DIALOG_PROPS} className={cx(css.modal, Classes.DIALOG)}>
         <div className={css.createConnectorWizard}>
           <ManifestWizard
+            isEditMode={isEditMode}
             types={allowedManifestTypes[deploymentType]}
             manifestStoreTypes={K8sManifestTypetoStoreMap[selectedManifest as K8sManifestTypes]}
             labels={getLabels()}


### PR DESCRIPTION
### Summary

<!-- ✍️ A clear and concise description...-->

#### Screenshots


https://user-images.githubusercontent.com/98325173/212955234-1723c908-ba11-4cc2-8ec3-c8144712a840.mov


#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
