### PR TITLE
fix: [CI-6814]: Fix logic to fetch repo name for onprem connectors

### DIFF
--- a/src/modules/70-pipeline/components/PipelineInputSetForm/CICodebaseInputSetForm.tsx
+++ b/src/modules/70-pipeline/components/PipelineInputSetForm/CICodebaseInputSetForm.tsx
@@ -419,7 +419,7 @@ function CICodebaseInputSetFormInternal({
     if (codebaseConnector) {
       const codebaseConnectorConnectionType = get(codebaseConnector, 'spec.type')
       if (codebaseConnectorConnectionType === ConnectionType.Repo) {
-        fetchBranchesForRepo(getCodebaseRepoNameFromConnector(codebaseConnector, getString))
+        fetchBranchesForRepo(getCodebaseRepoNameFromConnector(codebaseConnector))
       } else if (
         codebaseConnectorConnectionType === ConnectionType.Account &&
         get(originalPipeline, 'properties.ci.codebase.repoName', '') !== RUNTIME_INPUT_VALUE

--- a/src/modules/70-pipeline/utils/__tests__/CIUtils.test.ts
+++ b/src/modules/70-pipeline/utils/__tests__/CIUtils.test.ts
@@ -5,18 +5,14 @@
  * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
  */
 
-import type { StringKeys } from 'framework/strings'
 import type { ConnectorInfoDTO } from 'services/cd-ng'
 import {
   shouldRenderRunTimeInputView,
   shouldRenderRunTimeInputViewWithAllowedValues,
   getAllowedValuesFromTemplate,
-  getCodebaseRepoNameFromConnector
+  getCodebaseRepoNameFromConnector,
+  extractRepoNameFromUrl
 } from '../CIUtils'
-
-function getString(key: StringKeys): StringKeys | string {
-  return key === 'connectors.gitProviderURLs.github' ? 'https://github.com' : key
-}
 
 describe('Test CIUtils', () => {
   test('Test shouldRenderRunTimeInputView method', () => {
@@ -107,11 +103,31 @@ describe('Test CIUtils', () => {
         type: 'Repo'
       }
     }
-    expect(getCodebaseRepoNameFromConnector(codebaseConnector, getString)).toBe('test-repo')
+    expect(getCodebaseRepoNameFromConnector(codebaseConnector)).toBe('test-repo')
     codebaseConnector = {
       ...codebaseConnector,
       spec: { type: 'Account', url: 'https://github.com', validationRepo: 'test-repo2' }
     }
-    expect(getCodebaseRepoNameFromConnector(codebaseConnector, getString)).toBe('test-repo2')
+    expect(getCodebaseRepoNameFromConnector(codebaseConnector)).toBe('test-repo2')
+    codebaseConnector = {
+      ...codebaseConnector,
+      spec: { type: 'Account', url: 'https://bitbucket.dev.harness.io/scm/~harnessadmin', validationRepo: 'test-repo3' }
+    }
+    expect(getCodebaseRepoNameFromConnector(codebaseConnector)).toBe('test-repo3')
+  })
+
+  test('Test extractRepoNameFromUrl method', () => {
+    expect(extractRepoNameFromUrl('https://github.com')).toBe('')
+    expect(extractRepoNameFromUrl('https://github.com/springboot.git')).toBe('springboot')
+    // SaaS
+    expect(extractRepoNameFromUrl('https://github.com/harness/springboot')).toBe('springboot')
+    // SaaS
+    expect(extractRepoNameFromUrl('https://github.com/harness/springboot')).toBe('springboot')
+    expect(extractRepoNameFromUrl('https://github.com/harness/springboot.git')).toBe('springboot')
+    expect(extractRepoNameFromUrl('https://gitlab.com/autouser1/springboot.git')).toBe('springboot')
+    // Onprem
+    expect(extractRepoNameFromUrl('https://bitbucket.dev.harness.io/scm/~harnessadmin/springboot.git')).toBe(
+      'springboot'
+    )
   })
 })


### PR DESCRIPTION
### Summary

This fixes: https://harness.atlassian.net/browse/CI-6814

This PR handles logic for onprem git connectors which have a slightly different git repo url as compared to SaaS git connectors.

<!-- ✍️ A clear and concise description...-->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
