### PR TITLE
fix: [CI-7845]: runTest and background Step connector and image validation exemption for template studio

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nextgenui",
   "description": "Harness Inc",
-  "version": "0.346.15",
+  "version": "0.346.16",
   "author": "Harness Inc",
   "license": "Harness Inc",
   "homepage": "https://app.harness.io/",

--- a/src/modules/75-ci/components/PipelineSteps/BackgroundStep/BackgroundStepBase.tsx
+++ b/src/modules/75-ci/components/PipelineSteps/BackgroundStep/BackgroundStepBase.tsx
@@ -23,7 +23,7 @@ import type { FormikProps } from 'formik'
 import { useLocation } from 'react-router-dom'
 import { getImagePullPolicyOptions } from '@common/utils/ContainerRunStepUtils'
 import { getCIShellOptions } from '@ci/utils/CIShellOptionsUtils'
-import { StepFormikFowardRef, setFormikRef } from '@pipeline/components/AbstractSteps/Step'
+import { StepFormikFowardRef, setFormikRef, StepViewType } from '@pipeline/components/AbstractSteps/Step'
 import MultiTypeFieldSelector from '@common/components/MultiTypeFieldSelector/MultiTypeFieldSelector'
 import { usePipelineContext } from '@pipeline/components/PipelineStudio/PipelineContext/PipelineContext'
 import { useStrings } from 'framework/strings'
@@ -105,7 +105,7 @@ export const BackgroundStepBase = (
         onChange?.(schemaValues)
         return validate(
           valuesToValidate,
-          getEditViewValidateFieldsConfig(isBuildInfrastructureTypeVM),
+          getEditViewValidateFieldsConfig(isBuildInfrastructureTypeVM, stepViewType === StepViewType.Template),
           {
             initialValues,
             steps: currentStage?.stage?.spec?.execution?.steps || {},
@@ -143,7 +143,7 @@ export const BackgroundStepBase = (
               CIBuildInfrastructureType.VM,
               CIBuildInfrastructureType.Cloud,
               CIBuildInfrastructureType.Docker
-            ].includes(buildInfrastructureType) ? (
+            ].includes(buildInfrastructureType) && stepViewType !== StepViewType.Template ? (
               <ConnectorRefWithImage showOptionalSublabel={false} readonly={readonly} stepViewType={stepViewType} />
             ) : null}
             <Container className={cx(css.formGroup, css.lg, css.bottomMargin5)}>
@@ -264,7 +264,7 @@ export const BackgroundStepBase = (
                 summary={getString('pipeline.additionalConfiguration')}
                 details={
                   <Container margin={{ top: 'medium' }}>
-                    {isBuildInfrastructureTypeVM ? (
+                    {isBuildInfrastructureTypeVM || stepViewType === StepViewType.Template ? (
                       <ConnectorRefWithImage
                         showOptionalSublabel={true}
                         readonly={readonly}

--- a/src/modules/75-ci/components/PipelineSteps/BackgroundStep/BackgroundStepFunctionConfigs.ts
+++ b/src/modules/75-ci/components/PipelineSteps/BackgroundStep/BackgroundStepFunctionConfigs.ts
@@ -79,7 +79,7 @@ export const transformValuesFieldsConfig = [
   }
 ]
 
-export const getEditViewValidateFieldsConfig = (isBuildInfrastructureTypeVM: boolean) => [
+export const getEditViewValidateFieldsConfig = (isBuildInfrastructureTypeVM: boolean, isTemplateView: boolean) => [
   {
     name: 'identifier',
     type: ValidationFieldTypes.Identifier,
@@ -96,13 +96,13 @@ export const getEditViewValidateFieldsConfig = (isBuildInfrastructureTypeVM: boo
     name: 'spec.connectorRef',
     type: ValidationFieldTypes.Text,
     label: 'pipelineSteps.connectorLabel',
-    isRequired: !isBuildInfrastructureTypeVM
+    isRequired: !isBuildInfrastructureTypeVM && !isTemplateView
   },
   {
     name: 'spec.image',
     type: ValidationFieldTypes.Text,
     label: 'imageLabel',
-    isRequired: !isBuildInfrastructureTypeVM
+    isRequired: !isBuildInfrastructureTypeVM && !isTemplateView
   },
   {
     name: 'spec.shell',
@@ -167,14 +167,12 @@ export function getInputSetViewValidateFieldsConfig(isRequired = true): Array<{
     {
       name: 'spec.connectorRef',
       type: ValidationFieldTypes.Text,
-      label: 'pipelineSteps.connectorLabel',
-      isRequired
+      label: 'pipelineSteps.connectorLabel'
     },
     {
       name: 'spec.image',
       type: ValidationFieldTypes.Text,
-      label: 'imageLabel',
-      isRequired
+      label: 'imageLabel'
     },
     {
       name: 'spec.shell',

--- a/src/modules/75-ci/components/PipelineSteps/RunStep/RunStepFunctionConfigs.ts
+++ b/src/modules/75-ci/components/PipelineSteps/RunStep/RunStepFunctionConfigs.ts
@@ -165,14 +165,12 @@ export function getInputSetViewValidateFieldsConfig(
     {
       name: 'spec.connectorRef',
       type: ValidationFieldTypes.Text,
-      label: 'pipelineSteps.connectorLabel',
-      isRequired
+      label: 'pipelineSteps.connectorLabel'
     },
     {
       name: 'spec.image',
       type: ValidationFieldTypes.Text,
-      label: 'imageLabel',
-      isRequired
+      label: 'imageLabel'
     },
     {
       name: 'spec.shell',

--- a/src/modules/75-ci/components/PipelineSteps/RunTestsStep/RunTestsStepBase.tsx
+++ b/src/modules/75-ci/components/PipelineSteps/RunTestsStep/RunTestsStepBase.tsx
@@ -24,7 +24,7 @@ import { Color, FontVariation } from '@harness/design-system'
 import type { FormikErrors, FormikProps } from 'formik'
 import { get, merge } from 'lodash-es'
 import cx from 'classnames'
-import { StepFormikFowardRef, setFormikRef } from '@pipeline/components/AbstractSteps/Step'
+import { StepFormikFowardRef, setFormikRef, StepViewType } from '@pipeline/components/AbstractSteps/Step'
 import { getImagePullPolicyOptions } from '@common/utils/ContainerRunStepUtils'
 import { getCIRunTestsStepShellOptions } from '@ci/utils/CIShellOptionsUtils'
 import MultiTypeFieldSelector from '@common/components/MultiTypeFieldSelector/MultiTypeFieldSelector'
@@ -486,7 +486,8 @@ export const RunTestsStepBase = (
             valuesToValidate,
             getEditViewValidateFieldsConfig(
               buildInfrastructureType,
-              (valuesToValidate?.spec?.language as any)?.value === Language.Csharp
+              (valuesToValidate?.spec?.language as any)?.value === Language.Csharp,
+              stepViewType === StepViewType.Template
             ),
             {
               initialValues,
@@ -534,7 +535,7 @@ export const RunTestsStepBase = (
               CIBuildInfrastructureType.VM,
               CIBuildInfrastructureType.Cloud,
               CIBuildInfrastructureType.Docker
-            ].includes(buildInfrastructureType) ? (
+            ].includes(buildInfrastructureType) && stepViewType !== StepViewType.Template ? (
               <ConnectorRefWithImage showOptionalSublabel={false} readonly={readonly} stepViewType={stepViewType} />
             ) : null}
             <Container className={cx(css.formGroup, css.lg, css.bottomMargin5)}>
@@ -788,7 +789,7 @@ gradle.projectsEvaluated {
                       CIBuildInfrastructureType.VM,
                       CIBuildInfrastructureType.Cloud,
                       CIBuildInfrastructureType.Docker
-                    ].includes(buildInfrastructureType) ? (
+                    ].includes(buildInfrastructureType) || stepViewType === StepViewType.Template ? (
                       <ConnectorRefWithImage
                         showOptionalSublabel={true}
                         readonly={readonly}

--- a/src/modules/75-ci/components/PipelineSteps/RunTestsStep/RunTestsStepFunctionConfigs.ts
+++ b/src/modules/75-ci/components/PipelineSteps/RunTestsStep/RunTestsStepFunctionConfigs.ts
@@ -114,7 +114,8 @@ export const transformValuesFieldsConfig = [
 
 export const getEditViewValidateFieldsConfig = (
   buildInfrastructureType: CIBuildInfrastructureType,
-  isLanguageCsharp: boolean
+  isLanguageCsharp: boolean,
+  isTemplateView: boolean
 ): { name: string; type: ValidationFieldTypes; label?: string; isRequired?: boolean }[] => [
   {
     name: 'identifier',
@@ -132,21 +133,19 @@ export const getEditViewValidateFieldsConfig = (
     name: 'spec.connectorRef',
     type: ValidationFieldTypes.Text,
     label: 'pipelineSteps.connectorLabel',
-    isRequired: ![
-      CIBuildInfrastructureType.Cloud,
-      CIBuildInfrastructureType.VM,
-      CIBuildInfrastructureType.Docker
-    ].includes(buildInfrastructureType)
+    isRequired:
+      ![CIBuildInfrastructureType.Cloud, CIBuildInfrastructureType.VM, CIBuildInfrastructureType.Docker].includes(
+        buildInfrastructureType
+      ) && !isTemplateView
   },
   {
     name: 'spec.image',
     type: ValidationFieldTypes.Text,
     label: 'imageLabel',
-    isRequired: ![
-      CIBuildInfrastructureType.Cloud,
-      CIBuildInfrastructureType.VM,
-      CIBuildInfrastructureType.Docker
-    ].includes(buildInfrastructureType)
+    isRequired:
+      ![CIBuildInfrastructureType.Cloud, CIBuildInfrastructureType.VM, CIBuildInfrastructureType.Docker].includes(
+        buildInfrastructureType
+      ) && !isTemplateView
   },
   {
     name: 'spec.language',
@@ -235,14 +234,12 @@ export function getInputSetViewValidateFieldsConfig(
     {
       name: 'spec.connectorRef',
       type: ValidationFieldTypes.Text,
-      label: 'pipelineSteps.connectorLabel',
-      isRequired
+      label: 'pipelineSteps.connectorLabel'
     },
     {
       name: 'spec.image',
       type: ValidationFieldTypes.Text,
-      label: 'imageLabel',
-      isRequired
+      label: 'imageLabel'
     },
     {
       name: 'spec.buildEnvironment',


### PR DESCRIPTION
### Summary

runTest and background Step connector and image validation exemption for template studio

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
