### PR TITLE
feat: [PIE-9850]: added cache header to templates API call

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nextgenui",
   "description": "Harness Inc",
-  "version": "0.345.17",
+  "version": "0.345.18",
   "author": "Harness Inc",
   "license": "Harness Inc",
   "homepage": "https://app.harness.io/",

--- a/src/modules/10-common/hooks/useMutateAsGet.tsx
+++ b/src/modules/10-common/hooks/useMutateAsGet.tsx
@@ -69,7 +69,8 @@ async function _fetchData<TData, TError, TQueryParams, TRequestBody, TPathParams
   try {
     const data = await mutate(props.body, {
       queryParams: props.queryParams,
-      pathParams: props.pathParams
+      pathParams: props.pathParams,
+      ...props.requestOptions
     })
     if (data) {
       unstable_batchedUpdates(() => {

--- a/src/modules/70-pipeline/components/InputSetForm/InputSetForm.tsx
+++ b/src/modules/70-pipeline/components/InputSetForm/InputSetForm.tsx
@@ -592,7 +592,12 @@ function InputSetForm(props: InputSetFormProps): React.ReactElement {
       pathParams: { inputSetIdentifier: inputSetIdentifier },
       requestOptions: { headers: { 'Load-From-Cache': 'false' } }
     })
-    refetchTemplate({ requestOptions: { headers: { 'Load-From-Cache': 'false' } } })
+    refetchTemplate({
+      body: {
+        stageIdentifiers: []
+      },
+      requestOptions: { headers: { 'Load-From-Cache': 'false' } }
+    })
     refetchPipeline({ requestOptions: { headers: { 'Load-From-Cache': 'false' } } })
   }
 

--- a/src/modules/70-pipeline/components/RunPipelineModal/RunModalHeader.tsx
+++ b/src/modules/70-pipeline/components/RunPipelineModal/RunModalHeader.tsx
@@ -31,6 +31,7 @@ import {
   ALL_STAGE_VALUE,
   getAllStageData,
   getAllStageItem,
+  getStageIdentifierFromStageData,
   SelectedStageData,
   StageSelectionData
 } from '@pipeline/utils/runPipelineUtils'
@@ -60,6 +61,7 @@ export interface RunModalHeaderProps {
   executionStageList: SelectOption[]
   runModalHeaderTitle: string
   refetchPipeline: any
+  refetchTemplate: any
 }
 
 export default function RunModalHeader(props: RunModalHeaderProps): React.ReactElement | null {
@@ -79,7 +81,8 @@ export default function RunModalHeader(props: RunModalHeaderProps): React.ReactE
     stageExecutionData,
     executionStageList,
     runModalHeaderTitle,
-    refetchPipeline
+    refetchPipeline,
+    refetchTemplate
   } = props
   const {
     isGitSyncEnabled: isGitSyncEnabledForProject,
@@ -101,6 +104,12 @@ export default function RunModalHeader(props: RunModalHeaderProps): React.ReactE
 
   const handleReloadFromCache = () => {
     refetchPipeline({
+      requestOptions: { headers: { 'Load-From-Cache': 'false' } }
+    })
+    refetchTemplate({
+      body: {
+        stageIdentifiers: getStageIdentifierFromStageData(selectedStageData)
+      },
       requestOptions: { headers: { 'Load-From-Cache': 'false' } }
     })
   }

--- a/src/modules/70-pipeline/components/RunPipelineModal/RunPipelineForm.tsx
+++ b/src/modules/70-pipeline/components/RunPipelineModal/RunPipelineForm.tsx
@@ -816,6 +816,7 @@ function RunPipelineFormBasic({
                     executionStageList={executionStageList}
                     runModalHeaderTitle={formTitleText}
                     refetchPipeline={refetchPipeline}
+                    refetchTemplate={getTemplateFromPipeline}
                   />
                   <RequiredStagesInfo
                     selectedStageData={selectedStageData}

--- a/src/modules/70-pipeline/components/RunPipelineModal/useInputSets.tsx
+++ b/src/modules/70-pipeline/components/RunPipelineModal/useInputSets.tsx
@@ -117,6 +117,7 @@ export function useInputSets(props: UseInputSetsProps): UseInputSetsReturn {
       parentEntityConnectorRef: connectorRef,
       parentEntityRepoName: repoIdentifier
     },
+    requestOptions: { headers: { 'Load-From-Cache': 'true' } },
     lazy: executionInputSetTemplateYaml || executionView || !selectedStageData.selectedStageItems.length
   })
 

--- a/src/modules/70-pipeline/pages/pipeline-list/__tests__/PipelineListPage.test.tsx
+++ b/src/modules/70-pipeline/pages/pipeline-list/__tests__/PipelineListPage.test.tsx
@@ -334,6 +334,10 @@ describe('CD Pipeline List Page', () => {
           searchTerm: 'asd',
           size: 20,
           sort: ['lastUpdatedAt', 'DESC']
+        },
+        pathParams: undefined,
+        headers: {
+          'content-type': 'application/json'
         }
       }
     )
@@ -401,6 +405,10 @@ describe('CI Pipeline List Page', () => {
           searchTerm: undefined,
           size: 20,
           sort: ['executionSummaryInfo.lastExecutionTs', 'ASC']
+        },
+        pathParams: undefined,
+        headers: {
+          'content-type': 'application/json'
         }
       }
     )


### PR DESCRIPTION
### Summary

- Added cache header in the templates call in run pipeline form
- templates call was failing in the IS studio on reload due to missing body
- Updated useMutateAsGet to take care of request Options

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
