### PR TITLE
fix: [CCM-10374]: GCP connector links

### DIFF
--- a/src/modules/35-connectors/components/CreateConnector/CEGcpConnector/__tests__/__snapshots__/CreateCeGcpConnector.test.tsx.snap
+++ b/src/modules/35-connectors/components/CreateConnector/CEGcpConnector/__tests__/__snapshots__/CreateCeGcpConnector.test.tsx.snap
@@ -1006,12 +1006,20 @@ exports[`Create Secret Manager Wizard should render form 2`] = `
               </div>
               <ul>
                 <li>
-                  <a>
+                  <a
+                    href="https://cloud.google.com/billing/docs/how-to/export-data-bigquery-setup"
+                    rel="noreferrer"
+                    target="_blank"
+                  >
                     connectors.ceGcp.billingExtention.link1
                   </a>
                 </li>
                 <li>
-                  <a>
+                  <a
+                    href="https://developer.harness.io/docs/cloud-cost-management/onboard-with-cloud-cost-management/set-up-cloud-cost-management/set-up-cost-visibility-for-gcp/"
+                    rel="noreferrer"
+                    target="_blank"
+                  >
                     connectors.ceGcp.billingExtention.link2
                   </a>
                 </li>

--- a/src/modules/35-connectors/components/CreateConnector/CEGcpConnector/steps/BillingExportExtention.tsx
+++ b/src/modules/35-connectors/components/CreateConnector/CEGcpConnector/steps/BillingExportExtention.tsx
@@ -38,10 +38,22 @@ const BillingExportExtention: React.FC = () => {
           <div> {getString('connectors.ceGcp.billingExtention.otherLinks')}</div>
           <ul>
             <li>
-              <a>{getString('connectors.ceGcp.billingExtention.link1')}</a>
+              <a
+                href="https://cloud.google.com/billing/docs/how-to/export-data-bigquery-setup"
+                target="_blank"
+                rel="noreferrer"
+              >
+                {getString('connectors.ceGcp.billingExtention.link1')}
+              </a>
             </li>
             <li>
-              <a>{getString('connectors.ceGcp.billingExtention.link2')}</a>
+              <a
+                href="https://developer.harness.io/docs/cloud-cost-management/onboard-with-cloud-cost-management/set-up-cloud-cost-management/set-up-cost-visibility-for-gcp/"
+                target="_blank"
+                rel="noreferrer"
+              >
+                {getString('connectors.ceGcp.billingExtention.link2')}
+              </a>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
### Summary

CCM GCP Connector reference links were not given, Added the same

#### Screenshots
<img width="1721" alt="Screenshot 2022-12-16 at 5 41 27 PM" src="https://user-images.githubusercontent.com/97077953/214012105-c9266012-2237-4651-a87e-fbcbc30f7f8d.png">

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
