### PR TITLE
fix: [CDS-68141]: fix asg category name for step palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nextgenui",
   "description": "Harness Inc",
-  "version": "0.347.2",
+  "version": "0.347.3",
   "author": "Harness Inc",
   "license": "Harness Inc",
   "homepage": "https://app.harness.io/",

--- a/src/modules/70-pipeline/utils/stepUtils.ts
+++ b/src/modules/70-pipeline/utils/stepUtils.ts
@@ -134,7 +134,7 @@ export function getStepPaletteModuleInfosFromStage(
       category = 'CustomDeployment'
       break
     case ServiceDeploymentType.Asg:
-      category = 'AutoScalingGroup'
+      category = 'AWS Auto Scaling Group'
       break
     case ServiceDeploymentType.GoogleCloudFunctions: {
       if (environmentType === GoogleCloudFunctionsEnvType.GenOne) {


### PR DESCRIPTION
### Summary

Fixed ASG Category Name

Earlier, the category name had a mismatch with the name on BE for ASG. Because of this, we were not able to see ASG & terraform related steps when trying to add steps in an ASG pipeline.

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
