### PR TITLE
fix: [PIE-9633]: remove conversion of runtime inputs with defaults to fixed inputs

### DIFF
--- a/src/modules/70-pipeline/components/ArtifactsSelection/ArtifactConfigDrawer/ArtifactSourceTemplateDetails.tsx
+++ b/src/modules/70-pipeline/components/ArtifactsSelection/ArtifactConfigDrawer/ArtifactSourceTemplateDetails.tsx
@@ -29,7 +29,7 @@ import { NameSchema } from '@common/utils/Validation'
 import { setFormikRef, StepViewType } from '@pipeline/components/AbstractSteps/Step'
 import { PageSpinner } from '@common/components'
 import type { Error, StepElementConfig, StageElementConfig, ArtifactConfig } from 'services/cd-ng'
-import { getTemplateErrorMessage, replaceDefaultValues } from '@pipeline/utils/templateUtils'
+import { getTemplateErrorMessage } from '@pipeline/utils/templateUtils'
 // eslint-disable-next-line no-restricted-imports
 import artifactSourceBaseFactory from '@cd/factory/ArtifactSourceFactory/ArtifactSourceBaseFactory'
 import { getsMergedTemplateInputYamlPromise, useGetTemplate, useGetTemplateInputSetYaml } from 'services/template-ng'
@@ -168,7 +168,7 @@ function ArtifactSourceTemplateDetails(
   const updateFormValues = (newTemplateInputs?: ArtifactConfig) => {
     const updateValues = getFormValues(
       produce(formValues, draft => {
-        set(draft, 'template.templateInputs', replaceDefaultValues(newTemplateInputs))
+        set(draft, 'template.templateInputs', newTemplateInputs)
       })
     )
     setFormValues(updateValues)

--- a/src/modules/70-pipeline/components/CommonPipelineStages/PipelineStage/PipelineStageInputSection.tsx
+++ b/src/modules/70-pipeline/components/CommonPipelineStages/PipelineStage/PipelineStageInputSection.tsx
@@ -56,7 +56,6 @@ import type { PipelineStageElementConfig, StageElementWrapper } from '@pipeline/
 import { getInputSetReference } from '@pipeline/components/OverlayInputSetForm/OverlayInputSetUtils'
 import { getsMergedTemplateInputYamlPromise } from 'services/template-ng'
 import { useMutateAsGet } from '@common/hooks/useMutateAsGet'
-import { replaceDefaultValues } from '@pipeline/utils/templateUtils'
 import ErrorsStripBinded from '@pipeline/components/ErrorsStrip/ErrorsStripBinded'
 import { StageErrorContext } from '@pipeline/context/StageErrorContext'
 import { FeatureFlag } from '@common/featureFlags'
@@ -269,7 +268,7 @@ function PipelineInputSetFormBasic(): React.ReactElement {
   const updateInputTabFormValues = (newFormValues?: PipelineInfoConfig): void => {
     const updatedStage = produce(selectedStage?.stage as PipelineStageElementConfig, draft => {
       if (!hasInputSets || pipelineInputsFromYaml) {
-        set(draft, 'spec.inputs', replaceDefaultValues(newFormValues))
+        set(draft, 'spec.inputs', newFormValues)
         delete draft?.spec?.inputSetReferences
       } else {
         let _inputSetReferences = selectedInputSetReferences
@@ -278,7 +277,7 @@ function PipelineInputSetFormBasic(): React.ReactElement {
         delete draft?.spec?.inputs
       }
     })
-    setInputTabFormValues(replaceDefaultValues(newFormValues) as PipelineInfoConfig)
+    setInputTabFormValues(newFormValues as PipelineInfoConfig)
     debounceUpdateStage(updatedStage)
   }
 

--- a/src/modules/70-pipeline/components/PipelineStudio/PipelineTemplateBuilder/TemplatePipelineSpecifications/TemplatePipelineSpecifications.tsx
+++ b/src/modules/70-pipeline/components/PipelineStudio/PipelineTemplateBuilder/TemplatePipelineSpecifications/TemplatePipelineSpecifications.tsx
@@ -12,7 +12,7 @@ import { Container, Formik, FormikForm, Heading, Layout, PageError } from '@harn
 import { Color } from '@harness/design-system'
 import type { FormikProps, FormikErrors } from 'formik'
 import { produce } from 'immer'
-import { getTemplateErrorMessage, replaceDefaultValues, TEMPLATE_INPUT_PATH } from '@pipeline/utils/templateUtils'
+import { getTemplateErrorMessage, TEMPLATE_INPUT_PATH } from '@pipeline/utils/templateUtils'
 import type { ProjectPathProps } from '@common/interfaces/RouteInterfaces'
 import {
   getsMergedTemplateInputYamlPromise,
@@ -159,11 +159,7 @@ export function TemplatePipelineSpecifications({
 
   const updateFormValues = (newTemplateInputs: PipelineInfoConfig): void => {
     const updatedPipeline = produce(pipeline, draft => {
-      set(
-        draft,
-        'template.templateInputs',
-        !isEmpty(newTemplateInputs) ? replaceDefaultValues(newTemplateInputs) : undefined
-      )
+      set(draft, 'template.templateInputs', !isEmpty(newTemplateInputs) ? newTemplateInputs : undefined)
     })
 
     setFormValues(updatedPipeline)

--- a/src/modules/70-pipeline/utils/__tests__/templateUtils.test.tsx
+++ b/src/modules/70-pipeline/utils/__tests__/templateUtils.test.tsx
@@ -11,7 +11,6 @@ import { render } from '@testing-library/react'
 import type { TemplateSummaryResponse } from 'services/template-ng'
 import { TestWrapper } from '@common/utils/testUtils'
 import * as utils from '../templateUtils'
-import { replaceDefaultValues } from '../templateUtils'
 
 jest.mock('uuid')
 
@@ -90,20 +89,6 @@ describe('templateUtils', () => {
         timeout: '30s',
         type: 'Http'
       })
-    })
-  })
-
-  test('replaceDefaultValues test', () => {
-    const template = {
-      var1: '<+input>',
-      var2: { var3: { var4: '<+input>', var5: '<+input>.default(myDefaultValue)' } },
-      var6: '<+input>.default(myDefaultValue).executionInput()'
-    }
-
-    expect(replaceDefaultValues(template)).toEqual({
-      var1: '<+input>',
-      var2: { var3: { var4: '<+input>', var5: 'myDefaultValue' } },
-      var6: '<+input>.default(myDefaultValue).executionInput()'
     })
   })
 

--- a/src/modules/70-pipeline/utils/templateUtils.tsx
+++ b/src/modules/70-pipeline/utils/templateUtils.tsx
@@ -5,7 +5,7 @@
  * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
  */
 
-import { defaultTo, get, isEmpty, isEqual, set, trim, unset, map, omit } from 'lodash-es'
+import { defaultTo, get, isEmpty, isEqual, set, unset, map, omit } from 'lodash-es'
 import produce from 'immer'
 import type { GetDataError } from 'restful-react'
 import React from 'react'
@@ -41,7 +41,6 @@ import type { StepOrStepGroupOrTemplateStepData } from '@pipeline/components/Pip
 import { generateRandomString } from '@pipeline/components/PipelineStudio/ExecutionGraph/ExecutionGraphUtil'
 import { Category } from '@common/constants/TrackingConstants'
 import type { ServiceDefinition } from 'services/cd-ng'
-import { INPUT_EXPRESSION_REGEX_STRING, parseInput } from '@common/components/ConfigureOptions/ConfigureOptionsUtils'
 import { ErrorHandler } from '@common/components/ErrorHandler/ErrorHandler'
 import { getGitQueryParamsWithParentScope } from '@common/utils/gitSyncUtils'
 import type { StoreMetadata } from '@common/constants/GitSyncTypes'
@@ -368,32 +367,6 @@ export const areTemplatesEqual = (
   template2?: TemplateSummaryResponse
 ): boolean => {
   return areTemplatesSame(template1, template2) && isEqual(template1?.versionLabel, template2?.versionLabel)
-}
-
-/**
- * Replaces all the "<+input>.defaultValue(value)" with "value"
- * Does not replace any other "<+input>"
- */
-export function replaceDefaultValues<T>(template: T): T {
-  const INPUT_EXPRESSION_REGEX = new RegExp(`"${INPUT_EXPRESSION_REGEX_STRING}"`, 'g')
-  return JSON.parse(
-    JSON.stringify(template || {}).replace(
-      new RegExp(`"${INPUT_EXPRESSION_REGEX.source.slice(1).slice(0, -1)}"`, 'g'),
-      value => {
-        const parsed = parseInput(trim(value, '"'))
-
-        if (!parsed || parsed.executionInput) {
-          return value
-        }
-
-        if (parsed.default !== null) {
-          return `"${parsed.default}"`
-        }
-
-        return value
-      }
-    )
-  )
 }
 
 export const getTemplateErrorMessage = (

--- a/src/modules/72-templates-library/components/PipelineSteps/TemplateStep/TemplateStepWidget/TemplateStepWidget.tsx
+++ b/src/modules/72-templates-library/components/PipelineSteps/TemplateStep/TemplateStepWidget/TemplateStepWidget.tsx
@@ -30,7 +30,7 @@ import {
 import MultiTypeDelegateSelector from '@common/components/MultiTypeDelegateSelector/MultiTypeDelegateSelector'
 import type { StageElementConfig, TemplateStepNode } from 'services/pipeline-ng'
 import { validateStep, validateSteps } from '@pipeline/components/PipelineStudio/StepUtil'
-import { getTemplateErrorMessage, replaceDefaultValues, TEMPLATE_INPUT_PATH } from '@pipeline/utils/templateUtils'
+import { getTemplateErrorMessage, TEMPLATE_INPUT_PATH } from '@pipeline/utils/templateUtils'
 import { useQueryParams } from '@common/hooks'
 import { parse, stringify } from '@common/utils/YamlHelperMethods'
 import { usePipelineContext } from '@pipeline/components/PipelineStudio/PipelineContext/PipelineContext'
@@ -118,11 +118,7 @@ function TemplateStepWidget(
 
   const updateFormValues = (newTemplateInputs?: StepElementConfig) => {
     const updateValues = produce(initialValues, draft => {
-      set(
-        draft,
-        'template.templateInputs',
-        !isEmpty(newTemplateInputs) ? replaceDefaultValues(newTemplateInputs) : undefined
-      )
+      set(draft, 'template.templateInputs', !isEmpty(newTemplateInputs) ? newTemplateInputs : undefined)
     })
     setFormValues(updateValues)
     onUpdate?.(updateValues)

--- a/src/modules/72-templates-library/components/TemplateStageSpecifications/TemplateStageSpecifications.tsx
+++ b/src/modules/72-templates-library/components/TemplateStageSpecifications/TemplateStageSpecifications.tsx
@@ -35,7 +35,7 @@ import { useGlobalEventListener, useQueryParams } from '@common/hooks'
 import ErrorsStripBinded from '@pipeline/components/ErrorsStrip/ErrorsStripBinded'
 import { useStageTemplateActions } from '@pipeline/utils/useStageTemplateActions'
 import { TemplateBar } from '@pipeline/components/PipelineStudio/TemplateBar/TemplateBar'
-import { getTemplateErrorMessage, replaceDefaultValues, TEMPLATE_INPUT_PATH } from '@pipeline/utils/templateUtils'
+import { getTemplateErrorMessage, TEMPLATE_INPUT_PATH } from '@pipeline/utils/templateUtils'
 import { parse, stringify } from '@common/utils/YamlHelperMethods'
 import { getGitQueryParamsWithParentScope } from '@common/utils/gitSyncUtils'
 import { useFeatureFlags } from '@common/hooks/useFeatureFlag'
@@ -126,11 +126,7 @@ export const TemplateStageSpecifications = (): JSX.Element => {
 
   const updateFormValues = (newTemplateInputs?: StageElementConfig): void => {
     const updatedStage = produce(stage?.stage as StageElementConfig, draft => {
-      set(
-        draft,
-        'template.templateInputs',
-        !isEmpty(newTemplateInputs) ? replaceDefaultValues(newTemplateInputs) : undefined
-      )
+      set(draft, 'template.templateInputs', !isEmpty(newTemplateInputs) ? newTemplateInputs : undefined)
     })
     setFormValues(updatedStage)
     updateStage(updatedStage)


### PR DESCRIPTION
### Summary

Cherry-pick of https://github.com/harness/harness-core-ui/pull/15235

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
