### PR TITLE
fix: [CET-1281]: Remove extra condition in

### DIFF
--- a/src/modules/10-common/navigation/ProjectSetupMenu/ProjectSetupMenu.tsx
+++ b/src/modules/10-common/navigation/ProjectSetupMenu/ProjectSetupMenu.tsx
@@ -124,7 +124,7 @@ const ProjectSetupMenu: React.FC<ProjectSetupMenuProps> = ({ module, defaultExpa
         {module === 'cd' && !isCDGetStartedVisible && (
           <SidebarLink label={getString('getStarted')} to={routes.toGetStartedWithCD({ ...params, module })} />
         )}
-        {SRM_ET_EXPERIMENTAL && module === 'cv' && !showGetStartedTabInMainMenu && (
+        {SRM_ET_EXPERIMENTAL && module === 'cv' && (
           <SidebarLink
             label={getString('common.codeErrorsSettings')}
             to={routes.toCVCodeErrorsSettings({ ...params })}


### PR DESCRIPTION
project menu

### Summary

Code Error Settings was not appearing in CV. I found an extra condition that wasn't relevant.

#### Screenshots
Before: 
<img width="273" alt="image" src="https://user-images.githubusercontent.com/112413753/236478158-906dcd0e-64e9-4e84-86af-0bd775b1ba7c.png">

After: 
<img width="271" alt="image" src="https://user-images.githubusercontent.com/112413753/236478327-a9b18dee-2f93-4688-858c-e9c139b56baa.png">

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
