### PR TITLE
fix: [DEL-6113]: k8yaml payload change-hotfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nextgenui",
   "description": "Harness Inc",
-  "version": "0.342.11",
+  "version": "0.342.12",
   "author": "Harness Inc",
   "license": "Harness Inc",
   "homepage": "https://app.harness.io/",

--- a/src/modules/30-delegates/pages/delegates/delegateCommandLineCreation/DelegateCommandLineCreation.tsx
+++ b/src/modules/30-delegates/pages/delegates/delegateCommandLineCreation/DelegateCommandLineCreation.tsx
@@ -106,12 +106,9 @@ const DelegateCommandLineCreation: React.FC<DelegateCommandLineCreationProps> = 
       const yamlData = await downloadKubernetesYaml({
         name: DelegateDefaultName.KUBERNETES,
         delegateType: CommandType.KUBERNETES,
-        k8sConfigDetails: { k8sPermissionType: 'CLUSTER_ADMIN' },
         orgIdentifier: orgIdentifier,
         projectIdentifier: projectIdentifier,
-        runAsRoot: true,
-        size: 'LAPTOP',
-        tokenName: 'default_token'
+        runAsRoot: true
       })
       setKubernetesYamlOriginal(yamlData as any)
       setKubernetesYamlUpdatedValue(yamlData as any)


### PR DESCRIPTION
### Summary
Change payload for the k8yaml file download, since the old payload is causing different tokens to be used in different places in the project scope
<!-- ✍️ A clear and concise description...-->

#### Tes cases done on PR env 

[screen-capture (63).webm](https://user-images.githubusercontent.com/73115842/225055756-934657c5-706f-42aa-96e5-4c594600ca95.webm)


<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
