### PR TITLE
chore: [PIE-8685]: fixing two variables call in the run pipeline form

### DIFF
--- a/src/modules/70-pipeline/components/InputSetForm/InputSetForm.tsx
+++ b/src/modules/70-pipeline/components/InputSetForm/InputSetForm.tsx
@@ -485,8 +485,8 @@ function InputSetForm(props: InputSetFormProps): React.ReactElement {
   const child = React.useCallback(
     () => (
       <PipelineVariablesContextProvider
-        pipeline={parsedPipeline}
-        enablePipelineTemplatesResolution={true}
+        pipeline={resolvedMergedPipeline}
+        enablePipelineTemplatesResolution={false}
         storeMetadata={{ storeType, connectorRef, repoName, branch, filePath }}
       >
         <FormikInputSetForm

--- a/src/modules/70-pipeline/components/PipelineVariablesContext/PipelineVariablesContext.tsx
+++ b/src/modules/70-pipeline/components/PipelineVariablesContext/PipelineVariablesContext.tsx
@@ -109,9 +109,10 @@ export function PipelineVariablesContextProvider(
     pipeline?: PipelineInfoConfig
     enablePipelineTemplatesResolution?: boolean
     storeMetadata?: StoreMetadata
+    lexicalContext?: string
   }>
 ): React.ReactElement {
-  const { pipeline: pipelineFromProps, enablePipelineTemplatesResolution, storeMetadata = {} } = props
+  const { pipeline: pipelineFromProps, enablePipelineTemplatesResolution, storeMetadata = {}, lexicalContext } = props
   const [originalPipeline, setOriginalPipeline] = React.useState<PipelineInfoConfig>(
     defaultTo(pipelineFromProps, {} as PipelineInfoConfig)
   )
@@ -166,7 +167,8 @@ export function PipelineVariablesContextProvider(
       parentEntityConnectorRef: storeMetadata.connectorRef,
       parentEntityRepoName: storeMetadata.repoName
     },
-    debounce: 1300
+    debounce: 1300,
+    ...(lexicalContext === 'runPipelineForm' && { lazy: isEmpty(originalPipeline) })
   })
 
   const {

--- a/src/modules/70-pipeline/components/PipelineVariablesContext/PipelineVariablesContext.tsx
+++ b/src/modules/70-pipeline/components/PipelineVariablesContext/PipelineVariablesContext.tsx
@@ -76,6 +76,10 @@ export interface GetPathToMetaKeyMapParams {
   pipeline: PipelineInfoConfig
 }
 
+export const LexicalScopes = {
+  RunPipelineForm: 'RunPipelineForm'
+}
+
 export interface PipelineMeta {
   value: string
   metaKeyId: string
@@ -168,7 +172,7 @@ export function PipelineVariablesContextProvider(
       parentEntityRepoName: storeMetadata.repoName
     },
     debounce: 1300,
-    ...(lexicalContext === 'runPipelineForm' && { lazy: isEmpty(originalPipeline) })
+    ...(lexicalContext === LexicalScopes.RunPipelineForm && { lazy: isEmpty(originalPipeline) })
   })
 
   const {

--- a/src/modules/70-pipeline/components/PipelineVariablesContext/PipelineVariablesContext.tsx
+++ b/src/modules/70-pipeline/components/PipelineVariablesContext/PipelineVariablesContext.tsx
@@ -76,8 +76,8 @@ export interface GetPathToMetaKeyMapParams {
   pipeline: PipelineInfoConfig
 }
 
-export const LexicalScopes = {
-  RunPipelineForm: 'RunPipelineForm'
+export enum LexicalContext {
+  RunPipelineForm = 'RunPipelineForm'
 }
 
 export interface PipelineMeta {
@@ -113,7 +113,7 @@ export function PipelineVariablesContextProvider(
     pipeline?: PipelineInfoConfig
     enablePipelineTemplatesResolution?: boolean
     storeMetadata?: StoreMetadata
-    lexicalContext?: string
+    lexicalContext?: Partial<Record<LexicalContext, string>>
   }>
 ): React.ReactElement {
   const { pipeline: pipelineFromProps, enablePipelineTemplatesResolution, storeMetadata = {}, lexicalContext } = props
@@ -172,7 +172,7 @@ export function PipelineVariablesContextProvider(
       parentEntityRepoName: storeMetadata.repoName
     },
     debounce: 1300,
-    ...(lexicalContext === LexicalScopes.RunPipelineForm && { lazy: isEmpty(originalPipeline) })
+    ...(lexicalContext === LexicalContext.RunPipelineForm && { lazy: isEmpty(originalPipeline) })
   })
 
   const {

--- a/src/modules/70-pipeline/components/PipelineVariablesContext/PipelineVariablesContext.tsx
+++ b/src/modules/70-pipeline/components/PipelineVariablesContext/PipelineVariablesContext.tsx
@@ -113,7 +113,7 @@ export function PipelineVariablesContextProvider(
     pipeline?: PipelineInfoConfig
     enablePipelineTemplatesResolution?: boolean
     storeMetadata?: StoreMetadata
-    lexicalContext?: Partial<Record<LexicalContext, string>>
+    lexicalContext?: LexicalContext
   }>
 ): React.ReactElement {
   const { pipeline: pipelineFromProps, enablePipelineTemplatesResolution, storeMetadata = {}, lexicalContext } = props

--- a/src/modules/70-pipeline/components/RunPipelineModal/RunPipelineForm.tsx
+++ b/src/modules/70-pipeline/components/RunPipelineModal/RunPipelineForm.tsx
@@ -1007,7 +1007,7 @@ export function RunPipelineForm(props: RunPipelineFormProps & InputSetGitQueryPa
       {props.executionView ? (
         <RunPipelineFormBasic {...props} />
       ) : (
-        <PipelineVariablesContextProvider storeMetadata={props.storeMetadata}>
+        <PipelineVariablesContextProvider storeMetadata={props.storeMetadata} lexicalContext="runPipelineForm">
           <RunPipelineFormBasic {...props} />
         </PipelineVariablesContextProvider>
       )}

--- a/src/modules/70-pipeline/components/RunPipelineModal/RunPipelineForm.tsx
+++ b/src/modules/70-pipeline/components/RunPipelineModal/RunPipelineForm.tsx
@@ -89,6 +89,7 @@ import SaveAsInputSet from './SaveAsInputSet'
 import ReplacedExpressionInputForm from './ReplacedExpressionInputForm'
 import {
   KVPair,
+  LexicalScopes,
   PipelineVariablesContextProvider,
   usePipelineVariables
 } from '../PipelineVariablesContext/PipelineVariablesContext'
@@ -1007,7 +1008,10 @@ export function RunPipelineForm(props: RunPipelineFormProps & InputSetGitQueryPa
       {props.executionView ? (
         <RunPipelineFormBasic {...props} />
       ) : (
-        <PipelineVariablesContextProvider storeMetadata={props.storeMetadata} lexicalContext="runPipelineForm">
+        <PipelineVariablesContextProvider
+          storeMetadata={props.storeMetadata}
+          lexicalContext={LexicalScopes.RunPipelineForm}
+        >
           <RunPipelineFormBasic {...props} />
         </PipelineVariablesContextProvider>
       )}

--- a/src/modules/70-pipeline/components/RunPipelineModal/RunPipelineForm.tsx
+++ b/src/modules/70-pipeline/components/RunPipelineModal/RunPipelineForm.tsx
@@ -89,7 +89,7 @@ import SaveAsInputSet from './SaveAsInputSet'
 import ReplacedExpressionInputForm from './ReplacedExpressionInputForm'
 import {
   KVPair,
-  LexicalScopes,
+  LexicalContext,
   PipelineVariablesContextProvider,
   usePipelineVariables
 } from '../PipelineVariablesContext/PipelineVariablesContext'
@@ -1010,7 +1010,7 @@ export function RunPipelineForm(props: RunPipelineFormProps & InputSetGitQueryPa
       ) : (
         <PipelineVariablesContextProvider
           storeMetadata={props.storeMetadata}
-          lexicalContext={LexicalScopes.RunPipelineForm}
+          lexicalContext={LexicalContext.RunPipelineForm}
         >
           <RunPipelineFormBasic {...props} />
         </PipelineVariablesContextProvider>


### PR DESCRIPTION
### Summary

- Remove the duplicate variables call in the run pipeline form . Made the call `lazy` dependent on the `pipeline` object being
empty.

- Remove the duplicate resolved pipeline call in the input set form


#### Screenshots


https://user-images.githubusercontent.com/106532291/224626650-5eae846c-46fa-4059-8418-8262154ef798.mov



#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
