### PR TITLE
feat: [FFM-6516]: Port getErrorMessage needed for Target Groups in MFE

### DIFF
--- a/src/modules/75-cf/FFCustomMicroFrontendProps.types.ts
+++ b/src/modules/75-cf/FFCustomMicroFrontendProps.types.ts
@@ -26,6 +26,7 @@ import type { useLicenseStore } from 'framework/LicenseStore/LicenseStoreContext
 import type { getIdentifierFromName } from '@common/utils/StringUtils'
 import type * as trackingConstants from '@common/constants/TrackingConstants'
 import type useActiveEnvironment from './hooks/useActiveEnvironment'
+import type { getErrorMessage } from './utils/CFUtils'
 
 export interface FFCustomMicroFrontendProps {
   ffServices: typeof ffServices & {
@@ -53,6 +54,7 @@ export interface FFCustomMicroFrontendProps {
     IdentifierSchema: typeof IdentifierSchema
     NameSchema: typeof NameSchema
     getIdentifierFromName: typeof getIdentifierFromName
+    getErrorMessage: typeof getErrorMessage
   }
   customEnums: {
     FeatureIdentifier: typeof FeatureIdentifier

--- a/src/modules/75-cf/pages/FFUIApp/FFUIApp.tsx
+++ b/src/modules/75-cf/pages/FFUIApp/FFUIApp.tsx
@@ -29,6 +29,7 @@ import { IdentifierSchema, NameSchema } from '@common/utils/Validation'
 import { FeatureIdentifier } from 'framework/featureStore/FeatureIdentifier'
 import { getIdentifierFromName } from '@common/utils/StringUtils'
 import * as trackingConstants from '@common/constants/TrackingConstants'
+import { getErrorMessage } from '@cf/utils/CFUtils'
 
 // eslint-disable-next-line import/no-unresolved
 const FFUIMFEApp = lazy(() => import('ffui/MicroFrontendApp'))
@@ -54,7 +55,7 @@ const FFUIApp: FC = () => (
     }}
     customComponents={{ RbacOptionsMenuButton, ContainerSpinner, Description }}
     customRoutes={routes}
-    customUtils={{ NameSchema, getIdentifierFromName, IdentifierSchema }}
+    customUtils={{ NameSchema, getIdentifierFromName, IdentifierSchema, getErrorMessage }}
     customEnums={{ FeatureIdentifier, PreferenceScope, trackingConstants }}
   />
 )


### PR DESCRIPTION
### Summary

getErrorMessage custom util needed for MFE.

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
