### PR TITLE
fix: [CDS-58094]: fix config file issue

### DIFF
--- a/src/modules/70-pipeline/components/ConfigFilesSelection/ConfigFilesListView/ConfigFilesListView.tsx
+++ b/src/modules/70-pipeline/components/ConfigFilesSelection/ConfigFilesListView/ConfigFilesListView.tsx
@@ -120,13 +120,16 @@ function ConfigFilesListView({
 
   const getInitialValues = (): ConfigInitStepData => {
     const initValues = get(listOfConfigFiles[configFileIndex], 'configFile.spec.store.spec', null)
+    const filesValues = get(listOfConfigFiles[configFileIndex], 'configFile.spec.store.spec.files', [''])
     let files
     let fileType
     if (get(listOfConfigFiles[configFileIndex], 'configFile.spec.store.spec.secretFiles', []).length > 0) {
       files = get(listOfConfigFiles[configFileIndex], 'configFile.spec.store.spec.secretFiles', [''])
       fileType = FILE_TYPE_VALUES.ENCRYPTED
     } else {
-      files = get(listOfConfigFiles[configFileIndex], 'configFile.spec.store.spec.files', ['']).filter((f: string) => f)
+      files = !isArray(filesValues)
+        ? filesValues
+        : get(listOfConfigFiles[configFileIndex], 'configFile.spec.store.spec.files', ['']).filter((f: string) => f)
       fileType = FILE_TYPE_VALUES.FILE_STORE
     }
 


### PR DESCRIPTION
### Summary

Setting Config File as Runtime Input was Causing page crash , this fix resolves that.

<!-- ✍️ A clear and concise description...-->

#### Screenshots

Before

https://user-images.githubusercontent.com/110456765/228002431-4417ff38-3d63-4750-95db-42e4c367f33e.mov

After

https://user-images.githubusercontent.com/110456765/228003082-b6580f66-3c82-4682-85b6-63b0486dad51.mov




<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
