### PR TITLE
fix: [CI-7048]: Adding check for onprem for rendering CI Build infra options

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nextgenui",
   "description": "Harness Inc",
-  "version": "0.336.4",
+  "version": "0.336.5",
   "author": "Harness Inc",
   "license": "Harness Inc",
   "homepage": "https://app.harness.io/",

--- a/src/modules/75-ci/components/PipelineStudio/BuildInfraSpecifications/BuildInfraSpecifications.tsx
+++ b/src/modules/75-ci/components/PipelineStudio/BuildInfraSpecifications/BuildInfraSpecifications.tsx
@@ -81,6 +81,7 @@ import type {
 } from 'services/ci'
 import { StageErrorContext } from '@pipeline/context/StageErrorContext'
 import { k8sLabelRegex, k8sAnnotationRegex } from '@common/utils/StringUtils'
+import { isOnPrem } from '@common/utils/utils'
 import ErrorsStripBinded from '@pipeline/components/ErrorsStrip/ErrorsStripBinded'
 import { Connectors } from '@connectors/constants'
 import { OsTypes, ArchTypes, CIBuildInfrastructureType } from '@pipeline/utils/constants'
@@ -406,7 +407,7 @@ export default function BuildInfraSpecifications({ children }: React.PropsWithCh
           } as Item
         ]
       : []),
-    ...(!isFreeEdition
+    ...(!isFreeEdition || isOnPrem()
       ? [
           {
             label: getString('pipeline.serviceDeploymentTypes.kubernetes'),
@@ -424,7 +425,7 @@ export default function BuildInfraSpecifications({ children }: React.PropsWithCh
           } as Item
         ]
       : []),
-    ...(!isFreeEdition
+    ...(!isFreeEdition || isOnPrem()
       ? [
           {
             label: getString('ci.buildInfra.vMs'),


### PR DESCRIPTION
### Summary

This fixes https://harness.atlassian.net/browse/CI-7048. As part of this change, both K8s and VMs infra should be available for On-prem installations.

<!-- ✍️ A clear and concise description...-->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
