### PR TITLE
fix: [CDS-49636]: removed expression/runtime support for ami fields

### DIFF
--- a/src/modules/70-pipeline/components/ArtifactsSelection/ArtifactRepository/ArtifactLastSteps/AmazonMachineImage/AmazonMachineImage.tsx
+++ b/src/modules/70-pipeline/components/ArtifactsSelection/ArtifactRepository/ArtifactLastSteps/AmazonMachineImage/AmazonMachineImage.tsx
@@ -201,7 +201,8 @@ function FormComponent({
             multiTypeInputProps={{
               selectProps: {
                 items: regions
-              }
+              },
+              allowableTypes: [MultiTypeInputType.FIXED]
             }}
             label={getString('regionLabel')}
             placeholder={getString('select')}
@@ -230,7 +231,7 @@ function FormComponent({
             name="spec.tags"
             className="tags-select"
             expressions={expressions}
-            allowableTypes={[MultiTypeInputType.FIXED, MultiTypeInputType.RUNTIME, MultiTypeInputType.EXPRESSION]}
+            allowableTypes={[MultiTypeInputType.FIXED]}
             tags={tags}
             label={'AMI Tags'}
             isLoadingTags={isTagsLoading}
@@ -260,7 +261,7 @@ function FormComponent({
             name="spec.filters"
             className="tags-select"
             expressions={expressions}
-            allowableTypes={[MultiTypeInputType.FIXED, MultiTypeInputType.RUNTIME, MultiTypeInputType.EXPRESSION]}
+            allowableTypes={[MultiTypeInputType.FIXED]}
             tags={amiFilters}
             label={'AMI Filters'}
             initialTags={formik?.initialValues?.spec?.filters || {}}


### PR DESCRIPTION
### Summary

<!-- ✍️ A clear and concise description...-->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
