### PR TITLE
fix: [SRM-14384]: Update to reset filters when user changes the project

### DIFF
--- a/src/modules/85-cv/pages/changes/CVChanges.tsx
+++ b/src/modules/85-cv/pages/changes/CVChanges.tsx
@@ -105,11 +105,11 @@ export const CVChanges = ({ updateTime }: { updateTime?: Date }): JSX.Element =>
     setSelectedSources([])
   }
 
-  const resetFilters = () => {
+  const resetFilters = useCallback(() => {
     setTimeRange({ startTime: 0, endTime: 0 })
     clearFilter()
     setShowTimelineSlider(false)
-  }
+  }, [])
 
   useEffect(() => {
     setLastUpdated(updateTime || new Date())

--- a/src/modules/85-cv/pages/changes/CVChanges.tsx
+++ b/src/modules/85-cv/pages/changes/CVChanges.tsx
@@ -104,6 +104,13 @@ export const CVChanges = ({ updateTime }: { updateTime?: Date }): JSX.Element =>
     setSelectedChangeTypes([])
     setSelectedSources([])
   }
+
+  const resetFilters = () => {
+    setTimeRange({ startTime: 0, endTime: 0 })
+    clearFilter()
+    setShowTimelineSlider(false)
+  }
+
   useEffect(() => {
     setLastUpdated(updateTime || new Date())
   }, [selectedServices, selectedEnvs, selectedChangeTypes, selectedSources, selectedTimePeriod])
@@ -262,10 +269,12 @@ export const CVChanges = ({ updateTime }: { updateTime?: Date }): JSX.Element =>
           <ChangesTable
             startTime={showTimelineSlider ? (timeRange?.startTime as number) : getStartTime}
             endTime={showTimelineSlider ? (timeRange?.endTime as number) : getEndTime}
+            isChangesPage
             hasChangeSource
             {...queryParams}
             recordsPerPage={25}
             customCols={columns}
+            resetFilters={resetFilters}
             dataTooltipId={'CVChangesTable'}
           />
         </Container>

--- a/src/modules/85-cv/pages/changes/__tests__/CVChangesFilterReset.test.tsx
+++ b/src/modules/85-cv/pages/changes/__tests__/CVChangesFilterReset.test.tsx
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2021 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import React, { useEffect, useState } from 'react'
+import { act, findByText, fireEvent, render, waitFor } from '@testing-library/react'
+import { Container } from '@harness/uicore'
+import { TestWrapper } from '@common/utils/testUtils'
+import { RiskValues } from '@cv/utils/CommonUtils'
+import { mockedHealthScoreData } from '@cv/pages/monitored-service/components/ServiceHealth/__tests__/ServiceHealth.mock'
+import { changeSummaryWithPositiveChange } from '@cv/pages/monitored-service/CVMonitoredService/__test__/CVMonitoredService.mock'
+import Button from '@rbac/components/Button/Button'
+
+import { mockedSecondaryEventsResponse } from '@cv/pages/slos/__tests__/CVSLOsListingPage.mock'
+import { filterPayloadWithENV, initialFilterPayload, mockData } from './data-mocks/ChangeEventListMock'
+import { CVChanges } from '../CVChanges'
+
+jest.useFakeTimers('modern')
+
+jest.mock('@common/hooks/useFeatureFlag', () => ({
+  useFeatureFlag: jest.fn(() => true),
+  useFeatureFlags: jest.fn(() => ({}))
+}))
+
+const mockHistoryPush = jest.fn()
+// eslint-disable-next-line jest-no-mock
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => {
+    const [projectIdentifier, setProjectIdentifier] = useState<string>('project1')
+
+    useEffect(() => {
+      setTimeout(() => {
+        setProjectIdentifier('project2')
+      }, 3000)
+    }, [])
+
+    return {
+      orgIdentifier: 'orgIdentifier',
+      projectIdentifier,
+      accountId: 'accountId',
+      identifier: 'identifier',
+      module: 'cv'
+    }
+  },
+  useHistory: jest.fn(() => ({
+    push: mockHistoryPush
+  }))
+}))
+
+const mockFetch = jest.fn()
+
+beforeEach(() => {
+  mockFetch.mockReset()
+})
+const WrapperComponent = (): React.ReactElement => {
+  const updateTime = new Date(1636428309233)
+  return (
+    <TestWrapper
+      path="/:orgIdentifier/:projectIdentifier/:accountId/:identifier"
+      pathParams={{ orgIdentifier: 'org', projectIdentifier: 'project1', accountId: 'account1', identifier: 'id1' }}
+    >
+      <CVChanges updateTime={updateTime} />
+    </TestWrapper>
+  )
+}
+
+const fetchHealthScore = jest.fn()
+
+jest.mock('highcharts-react-official', () => () => <></>)
+
+jest.mock('@cv/components/HarnessServiceAndEnvironment/HarnessServiceAndEnvironment', () => ({
+  useGetHarnessServices: () => ({
+    serviceOptions: [
+      { label: 'service1', value: 'service1' },
+      { label: 'AppDService101', value: 'AppDService101' }
+    ]
+  }),
+  HarnessServiceAsFormField: function MockComponent(props: any) {
+    return (
+      <Container>
+        <Button
+          className="addService"
+          onClick={() => props.serviceProps.onNewCreated({ name: 'newService', identifier: 'newService' })}
+        />
+      </Container>
+    )
+  },
+  HarnessEnvironmentAsFormField: function MockComponent(props: any) {
+    return (
+      <Container>
+        <Button
+          className="addEnv"
+          onClick={() => props.environmentProps.onNewCreated({ name: 'newEnv', identifier: 'newEnv' })}
+        />
+      </Container>
+    )
+  },
+  useGetHarnessEnvironments: () => {
+    return {
+      environmentOptions: [
+        { label: 'env1', value: 'env1' },
+        { label: 'AppDTestEnv1', value: 'AppDTestEnv1' }
+      ]
+    }
+  }
+}))
+jest.mock('services/cv', () => ({
+  useSaveMonitoredService: () =>
+    jest.fn().mockImplementation(() => ({ loading: false, error: null, data: {}, refetch: jest.fn() })),
+  useUpdateMonitoredService: () =>
+    jest.fn().mockImplementation(() => ({ loading: false, error: null, data: {}, refetch: jest.fn() })),
+  useGetMonitoredServiceScoresFromServiceAndEnvironment: jest.fn().mockImplementation(() => ({
+    data: { currentHealthScore: { riskStatus: RiskValues.HEALTHY, healthScore: 100 } },
+    loading: false,
+    error: null,
+    refetch: jest.fn()
+  })),
+  useGetMonitoredServiceOverAllHealthScore: jest.fn().mockImplementation(() => {
+    return { data: mockedHealthScoreData, refetch: fetchHealthScore, error: null, loading: false }
+  }),
+  useGetServiceDependencyGraph: jest.fn().mockImplementation(() => {
+    return {
+      data: {},
+      refetch: jest.fn(),
+      error: null,
+      loading: false
+    }
+  }),
+  useGetAnomaliesSummary: jest.fn().mockImplementation(() => {
+    return {
+      data: {},
+      refetch: jest.fn(),
+      error: null,
+      loading: false
+    }
+  }),
+  useChangeEventSummary: jest.fn().mockImplementation(() => {
+    return {
+      data: { resource: { ...changeSummaryWithPositiveChange } },
+      refetch: jest.fn(),
+      error: null,
+      loading: false
+    }
+  }),
+  useChangeEventList: jest
+    .fn()
+    .mockImplementation(
+      ({ queryParams: { serviceIdentifiers, envIdentifiers, changeSourceTypes, changeCategories } }) => {
+        const contents = mockData.resource.content.filter(content => {
+          let isIncluded = true
+          isIncluded = changeCategories.includes(content.category) && changeSourceTypes.includes(content.type)
+          if (serviceIdentifiers.length) isIncluded &&= serviceIdentifiers.includes(content.serviceIdentifier)
+          if (envIdentifiers.length) isIncluded &&= envIdentifiers.includes(content.envIdentifier)
+          return isIncluded
+        })
+        return {
+          data: {
+            ...mockData,
+            resource: {
+              ...mockData.resource,
+              totalItems: contents.length,
+              content: contents
+            }
+          },
+          refetch: mockFetch,
+          error: null,
+          loading: false
+        }
+      }
+    ),
+  useChangeEventTimeline: jest.fn().mockImplementation(() => {
+    return {
+      data: {},
+      refetch: jest.fn(),
+      error: null,
+      loading: false,
+      cancel: jest.fn()
+    }
+  }),
+  useChangeEventTimelineForAccount: jest.fn().mockImplementation(() => {
+    return {
+      data: {},
+      refetch: jest.fn(),
+      error: null,
+      loading: false,
+      cancel: jest.fn()
+    }
+  }),
+  useChangeEventListForAccount: jest.fn().mockImplementation(() => {
+    return {
+      data: {},
+      refetch: jest.fn(),
+      error: null,
+      loading: false,
+      cancel: jest.fn()
+    }
+  }),
+  useGetMonitoredServiceChangeTimeline: jest.fn().mockImplementation(() => {
+    return {
+      data: {
+        resource: {
+          categoryTimeline: {
+            Deployment: [],
+            Infrastructure: [],
+            Alert: []
+          }
+        }
+      },
+      refetch: jest.fn(),
+      error: null,
+      loading: false,
+      cancel: jest.fn()
+    }
+  }),
+  useGetSecondaryEvents: jest.fn().mockImplementation(() => {
+    return {
+      data: mockedSecondaryEventsResponse,
+      refetch: jest.fn(),
+      error: null,
+      loading: false,
+      cancel: jest.fn()
+    }
+  })
+}))
+
+describe('Unit tests for CVChanges', () => {
+  test('Filters should get reset when user changes the project', async () => {
+    const { container, getByTestId } = render(<WrapperComponent />)
+
+    expect(mockFetch).toBeCalledWith(initialFilterPayload)
+
+    mockFetch.mockClear()
+
+    const envDropdown = getByTestId('envFilter') as HTMLInputElement
+
+    await waitFor(() => {
+      fireEvent.click(envDropdown!)
+    })
+
+    const typeToSelect = await findByText(container, 'env1')
+
+    expect(typeToSelect).toBeInTheDocument()
+    act(() => {
+      fireEvent.click(typeToSelect)
+    })
+
+    const servicesDropdown1 = getByTestId('serviceFilter') as HTMLInputElement
+    await waitFor(() => {
+      fireEvent.click(servicesDropdown1!)
+    })
+    const typeToSelect2 = await findByText(container, 'AppDService101')
+    expect(typeToSelect2).toBeInTheDocument()
+    act(() => {
+      fireEvent.click(typeToSelect2)
+    })
+
+    expect(mockFetch).toBeCalledWith(filterPayloadWithENV)
+
+    mockFetch.mockClear()
+
+    act(() => {
+      jest.advanceTimersByTime(3000)
+    })
+
+    expect(mockFetch).toBeCalledWith(initialFilterPayload)
+  })
+})

--- a/src/modules/85-cv/pages/changes/__tests__/CVChangesFilterReset.test.tsx
+++ b/src/modules/85-cv/pages/changes/__tests__/CVChangesFilterReset.test.tsx
@@ -7,12 +7,10 @@
 
 import React, { useEffect, useState } from 'react'
 import { act, findByText, fireEvent, render, waitFor } from '@testing-library/react'
-import { Container } from '@harness/uicore'
 import { TestWrapper } from '@common/utils/testUtils'
 import { RiskValues } from '@cv/utils/CommonUtils'
 import { mockedHealthScoreData } from '@cv/pages/monitored-service/components/ServiceHealth/__tests__/ServiceHealth.mock'
 import { changeSummaryWithPositiveChange } from '@cv/pages/monitored-service/CVMonitoredService/__test__/CVMonitoredService.mock'
-import Button from '@rbac/components/Button/Button'
 
 import { mockedSecondaryEventsResponse } from '@cv/pages/slos/__tests__/CVSLOsListingPage.mock'
 import { filterPayloadWithENV, initialFilterPayload, mockData } from './data-mocks/ChangeEventListMock'
@@ -79,26 +77,6 @@ jest.mock('@cv/components/HarnessServiceAndEnvironment/HarnessServiceAndEnvironm
       { label: 'AppDService101', value: 'AppDService101' }
     ]
   }),
-  HarnessServiceAsFormField: function MockComponent(props: any) {
-    return (
-      <Container>
-        <Button
-          className="addService"
-          onClick={() => props.serviceProps.onNewCreated({ name: 'newService', identifier: 'newService' })}
-        />
-      </Container>
-    )
-  },
-  HarnessEnvironmentAsFormField: function MockComponent(props: any) {
-    return (
-      <Container>
-        <Button
-          className="addEnv"
-          onClick={() => props.environmentProps.onNewCreated({ name: 'newEnv', identifier: 'newEnv' })}
-        />
-      </Container>
-    )
-  },
   useGetHarnessEnvironments: () => {
     return {
       environmentOptions: [

--- a/src/modules/85-cv/pages/changes/__tests__/data-mocks/ChangeEventListMock.ts
+++ b/src/modules/85-cv/pages/changes/__tests__/data-mocks/ChangeEventListMock.ts
@@ -109,6 +109,7 @@ export const initialFilterPayload = {
       'K8sCluster',
       'PagerDuty',
       'HarnessFF',
+      'HarnessCE',
       'CustomDeploy',
       'CustomInfrastructure',
       'CustomIncident',
@@ -133,6 +134,7 @@ export const filterPayloadWithENV = {
       'K8sCluster',
       'PagerDuty',
       'HarnessFF',
+      'HarnessCE',
       'CustomDeploy',
       'CustomInfrastructure',
       'CustomIncident',
@@ -142,7 +144,7 @@ export const filterPayloadWithENV = {
     envIdentifiers: ['env1'],
     pageIndex: 0,
     pageSize: 25,
-    serviceIdentifiers: [],
+    serviceIdentifiers: ['AppDService101'],
     startTime: expect.any(Number)
   }
 }

--- a/src/modules/85-cv/pages/changes/__tests__/data-mocks/ChangeEventListMock.ts
+++ b/src/modules/85-cv/pages/changes/__tests__/data-mocks/ChangeEventListMock.ts
@@ -98,3 +98,51 @@ export const mockPaginatedData = {
   },
   responseMessages: []
 }
+
+export const initialFilterPayload = {
+  queryParamStringifyOptions: { arrayFormat: 'repeat' },
+  queryParams: {
+    changeCategories: ['Deployment', 'Infrastructure', 'Alert', 'FeatureFlag', 'ChaosExperiment'],
+    changeSourceTypes: [
+      'HarnessCDNextGen',
+      'HarnessCD',
+      'K8sCluster',
+      'PagerDuty',
+      'HarnessFF',
+      'CustomDeploy',
+      'CustomInfrastructure',
+      'CustomIncident',
+      'CustomFF'
+    ],
+    endTime: expect.any(Number),
+    envIdentifiers: [],
+    pageIndex: 0,
+    pageSize: 25,
+    serviceIdentifiers: [],
+    startTime: expect.any(Number)
+  }
+}
+
+export const filterPayloadWithENV = {
+  queryParamStringifyOptions: { arrayFormat: 'repeat' },
+  queryParams: {
+    changeCategories: ['Deployment', 'Infrastructure', 'Alert', 'FeatureFlag', 'ChaosExperiment'],
+    changeSourceTypes: [
+      'HarnessCDNextGen',
+      'HarnessCD',
+      'K8sCluster',
+      'PagerDuty',
+      'HarnessFF',
+      'CustomDeploy',
+      'CustomInfrastructure',
+      'CustomIncident',
+      'CustomFF'
+    ],
+    endTime: expect.any(Number),
+    envIdentifiers: ['env1'],
+    pageIndex: 0,
+    pageSize: 25,
+    serviceIdentifiers: [],
+    startTime: expect.any(Number)
+  }
+}

--- a/src/modules/85-cv/pages/monitored-service/components/ServiceHealth/components/ChangesAndServiceDependency/components/ChangesTable/ChangesTable.tsx
+++ b/src/modules/85-cv/pages/monitored-service/components/ServiceHealth/components/ChangesAndServiceDependency/components/ChangesTable/ChangesTable.tsx
@@ -14,6 +14,7 @@ import { Icon, Container, NoDataCard, PageError, TableV2, Pagination, Layout } f
 import { Color } from '@harness/design-system'
 import { useStrings } from 'framework/strings'
 import { useChangeEventList, useChangeEventListForAccount } from 'services/cv'
+import { useDeepCompareEffect } from '@common/hooks'
 import type { ProjectPathProps } from '@common/interfaces/RouteInterfaces'
 import {
   getCVMonitoringServicesSearchParam,
@@ -68,10 +69,6 @@ export default function ChangesTable({
     showConfirmationDuringClose: false
   })
 
-  useEffect(() => {
-    setPage(0)
-  }, [startTime, endTime])
-
   const monitoredServiceIdentifiers = useMemo(
     () => getMonitoredServiceIdentifiers(isAccountLevel, monitoredServiceDetails),
     [isAccountLevel, monitoredServiceDetails]
@@ -109,6 +106,14 @@ export default function ChangesTable({
     changeCategories,
     page
   ])
+
+  const { pageIndex: _, ...changeEventListQueryParamsExceptPage } = changeEventListQueryParams
+
+  useDeepCompareEffect(() => {
+    if (projectRef.current === projectIdentifier) {
+      setPage(0)
+    }
+  }, [changeEventListQueryParamsExceptPage])
 
   const {
     data: accountLevelChangeEventListData,
@@ -166,22 +171,8 @@ export default function ChangesTable({
   useEffect(() => {
     if (projectRef.current !== projectIdentifier && isChangesPage) {
       projectRef.current = projectIdentifier
+      setPage(0)
       resetFilters?.()
-      refetch({
-        queryParams: {
-          ...changeEventListQueryParams,
-          endTime: 0,
-          startTime: 0,
-          serviceIdentifiers: [],
-          envIdentifiers: [],
-          pageIndex: 0,
-          pageSize: defaultTo(recordsPerPage, PAGE_SIZE),
-          changeCategories: []
-        },
-        queryParamStringifyOptions: {
-          arrayFormat: 'repeat'
-        }
-      })
     }
   }, [projectIdentifier])
 

--- a/src/modules/85-cv/pages/monitored-service/components/ServiceHealth/components/ChangesAndServiceDependency/components/ChangesTable/ChangesTable.types.ts
+++ b/src/modules/85-cv/pages/monitored-service/components/ServiceHealth/components/ChangesAndServiceDependency/components/ChangesTable/ChangesTable.types.ts
@@ -14,6 +14,7 @@ export interface ChangesTableInterface {
   startTime: number
   endTime: number
   hasChangeSource: boolean
+  isChangesPage?: boolean
   monitoredServiceIdentifier?: string
   serviceIdentifier?: string | string[]
   environmentIdentifier?: string | string[]
@@ -23,6 +24,7 @@ export interface ChangesTableInterface {
   recordsPerPage?: number
   dataTooltipId?: string
   monitoredServiceDetails?: MonitoredServiceDetail[]
+  resetFilters?: () => void
 }
 
 export interface ChangesTableContentWrapper {

--- a/src/modules/85-cv/pages/monitored-service/components/ServiceHealth/components/ChangesAndServiceDependency/components/ChangesTable/__tests__/ChangesTable.test.tsx
+++ b/src/modules/85-cv/pages/monitored-service/components/ServiceHealth/components/ChangesAndServiceDependency/components/ChangesTable/__tests__/ChangesTable.test.tsx
@@ -43,6 +43,7 @@ describe('Change table', () => {
           endTime={1}
           serviceIdentifier={'srv'}
           environmentIdentifier={'env'}
+          resetFilters={() => void 0}
         />
       </TestWrapper>
     )
@@ -68,6 +69,7 @@ describe('Change table', () => {
           endTime={1}
           serviceIdentifier={'srv'}
           environmentIdentifier={'env'}
+          resetFilters={() => void 0}
         />
       </TestWrapper>
     )
@@ -94,6 +96,7 @@ describe('Change table', () => {
           endTime={1}
           serviceIdentifier={'srv'}
           environmentIdentifier={'env'}
+          resetFilters={() => void 0}
         />
       </TestWrapper>
     )
@@ -146,6 +149,7 @@ describe('Change table', () => {
           endTime={2}
           serviceIdentifier={'srv'}
           environmentIdentifier={'env'}
+          resetFilters={() => void 0}
         />
       </TestWrapper>
     )
@@ -197,6 +201,7 @@ describe('Change table', () => {
           endTime={2}
           serviceIdentifier={'srv'}
           environmentIdentifier={'env'}
+          resetFilters={() => void 0}
         />
       </TestWrapper>
     )
@@ -234,6 +239,7 @@ describe('Change table', () => {
           endTime={2}
           serviceIdentifier={'srv'}
           environmentIdentifier={'env'}
+          resetFilters={() => void 0}
         />
       </TestWrapper>
     )


### PR DESCRIPTION
### Summary

Changes:
1. Reset all filters if the user changes the project
2. Reset page number if the user changes the project or apply any filter(s)

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
