### PR TITLE
feat: [PL-38394]: adds StatusPage embed widget

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -20,6 +20,7 @@ sed -i "s|HARNESS_ENABLE_APPDY_EUM_PLACEHOLDER|$HARNESS_ENABLE_APPDY_EUM_PLACEHO
 sed -i "s|HARNESS_ENABLE_CDN_PLACEHOLDER|$HARNESS_ENABLE_CDN_PLACEHOLDER|" index.html
 sed -i "s|BROWSER_ROUTER_ENABLED_PLACEHOLDER|$BROWSER_ROUTER_ENABLED_PLACEHOLDER|" index.html
 sed -i "s|HARNESS_ENABLE_SABER_PLACEHOLDER|$HARNESS_ENABLE_SABER_PLACEHOLDER|" index.html
+sed -i "s|HARNESS_ENABLE_STATUS_EMBED_PLACEHOLDER|$HARNESS_ENABLE_STATUS_EMBED_PLACEHOLDER|" index.html
 sed -i "s|<\!-- segmentToken -->|<script>window.segmentToken = '$SEGMENT_TOKEN'</script>|" index.html
 sed -i "s|<\!-- bugsnagToken -->|<script>window.bugsnagToken = '$BUGSNAG_TOKEN'</script>|" index.html
 sed -i "s|<\!-- appDyEUMToken -->|<script>window.appDyEUMToken = '$APPDY_EUM_TOKEN'</script>|" index.html

--- a/src/index.html
+++ b/src/index.html
@@ -194,7 +194,7 @@
       if (window.HARNESS_ENABLE_STATUS_EMBED) {
         var e = document.createElement('script')
         e.setAttribute('type', 'text/javascript')
-        e.setAttribute('src', 'https://status.harness.io/embed/script.js')
+        e.setAttribute('src', 'https://widget1.statuspage.io/embed/script.js')
         document.getElementsByTagName('head')[0].appendChild(e)
       }
     </script>

--- a/src/index.html
+++ b/src/index.html
@@ -190,7 +190,6 @@
     </script>
 
     <!-- StatusPage Embed -->
-    <script src="https://widget1.statuspage.io/embed/script.js"></script>
     <!-- <script>
       if (window.HARNESS_ENABLE_STATUS_EMBED) {
         var e = document.createElement('script')
@@ -278,5 +277,6 @@
       </div>
     </div>
     <div id="ngTooltipEditorRootParent"></div>
+    <script src="https://widget1.statuspage.io/embed/script.js"></script>
   </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -190,14 +190,15 @@
     </script>
 
     <!-- StatusPage Embed -->
-    <script>
+    <script src="https://widget1.statuspage.io/embed/script.js"></script>
+    <!-- <script>
       if (window.HARNESS_ENABLE_STATUS_EMBED) {
         var e = document.createElement('script')
         e.setAttribute('type', 'text/javascript')
         e.setAttribute('src', 'https://widget1.statuspage.io/embed/script.js')
         document.getElementsByTagName('head')[0].appendChild(e)
       }
-    </script>
+    </script> -->
     <!-- End of StatusPage Embed -->
 
     <!-- saberToken -->

--- a/src/index.html
+++ b/src/index.html
@@ -49,7 +49,6 @@
     <!-- newNavContentfulEnvironment -->
     <!-- harnessNameSpacePlaceHolder -->
     <!-- harnessClusterURLPlaceHolder -->
-    <!-- adding bugsnag for SAAS build -->
 
     <% if (!__DEV__) { %>
     <script type="text/javascript">
@@ -144,6 +143,7 @@
       window.HARNESS_ENABLE_APPDY_EUM = 'HARNESS_ENABLE_APPDY_EUM_PLACEHOLDER' === 'true'
       window.HARNESS_ENABLE_CDN = 'HARNESS_ENABLE_CDN_PLACEHOLDER' === 'true'
       window.HARNESS_ENABLE_SABER = 'HARNESS_ENABLE_SABER_PLACEHOLDER' === 'true'
+      window.HARNESS_ENABLE_STATUS_EMBED = 'HARNESS_ENABLE_STATUS_EMBED_PLACEHOLDER' === 'true'
       window.HARNESS_PLG_FF_SDK_KEY = 'HARNESS_PLG_FF_SDK_KEY_PLACEHOLDER'
     </script>
 
@@ -188,6 +188,17 @@
     <script>
       window.resourceBasePath = window.HARNESS_ENABLE_CDN ? '//static.harness.io/ng-static/' : window.NON_CDN_BASE_PATH
     </script>
+
+    <!-- StatusPage Embed -->
+    <script>
+      if (window.HARNESS_ENABLE_STATUS_EMBED) {
+        var e = document.createElement('script')
+        e.setAttribute('type', 'text/javascript')
+        e.setAttribute('src', 'https://status.harness.io/embed/script.js')
+        document.getElementsByTagName('head')[0].appendChild(e)
+      }
+    </script>
+    <!-- End of StatusPage Embed -->
 
     <!-- saberToken -->
     <!-- Saber Feedback button -->


### PR DESCRIPTION
### Summary

Adds the StatusPage Embed widget to show maintenance windows and downtime alerts to users on Harness.
https://support.atlassian.com/statuspage/docs/what-is-status-embed/

#### Screenshots

NA

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
