### PR TITLE
fix: [PL-32628]: missing permissions on default settings

### DIFF
--- a/src/modules/20-rbac/utils/useRBACError/useRBACError.tsx
+++ b/src/modules/20-rbac/utils/useRBACError/useRBACError.tsx
@@ -79,6 +79,7 @@ const useRBACError = (): RbacErrorReturn => {
         (err as AccessControlCheckError)?.failedPermissionChecks
       ) {
         if (allowMultiple) {
+          debugger
           return (
             <Layout.Vertical>
               <Text font={{ size: 'small', weight: 'semi-bold' }} color={Color.GREY_800}>
@@ -129,6 +130,7 @@ const useRBACError = (): RbacErrorReturn => {
             </Layout.Vertical>
           )
         } else {
+          debugger
           const { permission, resourceType, resourceScope, resourceIdentifier } =
             (err as AccessControlCheckError)?.failedPermissionChecks?.[0] || {}
           const resourceIdentifierLabel = resourceIdentifier ? ` on ${resourceIdentifier} ` : ''

--- a/src/modules/20-rbac/utils/useRBACError/useRBACError.tsx
+++ b/src/modules/20-rbac/utils/useRBACError/useRBACError.tsx
@@ -79,7 +79,6 @@ const useRBACError = (): RbacErrorReturn => {
         (err as AccessControlCheckError)?.failedPermissionChecks
       ) {
         if (allowMultiple) {
-          debugger
           return (
             <Layout.Vertical>
               <Text font={{ size: 'small', weight: 'semi-bold' }} color={Color.GREY_800}>
@@ -130,7 +129,6 @@ const useRBACError = (): RbacErrorReturn => {
             </Layout.Vertical>
           )
         } else {
-          debugger
           const { permission, resourceType, resourceScope, resourceIdentifier } =
             (err as AccessControlCheckError)?.failedPermissionChecks?.[0] || {}
           const resourceIdentifierLabel = resourceIdentifier ? ` on ${resourceIdentifier} ` : ''

--- a/src/modules/30-secrets/pages/secretDetailsHomePage/SecretDetailsHomePage.tsx
+++ b/src/modules/30-secrets/pages/secretDetailsHomePage/SecretDetailsHomePage.tsx
@@ -5,9 +5,9 @@
  * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
  */
 
-import React, { useState, useEffect } from 'react'
+import React, { useState } from 'react'
 import { useHistory, useParams, useRouteMatch } from 'react-router-dom'
-import { Container, Layout, Text, Icon, Tabs, useToaster } from '@harness/uicore'
+import { Container, Layout, Text, Icon, Tabs } from '@harness/uicore'
 import { Color } from '@harness/design-system'
 import { useStrings } from 'framework/strings'
 import { Page } from '@common/exports'
@@ -19,7 +19,6 @@ import { useAppStore } from 'framework/AppStore/AppStoreContext'
 import type { UseGetMockData } from '@common/utils/testUtils'
 import { getScopeFromDTO } from '@common/components/EntityReference/EntityReference'
 import { Scope } from '@common/interfaces/SecretsInterface'
-import useRBACError from '@rbac/utils/useRBACError/useRBACError'
 import { SettingType } from '@common/constants/Utils'
 import { useFeatureFlags } from '@common/hooks/useFeatureFlag'
 import SecretDetails from '../secretDetails/SecretDetails'
@@ -62,22 +61,13 @@ const SecretDetaislHomePage: React.FC<SecretDetailsProps> = props => {
   )?.isExact
 
   const [isReference, setIsReference] = useState(Boolean(isReferenceTab))
-  const { showError } = useToaster()
   const { selectedProject } = useAppStore()
-  const { getRBACErrorMessage } = useRBACError()
   const { PL_FORCE_DELETE_CONNECTOR_SECRET, NG_SETTINGS } = useFeatureFlags()
-  const { data: forceDeleteSettings, error: forceDeleteSettingsError } = useGetSettingValue({
+  const { data: forceDeleteSettings } = useGetSettingValue({
     identifier: SettingType.ENABLE_FORCE_DELETE,
     queryParams: { accountIdentifier: accountId },
     lazy: !NG_SETTINGS
   })
-
-  useEffect(() => {
-    if (forceDeleteSettingsError) {
-      showError(getRBACErrorMessage(forceDeleteSettingsError))
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [forceDeleteSettingsError])
 
   const history = useHistory()
   const { loading, data, error, refetch } = useGetSecretV2({

--- a/src/modules/30-secrets/pages/secrets/views/SecretsListView/SecretsList.tsx
+++ b/src/modules/30-secrets/pages/secrets/views/SecretsListView/SecretsList.tsx
@@ -5,7 +5,7 @@
  * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
  */
 
-import React, { useMemo, useState, useEffect } from 'react'
+import React, { useMemo, useState } from 'react'
 import { useParams, useHistory, useLocation, useRouteMatch } from 'react-router-dom'
 import ReactTimeago from 'react-timeago'
 import { Menu, Position, Classes, Intent } from '@blueprintjs/core'
@@ -322,25 +322,16 @@ export const RenderColumnAction: Renderer<CellProps<SecretResponseWrapper>> = ({
 }
 const SecretsList: React.FC<SecretsListProps> = ({ secrets, refetch }) => {
   const history = useHistory()
-  const { showError } = useToaster()
   const { accountId } = useParams<ProjectPathProps>()
   const data: SecretResponseWrapper[] = useMemo(() => secrets?.content || [], [secrets?.content])
   const { pathname } = useLocation()
   const { getString } = useStrings()
-  const { getRBACErrorMessage } = useRBACError()
   const { PL_FORCE_DELETE_CONNECTOR_SECRET, NG_SETTINGS, PL_NEW_PAGE_SIZE } = useFeatureFlags()
-  const { data: forceDeleteSettings, error: forceDeleteSettingsError } = useGetSettingValue({
+  const { data: forceDeleteSettings } = useGetSettingValue({
     identifier: SettingType.ENABLE_FORCE_DELETE,
     queryParams: { accountIdentifier: accountId },
     lazy: !NG_SETTINGS
   })
-
-  useEffect(() => {
-    if (forceDeleteSettingsError) {
-      showError(getRBACErrorMessage(forceDeleteSettingsError))
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [forceDeleteSettingsError])
 
   const columns: CustomColumn[] = useMemo(
     () => [

--- a/src/modules/35-connectors/pages/connectors/ConnectorDetailsPage/ConnectorDetailsPage.tsx
+++ b/src/modules/35-connectors/pages/connectors/ConnectorDetailsPage/ConnectorDetailsPage.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useEffect, useMemo } from 'react'
-import { Layout, Container, Icon, Text, SelectOption, PageSpinner, PageError, useToaster } from '@harness/uicore'
+import { Layout, Container, Icon, Text, SelectOption, PageSpinner, PageError } from '@harness/uicore'
 import { useParams, useHistory } from 'react-router-dom'
 import { Color } from '@harness/design-system'
 import { Page } from '@common/exports'
@@ -31,7 +31,6 @@ import ScopedTitle from '@common/components/Title/ScopedTitle'
 import useCreateConnectorModal from '@connectors/modals/ConnectorModal/useCreateConnectorModal'
 import { useFeatureFlags } from '@common/hooks/useFeatureFlag'
 import { SettingType } from '@common/constants/Utils'
-import useRBACError from '@rbac/utils/useRBACError/useRBACError'
 import { getIconByType } from '../utils/ConnectorUtils'
 import ConnectorPageGitDetails from './ConnectorDetailsPageGitDetails/ConnectorPageGitDetails'
 import RenderConnectorDetailsActiveTab from '../views/RenderConnectorDetailsActiveTab/RenderConnectorDetailsActiveTab'
@@ -258,21 +257,12 @@ const ConnectorDetailsPage: React.FC<ConnectorDetailsPageProps> = props => {
     history.push(routes.toConnectors({ accountId, projectIdentifier, orgIdentifier, module }))
   }
   const { PL_FORCE_DELETE_CONNECTOR_SECRET, NG_SETTINGS } = useFeatureFlags()
-  const { data: forceDeleteSettings, error: forceDeleteSettingsError } = useGetSettingValue({
+  const { data: forceDeleteSettings } = useGetSettingValue({
     identifier: SettingType.ENABLE_FORCE_DELETE,
     queryParams: { accountIdentifier: accountId },
     lazy: !NG_SETTINGS
   })
 
-  const { getRBACErrorMessage } = useRBACError()
-
-  const { showError } = useToaster()
-  useEffect(() => {
-    if (forceDeleteSettingsError) {
-      showError(getRBACErrorMessage(forceDeleteSettingsError))
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [forceDeleteSettingsError])
   return (
     <>
       <Page.Header

--- a/src/modules/35-connectors/pages/connectors/ConnectorsPage.tsx
+++ b/src/modules/35-connectors/pages/connectors/ConnectorsPage.tsx
@@ -133,18 +133,12 @@ const ConnectorsPage: React.FC<ConnectorsListProps> = ({ catalogueMockData, stat
   useDocumentTitle(getString('connectorsLabel'))
   const { trackEvent } = useTelemetry()
   const { PL_FORCE_DELETE_CONNECTOR_SECRET, NG_SETTINGS } = useFeatureFlags()
-  const { data: forceDeleteSettings, error: forceDeleteSettingsError } = useGetSettingValue({
+  const { data: forceDeleteSettings } = useGetSettingValue({
     identifier: SettingType.ENABLE_FORCE_DELETE,
     queryParams: { accountIdentifier: accountId },
     lazy: !NG_SETTINGS
   })
 
-  useEffect(() => {
-    if (forceDeleteSettingsError) {
-      showError(getRBACErrorMessage(forceDeleteSettingsError))
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [forceDeleteSettingsError])
 
   /* #region Connector CRUD section */
 

--- a/src/modules/70-pipeline/components/InputSetErrorHandling/OutOfSyncErrorStrip/OutOfSyncErrorStrip.tsx
+++ b/src/modules/70-pipeline/components/InputSetErrorHandling/OutOfSyncErrorStrip/OutOfSyncErrorStrip.tsx
@@ -147,17 +147,11 @@ export function OutOfSyncErrorStrip(props: OutOfSyncErrorStripProps): React.Reac
   })
 
   const isSettingEnabled = useFeatureFlag(FeatureFlag.NG_SETTINGS)
-  const { data: allowDifferentRepoSettings, error: allowDifferentRepoSettingsError } = useGetSettingValue({
+  const { data: allowDifferentRepoSettings } = useGetSettingValue({
     identifier: SettingType.ALLOW_DIFFERENT_REPO_FOR_INPUT_SETS,
     queryParams: { accountIdentifier: accountId },
     lazy: !isSettingEnabled
   })
-
-  React.useEffect(() => {
-    if (allowDifferentRepoSettingsError) {
-      showError(getRBACErrorMessage(allowDifferentRepoSettingsError))
-    }
-  }, [allowDifferentRepoSettingsError, getRBACErrorMessage, showError])
 
   const reconcileBranch = isGitSyncEnabled
     ? overlayInputSetBranch ?? inputSetBranch

--- a/src/modules/70-pipeline/components/InputSetForm/FormikInputSetForm.tsx
+++ b/src/modules/70-pipeline/components/InputSetForm/FormikInputSetForm.tsx
@@ -28,8 +28,6 @@ import type {
   ResponseInputSetTemplateWithReplacedExpressionsResponse
 } from 'services/pipeline-ng'
 import { useGetSettingValue } from 'services/cd-ng'
-import { useToaster } from '@common/exports'
-import useRBACError from '@rbac/utils/useRBACError/useRBACError'
 import type { YamlBuilderHandlerBinding, YamlBuilderProps } from '@common/interfaces/YAMLBuilderProps'
 import type { InputSetGitQueryParams, InputSetPathProps, PipelineType } from '@common/interfaces/RouteInterfaces'
 import { NameIdDescriptionTags } from '@common/components'
@@ -253,8 +251,6 @@ export default function FormikInputSetForm(props: FormikInputSetFormProps): Reac
   const { projectIdentifier, orgIdentifier, accountId, pipelineIdentifier } = useParams<
     PipelineType<InputSetPathProps> & { accountId: string }
   >()
-  const { showError } = useToaster()
-  const { getRBACErrorMessage } = useRBACError()
   const queryParams = useQueryParams<InputSetGitQueryParams>()
   const repoIdentifier = queryParams.repoIdentifier
   const { branch, connectorRef, storeType, repoName } = getInputSetGitDetails(queryParams, {
@@ -276,17 +272,11 @@ export default function FormikInputSetForm(props: FormikInputSetFormProps): Reac
   }, [inputSet?.outdated])
 
   const isSettingEnabled = useFeatureFlag(FeatureFlag.NG_SETTINGS)
-  const { data: allowDifferentRepoSettings, error: allowDifferentRepoSettingsError } = useGetSettingValue({
+  const { data: allowDifferentRepoSettings } = useGetSettingValue({
     identifier: SettingType.ALLOW_DIFFERENT_REPO_FOR_INPUT_SETS,
     queryParams: { accountIdentifier: accountId },
     lazy: !isSettingEnabled
   })
-
-  React.useEffect(() => {
-    if (allowDifferentRepoSettingsError) {
-      showError(getRBACErrorMessage(allowDifferentRepoSettingsError))
-    }
-  }, [allowDifferentRepoSettingsError, getRBACErrorMessage, showError])
 
   useEffect(() => {
     // only do this for CI

--- a/src/modules/70-pipeline/components/OverlayInputSetForm/OverlayInputSetForm.tsx
+++ b/src/modules/70-pipeline/components/OverlayInputSetForm/OverlayInputSetForm.tsx
@@ -240,17 +240,11 @@ export function OverlayInputSetForm({
   })
 
   const isSettingEnabled = useFeatureFlag(FeatureFlag.NG_SETTINGS)
-  const { data: allowDifferentRepoSettings, error: allowDifferentRepoSettingsError } = useGetSettingValue({
+  const { data: allowDifferentRepoSettings } = useGetSettingValue({
     identifier: SettingType.ALLOW_DIFFERENT_REPO_FOR_INPUT_SETS,
     queryParams: { accountIdentifier: accountId },
     lazy: !isSettingEnabled
   })
-
-  React.useEffect(() => {
-    if (allowDifferentRepoSettingsError) {
-      showError(getRBACErrorMessage(allowDifferentRepoSettingsError))
-    }
-  }, [allowDifferentRepoSettingsError, getRBACErrorMessage, showError])
 
   const { mutate: createOverlayInputSet, loading: createOverlayInputSetLoading } = useCreateOverlayInputSetForPipeline({
     queryParams: { ...commonQueryParams, branch },

--- a/src/modules/70-pipeline/components/PipelineStudio/PipelineCanvas/PipelineCanvas.tsx
+++ b/src/modules/70-pipeline/components/PipelineStudio/PipelineCanvas/PipelineCanvas.tsx
@@ -267,11 +267,7 @@ export function PipelineCanvas({
 
   useSaveTemplateListener()
 
-  const {
-    data: enforceGitXSetting,
-    error: enforceGitXSettingError,
-    loading: loadingSetting
-  } = useGetSettingValue({
+  const { data: enforceGitXSetting, loading: loadingSetting } = useGetSettingValue({
     identifier: SettingType.ENFORCE_GIT_EXPERIENCE,
     queryParams: {
       accountIdentifier: accountId,
@@ -288,14 +284,6 @@ export function PipelineCanvas({
       return defaultTo(storeType, StoreType.INLINE) //Handle rest all use cases
     }
   }
-
-  React.useEffect(() => {
-    if (!loadingSetting) {
-      if (enforceGitXSettingError) {
-        showError(enforceGitXSettingError.message)
-      }
-    }
-  }, [enforceGitXSettingError, showError, loadingSetting])
 
   const dialogWidth = React.useMemo<number | undefined>(() => {
     if (supportingGitSimplification) {

--- a/src/modules/70-pipeline/v1/components/InputSetFormV1/FormikInputSetFormV1.tsx
+++ b/src/modules/70-pipeline/v1/components/InputSetFormV1/FormikInputSetFormV1.tsx
@@ -15,9 +15,7 @@ import type { FormikProps } from 'formik'
 import type { InputsResponseBody } from '@harnessio/react-pipeline-service-client'
 import type { EntityGitDetails } from 'services/pipeline-ng'
 import { useGetSettingValue } from 'services/cd-ng'
-import { useToaster } from '@common/exports'
 import { SettingType } from '@common/constants/Utils'
-import useRBACError from '@rbac/utils/useRBACError/useRBACError'
 import type {
   AccountPathProps,
   InputSetGitQueryParams,
@@ -98,8 +96,6 @@ export default function FormikInputSetFormV1(props: FormikInputSetFormV1Props): 
   const { projectIdentifier, orgIdentifier, accountId, pipelineIdentifier } = useParams<
     PipelineType<InputSetPathProps> & AccountPathProps
   >()
-  const { showError } = useToaster()
-  const { getRBACErrorMessage } = useRBACError()
   const queryParams = useQueryParams<InputSetGitQueryParams>()
   const repoIdentifier = queryParams.repoIdentifier
   const { branch, connectorRef, storeType, repoName } = getInputSetGitDetails(queryParams, {
@@ -111,17 +107,11 @@ export default function FormikInputSetFormV1(props: FormikInputSetFormV1Props): 
   const history = useHistory()
 
   const isSettingEnabled = useFeatureFlag(FeatureFlag.NG_SETTINGS)
-  const { data: allowDifferentRepoSettings, error: allowDifferentRepoSettingsError } = useGetSettingValue({
+  const { data: allowDifferentRepoSettings } = useGetSettingValue({
     identifier: SettingType.ALLOW_DIFFERENT_REPO_FOR_INPUT_SETS,
     queryParams: { accountIdentifier: accountId },
     lazy: !isSettingEnabled
   })
-
-  React.useEffect(() => {
-    if (allowDifferentRepoSettingsError) {
-      showError(getRBACErrorMessage(allowDifferentRepoSettingsError))
-    }
-  }, [allowDifferentRepoSettingsError, getRBACErrorMessage, showError])
 
   const [hasEditPermission] = usePermission(
     {

--- a/src/modules/72-templates-library/components/DeleteTemplateModal/DeleteTemplateModal.tsx
+++ b/src/modules/72-templates-library/components/DeleteTemplateModal/DeleteTemplateModal.tsx
@@ -81,20 +81,13 @@ export const DeleteTemplateModal = (props: DeleteTemplateProps) => {
   const [templateVersionsToDelete, setTemplateVersionsToDelete] = React.useState<string[]>([])
 
   const isSettingsEnabled = useFeatureFlag(FeatureFlag.NG_SETTINGS)
-  const { data: forceDeleteSettings, error: forceDeleteSettingsError } = useGetSettingValue({
+  const { data: forceDeleteSettings } = useGetSettingValue({
     identifier: SettingType.ENABLE_FORCE_DELETE,
     queryParams: {
       accountIdentifier: accountId
     },
     lazy: !isSettingsEnabled
   })
-
-  React.useEffect(() => {
-    if (forceDeleteSettingsError) {
-      showError(getRBACErrorMessage(forceDeleteSettingsError))
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [forceDeleteSettingsError])
 
   const {
     data: templateData,

--- a/src/modules/72-triggers/components/Triggers/WebhookTrigger/useIsGithubWebhookAuthenticationEnabled.tsx
+++ b/src/modules/72-triggers/components/Triggers/WebhookTrigger/useIsGithubWebhookAuthenticationEnabled.tsx
@@ -5,28 +5,21 @@
  * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
  */
 
-import { useMemo, useEffect } from 'react'
+import { useMemo } from 'react'
 import { useParams } from 'react-router-dom'
-import { useToaster } from '@harness/uicore'
 import { useFeatureFlags } from '@common/hooks/useFeatureFlag'
 import { useGetSettingValue } from 'services/cd-ng'
 import type { ProjectPathProps } from '@common/interfaces/RouteInterfaces'
 import { SettingType } from '@common/constants/Utils'
-import { getErrorMessage } from '../utils'
 
 const useIsGithubWebhookAuthenticationEnabled = (): {
   isGithubWebhookAuthenticationEnabled: boolean
   isGithubWebhookAuthenticationDataLoading: boolean
 } => {
-  const { showError } = useToaster()
   const { NG_SETTINGS } = useFeatureFlags()
   const { accountId: accountIdentifier, orgIdentifier, projectIdentifier } = useParams<ProjectPathProps>()
 
-  const {
-    data: projectSettingData,
-    loading: isGithubWebhookAuthenticationDataLoading,
-    error: projectSettingDataError
-  } = useGetSettingValue({
+  const { data: projectSettingData, loading: isGithubWebhookAuthenticationDataLoading } = useGetSettingValue({
     identifier: SettingType.WEBHOOK_GITHUB_TRIGGERS_AUTHENTICATION,
     queryParams: {
       accountIdentifier,
@@ -35,14 +28,6 @@ const useIsGithubWebhookAuthenticationEnabled = (): {
     },
     lazy: !NG_SETTINGS
   })
-
-  useEffect(() => {
-    if (projectSettingDataError) {
-      showError(getErrorMessage(projectSettingDataError))
-    }
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [projectSettingDataError])
 
   const isGithubWebhookAuthenticationEnabled = useMemo(
     () => projectSettingData?.data?.value === 'true',

--- a/src/modules/75-cd/components/EnvironmentGroups/EnvironmentGroups.tsx
+++ b/src/modules/75-cd/components/EnvironmentGroups/EnvironmentGroups.tsx
@@ -24,8 +24,7 @@ import {
   Text,
   DropDown,
   Pagination,
-  ExpandingSearchInputHandle,
-  useToaster
+  ExpandingSearchInputHandle
 } from '@harness/uicore'
 import { Color, FontVariation } from '@harness/design-system'
 import { useModalHook } from '@harness/use-modal'
@@ -66,28 +65,16 @@ import css from './EnvironmentGroups.module.scss'
 export default function EnvironmentGroupsPage(): React.ReactElement {
   const { accountId, orgIdentifier, projectIdentifier, module } = useParams<ProjectPathProps & ModulePathParams>()
   const { getString } = useStrings()
-  const { showError } = useToaster()
   const { getRBACErrorMessage } = useRBACError()
 
   const isSettingsEnabled = useFeatureFlag(FeatureFlag.NG_SETTINGS)
-  const {
-    data: forceDeleteSettings,
-    loading: forceDeleteSettingsLoading,
-    error: forceDeleteSettingsError
-  } = useGetSettingValue({
+  const { data: forceDeleteSettings, loading: forceDeleteSettingsLoading } = useGetSettingValue({
     identifier: SettingType.ENABLE_FORCE_DELETE,
     queryParams: {
       accountIdentifier: accountId
     },
     lazy: !isSettingsEnabled
   })
-
-  React.useEffect(() => {
-    if (forceDeleteSettingsError) {
-      showError(getRBACErrorMessage(forceDeleteSettingsError))
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [forceDeleteSettingsError])
 
   /* #region Sort changes */
   const sortOptions: SelectOption[] = [

--- a/src/modules/75-cd/components/Environments/Environments.tsx
+++ b/src/modules/75-cd/components/Environments/Environments.tsx
@@ -10,16 +10,12 @@ import { useParams } from 'react-router-dom'
 import { noop } from 'lodash-es'
 
 import { HelpPanel, HelpPanelType } from '@harness/help-panel'
-import { useToaster } from '@harness/uicore'
-
 import { useGetSettingValue } from 'services/cd-ng'
 
 import { FeatureFlag } from '@common/featureFlags'
 import { useFeatureFlag } from '@common/hooks/useFeatureFlag'
 import { SettingType } from '@common/constants/Utils'
 import type { AccountPathProps } from '@common/interfaces/RouteInterfaces'
-
-import useRBACError from '@rbac/utils/useRBACError/useRBACError'
 
 import { Views, EnvironmentStoreContext } from './common'
 import { EnvironmentList } from './EnvironmentList/EnvironmentsList'
@@ -29,24 +25,14 @@ export const Environments: React.FC = () => {
   const fetchDeploymentList = useRef<() => void>(noop)
   const { accountId } = useParams<AccountPathProps>()
 
-  const { getRBACErrorMessage } = useRBACError()
-  const { showError } = useToaster()
-
   const isSettingsEnabled = useFeatureFlag(FeatureFlag.NG_SETTINGS)
-  const { data: forceDeleteSettings, error: forceDeleteSettingsError } = useGetSettingValue({
+  const { data: forceDeleteSettings } = useGetSettingValue({
     identifier: SettingType.ENABLE_FORCE_DELETE,
     queryParams: {
       accountIdentifier: accountId
     },
     lazy: !isSettingsEnabled
   })
-
-  React.useEffect(() => {
-    if (forceDeleteSettingsError) {
-      showError(getRBACErrorMessage(forceDeleteSettingsError))
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [forceDeleteSettingsError])
 
   return (
     <EnvironmentStoreContext.Provider

--- a/src/modules/75-cd/components/EnvironmentsV2/EnvironmentDetails/InfrastructureDefinition/InfrastructureList/InfrastructureList.tsx
+++ b/src/modules/75-cd/components/EnvironmentsV2/EnvironmentDetails/InfrastructureDefinition/InfrastructureList/InfrastructureList.tsx
@@ -53,20 +53,13 @@ export default function InfrastructureList({
   const { updateQueryParams } = useUpdateQueryParams<EnvironmentQueryParams>()
   const [infraDetailsToBeDeleted, setInfraDetailsToBeDeleted] = React.useState<InfraDetails>()
 
-  const { data: forceDeleteSettings, error: forceDeleteSettingsError } = useGetSettingValue({
+  const { data: forceDeleteSettings } = useGetSettingValue({
     identifier: SettingType.ENABLE_FORCE_DELETE,
     queryParams: {
       accountIdentifier: accountId
     },
     lazy: !isSettingsEnabled
   })
-
-  React.useEffect(() => {
-    if (forceDeleteSettingsError) {
-      showError(getRBACErrorMessage(forceDeleteSettingsError))
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [forceDeleteSettingsError])
 
   const redirectToReferencedBy = (): void => {
     closeReferenceErrorDialog()

--- a/src/modules/75-cd/components/EnvironmentsV2/PageTemplate/PageTemplate.tsx
+++ b/src/modules/75-cd/components/EnvironmentsV2/PageTemplate/PageTemplate.tsx
@@ -24,9 +24,7 @@ import {
   Pagination,
   SelectOption,
   Text,
-  DropDown,
-  useToaster
-} from '@harness/uicore'
+  DropDown} from '@harness/uicore'
 import { Color, FontVariation } from '@harness/design-system'
 
 import { useStrings } from 'framework/strings'
@@ -43,7 +41,6 @@ import { FeatureFlag } from '@common/featureFlags'
 import { SettingType } from '@common/constants/Utils'
 
 import RbacButton, { ButtonProps } from '@rbac/components/Button/Button'
-import useRBACError from '@rbac/utils/useRBACError/useRBACError'
 
 import { FilterContextProvider } from '@cd/context/FiltersContext'
 
@@ -106,8 +103,6 @@ export default function PageTemplate({
 
   const { view, setView } = usePageStore()
   const { getString } = useStrings()
-  const { getRBACErrorMessage } = useRBACError()
-  const { showError } = useToaster()
 
   const [sort, setSort] = useState<string[]>(defaultSortOption)
   const [sortOption, setSortOption] = useState<SelectOption>(sortOptions[0])
@@ -122,24 +117,13 @@ export default function PageTemplate({
   const hasFilterIdentifier = getHasFilterIdentifier(filterIdentifier)
 
   const isSettingsEnabled = useFeatureFlag(FeatureFlag.NG_SETTINGS)
-  const {
-    data: forceDeleteSettings,
-    loading: forceDeleteSettingsLoading,
-    error: forceDeleteSettingsError
-  } = useGetSettingValue({
+  const { data: forceDeleteSettings, loading: forceDeleteSettingsLoading } = useGetSettingValue({
     identifier: SettingType.ENABLE_FORCE_DELETE,
     queryParams: {
       accountIdentifier: accountId
     },
     lazy: !(isForceDeleteAllowed && isSettingsEnabled)
   })
-
-  React.useEffect(() => {
-    if (forceDeleteSettingsError) {
-      showError(getRBACErrorMessage(forceDeleteSettingsError))
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [forceDeleteSettingsError])
 
   const isForceDeleteEnabled = useMemo(
     () => forceDeleteSettings?.data?.value == 'true',

--- a/src/modules/75-cd/components/Services/ServicesList/ServicesList.tsx
+++ b/src/modules/75-cd/components/Services/ServicesList/ServicesList.tsx
@@ -559,26 +559,17 @@ function ServiceListHeaderCustomPrimary(headerProps: { total?: number }): JSX.El
 export const ServicesList: React.FC<ServicesListProps> = props => {
   const { loading, data, error, refetch, setSavedSortOption, setSort, sort } = props
   const { getString } = useStrings()
-  const { getRBACErrorMessage } = useRBACError()
-  const { showError } = useToaster()
   const { accountId, orgIdentifier, projectIdentifier, module } = useParams<ProjectPathProps & ModulePathParams>()
   const isSettingsEnabled = useFeatureFlag(FeatureFlag.NG_SETTINGS)
   const history = useHistory()
 
-  const { data: forceDeleteSettings, error: forceDeleteSettingsError } = useGetSettingValue({
+  const { data: forceDeleteSettings } = useGetSettingValue({
     identifier: SettingType.ENABLE_FORCE_DELETE,
     queryParams: {
       accountIdentifier: accountId
     },
     lazy: !isSettingsEnabled
   })
-
-  React.useEffect(() => {
-    if (forceDeleteSettingsError) {
-      showError(getRBACErrorMessage(forceDeleteSettingsError))
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [forceDeleteSettingsError])
 
   const columns: TableProps<ServiceListItem>['columns'] = useMemo(
     () => {

--- a/src/modules/75-cd/components/Services/ServicesListPage/ServicesListPage.tsx
+++ b/src/modules/75-cd/components/Services/ServicesListPage/ServicesListPage.tsx
@@ -64,7 +64,6 @@ export const ServicesListPage = ({ setShowBanner }: ServicesListPageProps): Reac
 
   const { getString } = useStrings()
   const { showError } = useToaster()
-  const { getRBACErrorMessage } = useRBACError()
   const { fetchDeploymentList } = useServiceStore()
   const history = useHistory()
   const isFreeOrCommunityCD = useGetFreeOrCommunityCD()
@@ -98,20 +97,13 @@ export const ServicesListPage = ({ setShowBanner }: ServicesListPageProps): Reac
     }
   }, [isEdit])
 
-  const { data: forceDeleteSettings, error: forceDeleteSettingsError } = useGetSettingValue({
+  const { data: forceDeleteSettings } = useGetSettingValue({
     identifier: SettingType.ENABLE_FORCE_DELETE,
     queryParams: {
       accountIdentifier: accountId
     },
     lazy: !isSettingsEnabled
   })
-
-  useEffect(() => {
-    if (forceDeleteSettingsError) {
-      showError(getRBACErrorMessage(forceDeleteSettingsError))
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [forceDeleteSettingsError])
 
   const goToServiceDetails = useCallback(
     (selectedService: ServiceResponseDTO): void => {


### PR DESCRIPTION
### Summary

Since all the settings in this PR which are read from api useGetSettingValue  to be  true or false, we don't need to show the error message of settings not accessible, instead code will assume it to be false and there should not be any issue, so removed  code to show rbac error message

<!-- ✍️ A clear and concise description...-->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
