### PR TITLE
chore: [FFM-7568]: Change `useGetAllEnvironmentFlags` to `useGetProjectFlags`

### DIFF
--- a/src/modules/75-cf/hooks/__tests__/useEnvironmentSelectV2.test.tsx
+++ b/src/modules/75-cf/hooks/__tests__/useEnvironmentSelectV2.test.tsx
@@ -51,7 +51,7 @@ describe('Test useEnvironmentSelectV2', () => {
       clearPreference: jest.fn()
     })
 
-    jest.spyOn(cfServices, 'useGetAllEnvironmentsFlags').mockReturnValue({
+    jest.spyOn(cfServices, 'useGetProjectFlags').mockReturnValue({
       loading: false,
       error: null,
       absolutePath: '',

--- a/src/modules/75-cf/hooks/useEnvironmentSelectV2.tsx
+++ b/src/modules/75-cf/hooks/useEnvironmentSelectV2.tsx
@@ -9,7 +9,7 @@ import React, { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { Select, SelectOption, SelectProps } from '@harness/uicore'
 import { useStrings } from 'framework/strings'
-import { useGetAllEnvironmentsFlags } from 'services/cf'
+import { useGetProjectFlags } from 'services/cf'
 import { EnvironmentResponseDTO, useGetEnvironmentListForProject } from 'services/cd-ng'
 import { PreferenceScope, usePreferenceStore } from 'framework/PreferenceStore/PreferenceStoreContext'
 import { useQueryParamsState } from '@common/hooks/useQueryParamsState'
@@ -77,7 +77,7 @@ export const useEnvironmentSelectV2 = (params: UseEnvironmentSelectV2Params) => 
     error: fetchAllEnvironmentsFlagsError,
     data: allEnvironmentsFlags,
     refetch: refetchAllEnvironmentsFlags
-  } = useGetAllEnvironmentsFlags({
+  } = useGetProjectFlags({
     identifier: projectIdentifier,
     queryParams,
     lazy: true

--- a/src/modules/75-cf/pages/feature-flags/FeatureFlagsPage.tsx
+++ b/src/modules/75-cf/pages/feature-flags/FeatureFlagsPage.tsx
@@ -222,7 +222,7 @@ const FeatureFlagsPage: React.FC = () => {
           />
         </Container>
       )}
-      {!emptyFeatureFlags || !!allEnvironmentsFlags?.flags.length ? (
+      {!emptyFeatureFlags || !!allEnvironmentsFlags?.flags?.length ? (
         <Container padding={{ top: 'medium', right: 'xlarge', left: 'xlarge' }}>
           {allEnvironmentsFlags && !!environments?.length ? (
             <AllEnvironmentsFlagsListing

--- a/src/modules/75-cf/pages/feature-flags/components/AllEnvironmentsFlagsListing.tsx
+++ b/src/modules/75-cf/pages/feature-flags/components/AllEnvironmentsFlagsListing.tsx
@@ -10,7 +10,7 @@ import type { Cell, Column } from 'react-table'
 import { Container, Layout, TableV2, Text, Utils } from '@harness/uicore'
 import { Color, FontVariation } from '@harness/design-system'
 import type { MutateRequestOptions } from 'restful-react/dist/Mutate'
-import type { AllEnvironmentsFlags, AllEnvironmentsFlag, DeleteFeatureFlagQueryParams, Feature } from 'services/cf'
+import type { DeleteFeatureFlagQueryParams, Feature, FlagState, ProjectFlags } from 'services/cf'
 import type { EnvironmentResponseDTO } from 'services/cd-ng'
 import { useStrings } from 'framework/strings'
 import FlagOptionsMenuButton from '@cf/components/FlagOptionsMenuButton/FlagOptionsMenuButton'
@@ -19,7 +19,7 @@ import { formatDate } from '@cf/utils/CFUtils'
 import FlagEnvironmentsState from './FlagEnvironmentsState'
 export interface AllEnvironmentsFlagsListingProps {
   environments: EnvironmentResponseDTO[]
-  allEnvironmentsFlags: AllEnvironmentsFlags
+  allEnvironmentsFlags: ProjectFlags
   refetchFlags: () => void
   deleteFlag: (data: string, mutateRequestOptions?: MutateRequestOptions<DeleteFeatureFlagQueryParams, void>) => void
   queryParams: DeleteFeatureFlagQueryParams
@@ -37,14 +37,14 @@ export const AllEnvironmentsFlagsListing: FC<AllEnvironmentsFlagsListingProps> =
   const gitSync = useFFGitSyncContext()
   const { getString } = useStrings()
 
-  const allEnvironmentsColumns: Column<AllEnvironmentsFlag>[] = useMemo(
+  const allEnvironmentsColumns: Column<FlagState>[] = useMemo(
     () => [
       {
         font: FontVariation.TABLE_HEADERS,
         id: 'flagName',
         accessor: row => row.name,
         width: '25%',
-        Cell: (cell: Cell<AllEnvironmentsFlag>) => (
+        Cell: (cell: Cell<FlagState>) => (
           <Container
             flex={{ distribution: 'space-between', align: 'center-center' }}
             padding={{ left: 'small', right: 'small' }}
@@ -68,7 +68,7 @@ export const AllEnvironmentsFlagsListing: FC<AllEnvironmentsFlagsListingProps> =
         id: 'createdAt',
         accessor: 'createdAt',
         width: '15%',
-        Cell: (cell: Cell<AllEnvironmentsFlag>) => (
+        Cell: (cell: Cell<FlagState>) => (
           <Layout.Horizontal
             flex={{ distribution: 'space-between', align: 'center-center' }}
             padding={{ left: 'small', right: 'small' }}
@@ -89,7 +89,7 @@ export const AllEnvironmentsFlagsListing: FC<AllEnvironmentsFlagsListingProps> =
         id: 'environments',
         font: FontVariation.TABLE_HEADERS,
         width: '55%',
-        Cell: (cell: Cell<AllEnvironmentsFlag>) => {
+        Cell: (cell: Cell<FlagState>) => {
           const environmentsByType = {
             nonProd: nonProdEnvs.map(env => ({
               identifier: env.identifier,
@@ -126,7 +126,7 @@ export const AllEnvironmentsFlagsListing: FC<AllEnvironmentsFlagsListingProps> =
     [nonProdEnvs, prodEnvs, queryParams, gitSync]
   )
 
-  return <TableV2<AllEnvironmentsFlag> columns={allEnvironmentsColumns} data={allEnvironmentsFlags?.flags || []} />
+  return <TableV2<FlagState> columns={allEnvironmentsColumns} data={allEnvironmentsFlags?.flags || []} />
 }
 
 export default AllEnvironmentsFlagsListing

--- a/src/modules/75-cf/pages/feature-flags/components/__tests__/AllEnvironmentsFlagsListing.test.tsx
+++ b/src/modules/75-cf/pages/feature-flags/components/__tests__/AllEnvironmentsFlagsListing.test.tsx
@@ -39,7 +39,7 @@ const renderComponent = (props?: Partial<AllEnvironmentsFlagsListingProps>): Ren
 
 describe('AllEnvironmentsFlagsListing', () => {
   beforeAll(() => {
-    jest.spyOn(cfServices, 'useGetAllEnvironmentsFlags').mockReturnValue({
+    jest.spyOn(cfServices, 'useGetProjectFlags').mockReturnValue({
       loading: false,
       data: mockAllEnvsFlags,
       refetch: jest.fn(),

--- a/src/services/cf/index.tsx
+++ b/src/services/cf/index.tsx
@@ -652,6 +652,14 @@ export interface FlagEnvironmentState {
  * Flag object with its state in each environment
  */
 export interface FlagState {
+  /**
+   * The date the flag was created in milliseconds
+   */
+  createdAt: number
+  /**
+   * The flags description
+   */
+  description: string
   environments: {
     [key: string]: FlagEnvironmentState
   }
@@ -1277,10 +1285,10 @@ export interface UsageDataDTO {
 }
 
 /**
- * Returns counts of Active (Where flag state is on in 1+ environments) and Total Flags
+ * Returns counts of Enabled (Where flag state is on in 1+ environments) and Total Flags
  */
 export interface UserFlagOverview {
-  active: number
+  enabled: number
   total: number
 }
 
@@ -4884,9 +4892,9 @@ export type GetUserFlagOverviewProps = Omit<
 >
 
 /**
- * Returns a count of active and total flags for projects a User can access
+ * Returns a count of enabled and total flags for projects a User can access
  *
- * Returns an active (where flag state is on in 1+ environment) and total count of flags in all projects a user can access
+ * Returns an enabled (where flag state is on in 1+ environment) and total count of flags in all projects a user can access
  */
 export const GetUserFlagOverview = (props: GetUserFlagOverviewProps) => (
   <Get<
@@ -4912,9 +4920,9 @@ export type UseGetUserFlagOverviewProps = Omit<
 >
 
 /**
- * Returns a count of active and total flags for projects a User can access
+ * Returns a count of enabled and total flags for projects a User can access
  *
- * Returns an active (where flag state is on in 1+ environment) and total count of flags in all projects a user can access
+ * Returns an enabled (where flag state is on in 1+ environment) and total count of flags in all projects a user can access
  */
 export const useGetUserFlagOverview = (props: UseGetUserFlagOverviewProps) =>
   useGet<
@@ -4925,9 +4933,9 @@ export const useGetUserFlagOverview = (props: UseGetUserFlagOverviewProps) =>
   >(`/admin/overview`, { base: getConfig('cf'), ...props })
 
 /**
- * Returns a count of active and total flags for projects a User can access
+ * Returns a count of enabled and total flags for projects a User can access
  *
- * Returns an active (where flag state is on in 1+ environment) and total count of flags in all projects a user can access
+ * Returns an enabled (where flag state is on in 1+ environment) and total count of flags in all projects a user can access
  */
 export const getUserFlagOverviewPromise = (
   props: GetUsingFetchProps<
@@ -6919,156 +6927,6 @@ export const getSegmentFlagsPromise = (
     GetSegmentFlagsQueryParams,
     GetSegmentFlagsPathParams
   >(getConfig('cf'), `/admin/segments/${identifier}/flags`, props, signal)
-
-export interface AllEnvironmentsFlag {
-  /**
-   * The date the flag was created in milliseconds
-   */
-  createdAt: number
-  /**
-   * A description for this Environment
-   */
-  description?: string
-  /**
-   * Unique identifier for the object in the API.
-   */
-  identifier: string
-  /**
-   * The user friendly identifier for the API Key
-   */
-  name: string
-  /**
-   * The state of the flag across all environments
-   */
-  environments: {
-    [key: string]: {
-      enabled: boolean
-    }
-  }
-}
-
-export type AllEnvironmentsFlags = {
-  flags?: AllEnvironmentsFlag[]
-}
-
-/**
- * OK
- */
-export type AllEnvironmentsFlagsResponseResponse = Pagination & {
-  flags: AllEnvironmentsFlag[]
-  /**
-   * All environments names
-   */
-  environments: {
-    [key: string]: {
-      name: string
-    }
-  }
-}
-
-export type GetAllEnvironmentsFlagsProps = Omit<
-  GetProps<
-    AllEnvironmentsFlagsResponseResponse,
-    UnauthenticatedResponse | UnauthorizedResponse | NotFoundResponse | InternalServerErrorResponse,
-    GetAllEnvironmentsFlagsQueryParams,
-    GetAllEnvironmentsFlagsPathParams
-  >,
-  'path'
-> &
-  GetAllEnvironmentsFlagsPathParams
-export interface GetAllEnvironmentsFlagsPathParams {
-  /**
-   * Project identifier for the object in the API.
-   */
-  identifier: string
-}
-export interface GetAllEnvironmentsFlagsQueryParams {
-  /**
-   * Account Identifier
-   */
-  accountIdentifier: string
-  /**
-   * Organization Identifier
-   */
-  orgIdentifier: string
-  /**
-   * Flag Name - used for search
-   */
-  name?: string
-}
-
-/**
- * Returns flag states across all Environments for the given Project identifier
- */
-export const GetAllEnvironmentsFlags = ({ identifier, ...props }: GetAllEnvironmentsFlagsProps) => (
-  <Get<
-    AllEnvironmentsFlagsResponseResponse,
-    UnauthenticatedResponse | UnauthorizedResponse | NotFoundResponse | InternalServerErrorResponse,
-    GetAllEnvironmentsFlagsQueryParams,
-    GetAllEnvironmentsFlagsPathParams
-  >
-    path={`/admin/projects/${identifier}/flags`}
-    base={getConfig('cf')}
-    {...props}
-  />
-)
-
-export type UseGetAllEnvironmentsFlagsProps = Omit<
-  UseGetProps<
-    AllEnvironmentsFlagsResponseResponse,
-    UnauthenticatedResponse | UnauthorizedResponse | NotFoundResponse | InternalServerErrorResponse,
-    GetAllEnvironmentsFlagsQueryParams,
-    GetAllEnvironmentsFlagsPathParams
-  >,
-  'path'
-> &
-  GetProjectPathParams
-
-/**
- * Returns All Feature Flags
- *
- * Returns All Feature Flags across all Environments for the given identifier
- */
-export const useGetAllEnvironmentsFlags = ({ identifier, ...props }: UseGetAllEnvironmentsFlagsProps) =>
-  useGet<
-    AllEnvironmentsFlagsResponseResponse,
-    UnauthenticatedResponse | UnauthorizedResponse | NotFoundResponse | InternalServerErrorResponse,
-    GetAllEnvironmentsFlagsQueryParams,
-    GetAllEnvironmentsFlagsPathParams
-  >((paramsInPath: GetAllEnvironmentsFlagsPathParams) => `/admin/projects/${paramsInPath.identifier}/flags`, {
-    base: getConfig('cf'),
-    pathParams: { identifier },
-    ...props
-  })
-
-/**
- * Returns All Feature Flags
- *
- * Returns All Feature Flags across all Environments for the given identifier
- */
-export const getAllEnvironmentsFlagsPromise = (
-  {
-    identifier,
-    ...props
-  }: GetUsingFetchProps<
-    AllEnvironmentsFlagsResponseResponse,
-    UnauthenticatedResponse | UnauthorizedResponse | NotFoundResponse | InternalServerErrorResponse,
-    GetAllEnvironmentsFlagsQueryParams,
-    GetAllEnvironmentsFlagsPathParams
-  > & {
-    /**
-     * Unique identifier for the object in the API.
-     */
-    identifier: string
-  },
-  signal?: RequestInit['signal']
-) =>
-  getUsingFetch<
-    AllEnvironmentsFlagsResponseResponse,
-    UnauthenticatedResponse | UnauthorizedResponse | NotFoundResponse | InternalServerErrorResponse,
-    GetAllEnvironmentsFlagsQueryParams,
-    GetAllEnvironmentsFlagsPathParams
-  >(getConfig('cf'), `/admin/projects/${identifier}/flags`, props, signal)
 
 export interface GetAllTargetsQueryParams {
   /**


### PR DESCRIPTION
This PR replaces usage of the `useGetAllEnvironmentFlags` hook with the `useGetProjectFlags` hook.