### PR TITLE
fix: [CHAOS-1156]: replaced start free plan in favour of sending the user to explore plans page. logic is shifted to MFE

### DIFF
--- a/src/modules/70-pipeline/pages/execution/ResilienceView/__tests__/ResilienceView.test.tsx
+++ b/src/modules/70-pipeline/pages/execution/ResilienceView/__tests__/ResilienceView.test.tsx
@@ -20,11 +20,7 @@ import { mockEmptyPipelineContext, mockPipelineContextWithChaosStep } from './mo
 // eslint-disable-next-line react/display-name
 jest.mock('microfrontends/ChildAppMounter', () => (props: ResilienceViewContentProps | ResilienceViewCTAProps) => {
   const resCTAProps = props as ResilienceViewCTAProps
-  if (resCTAProps.isSubscriptionAvailable) {
-    resCTAProps.addResilienceStep && resCTAProps.addResilienceStep()
-  } else {
-    resCTAProps.startFreePlan && resCTAProps.startFreePlan()
-  }
+  resCTAProps.addResilienceStep && resCTAProps.addResilienceStep()
 
   const resProps = props as ResilienceViewContentProps
   resProps.onStageSelectionChange && resProps.onStageSelectionChange('stageID2')
@@ -129,37 +125,12 @@ describe('<MemoizedResilienceViewContent /> tests', () => {
 })
 
 describe('<MemoizedResilienceViewCTA /> tests', () => {
-  test('Should render MemoizedResilienceViewCTA when chaos license is not present', () => {
-    const mockStartFreePlan = jest.fn()
-    const mockAddResilienceStep = jest.fn()
-    const mockIsSubscriptionAvailable = false
-
-    const { container } = render(
-      <TestWrapper>
-        <MemoizedResilienceViewCTA
-          isSubscriptionAvailable={mockIsSubscriptionAvailable}
-          startFreePlan={mockStartFreePlan}
-          addResilienceStep={mockAddResilienceStep}
-        />
-      </TestWrapper>
-    )
-
-    expect(container).toMatchSnapshot()
-    expect(mockStartFreePlan).toHaveBeenCalledTimes(1)
-  })
-
   test('Should render MemoizedResilienceViewCTA when chaos step is not present', () => {
-    const mockStartFreePlan = jest.fn()
     const mockAddResilienceStep = jest.fn()
-    const mockIsSubscriptionAvailable = true
 
     const { container } = render(
       <TestWrapper>
-        <MemoizedResilienceViewCTA
-          isSubscriptionAvailable={mockIsSubscriptionAvailable}
-          startFreePlan={mockStartFreePlan}
-          addResilienceStep={mockAddResilienceStep}
-        />
+        <MemoizedResilienceViewCTA addResilienceStep={mockAddResilienceStep} />
       </TestWrapper>
     )
 

--- a/src/modules/70-pipeline/pages/execution/ResilienceView/__tests__/__snapshots__/ResilienceView.test.tsx.snap
+++ b/src/modules/70-pipeline/pages/execution/ResilienceView/__tests__/__snapshots__/ResilienceView.test.tsx.snap
@@ -1,15 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<MemoizedResilienceViewCTA /> tests Should render MemoizedResilienceViewCTA when chaos license is not present 1`] = `
-<div>
-  <div
-    data-testid="error-tracking-child-mounter"
-  >
-    mounted
-  </div>
-</div>
-`;
-
 exports[`<MemoizedResilienceViewCTA /> tests Should render MemoizedResilienceViewCTA when chaos step is not present 1`] = `
 <div>
   <div
@@ -42,20 +32,30 @@ exports[`<MemoizedResilienceViewContent /> tests Should re-render MemoizedResili
 
 exports[`<ResilienceView /> tests Should not crash when chaos notifyIDs are not yet created/empty 1`] = `
 <div>
-  <div
-    data-testid="error-tracking-child-mounter"
-  >
-    mounted
+  <div>
+    <h1>
+      Not Found
+    </h1>
+    <div
+      data-testid="location"
+    >
+      /account/undefined/home/orgs/undefined/projects/undefined/pipelines/undefined/pipeline-studio/?storeType=INLINE&stageId=&sectionId=EXECUTION
+    </div>
   </div>
 </div>
 `;
 
 exports[`<ResilienceView /> tests Should render ResilienceView when pipeline has chaos step 1`] = `
 <div>
-  <div
-    data-testid="error-tracking-child-mounter"
-  >
-    mounted
+  <div>
+    <h1>
+      Not Found
+    </h1>
+    <div
+      data-testid="location"
+    >
+      /account/undefined/chaos/orgs/undefined/projects/undefined/experiments/expID/runs/expRunID?fault=faultName
+    </div>
   </div>
 </div>
 `;


### PR DESCRIPTION
### Summary

<!-- ✍️ A clear and concise description...-->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
