### PR TITLE
fix: [CDS-68201]: revert UX enhancements for re-run/re-try pipeline

### DIFF
--- a/src/modules/10-common/constants/TrackingConstants.ts
+++ b/src/modules/10-common/constants/TrackingConstants.ts
@@ -392,8 +392,3 @@ export enum PLG_ELEMENTS {
   RIGHT_COLUMN = 'Right column list',
   MODULE_CARD = 'Module card'
 }
-
-export enum PipelineExecutionActions {
-  ReRunPipeline = 'Re-run Pipeline',
-  RetryPipeline = 'Retry Pipeline'
-}

--- a/src/modules/70-pipeline/components/ExecutionActions/ExecutionActions.tsx
+++ b/src/modules/70-pipeline/components/ExecutionActions/ExecutionActions.tsx
@@ -16,7 +16,8 @@ import {
   ButtonSize,
   ButtonVariation
 } from '@harness/uicore'
-import { Classes, Intent, Menu, MenuItem, Position } from '@blueprintjs/core'
+import { useModalHook } from '@harness/use-modal'
+import { Classes, Dialog, IDialogProps, Intent, Menu, MenuItem, Position } from '@blueprintjs/core'
 import { Link } from 'react-router-dom'
 import { defaultTo } from 'lodash-es'
 
@@ -38,12 +39,13 @@ import { useRunPipelineModalV1 } from '@pipeline/v1/components/RunPipelineModalV
 import type { StringKeys } from 'framework/strings'
 import { useAppStore } from 'framework/AppStore/AppStoreContext'
 import type { ExecutionPathProps, GitQueryParams, PipelineType } from '@common/interfaces/RouteInterfaces'
+import RbacButton from '@rbac/components/Button/Button'
 import { killEvent } from '@common/utils/eventUtils'
 import { useFeatureFlags } from '@common/hooks/useFeatureFlag'
 import { isSimplifiedYAMLEnabled } from '@common/utils/utils'
+import RetryPipeline from '../RetryPipeline/RetryPipeline'
 import { useRunPipelineModal } from '../RunPipelineModal/useRunPipelineModal'
 import { useExecutionCompareContext } from '../ExecutionCompareYaml/ExecutionCompareContext'
-import { useOpenRetryPipelineModal } from './useOpenRetryPipelineModal'
 import css from './ExecutionActions.module.scss'
 
 const commonButtonProps: ButtonProps = {
@@ -82,7 +84,7 @@ export interface ExecutionActionsProps {
   isExecutionListView?: boolean
 }
 
-export function getValidExecutionActions(canExecute: boolean, executionStatus?: ExecutionStatus) {
+function getValidExecutionActions(canExecute: boolean, executionStatus?: ExecutionStatus) {
   return {
     canAbort: isExecutionActive(executionStatus) && canExecute,
     canRollback: isExecutionActive(executionStatus) && canExecute,
@@ -283,11 +285,42 @@ const ExecutionActions: React.FC<ExecutionActionsProps> = props => {
   }
 
   /*--------------------------------------Retry Pipeline---------------------------------------------*/
-  const { openRetryPipelineModal } = useOpenRetryPipelineModal({ modules, params })
   const retryPipeline = (): void => {
-    openRetryPipelineModal()
+    showRetryPipelineModal()
   }
   const showRetryPipelineOption = isRetryPipelineAllowed(executionStatus) && canRetry
+
+  const DIALOG_PROPS: IDialogProps = {
+    isOpen: true,
+    usePortal: true,
+    autoFocus: true,
+    canEscapeKeyClose: false,
+    canOutsideClickClose: false,
+    enforceFocus: false,
+    className: css.runPipelineDialog,
+    style: { width: 872, height: 'fit-content', overflow: 'auto' }
+  }
+
+  const [showRetryPipelineModal, hideRetryPipelineModal] = useModalHook(() => {
+    const onClose = (): void => {
+      hideRetryPipelineModal()
+    }
+
+    return (
+      <Dialog onClose={onClose} {...DIALOG_PROPS}>
+        <div className={css.modalContent}>
+          <RetryPipeline
+            onClose={onClose}
+            executionIdentifier={executionIdentifier}
+            pipelineIdentifier={pipelineIdentifier}
+            modules={modules}
+            params={params}
+          />
+          <Button minimal icon="cross" onClick={onClose} className={css.crossIcon} />
+        </div>
+      </Dialog>
+    )
+  }, [pipelineIdentifier, executionIdentifier, params])
 
   /*--------------------------------------Retry Pipeline---------------------------------------------*/
 
@@ -328,6 +361,17 @@ const ExecutionActions: React.FC<ExecutionActionsProps> = props => {
               onClick={resumePipeline}
               {...commonButtonProps}
               disabled={!canExecute}
+            />
+          )}
+
+          {!stageId && canRerun && (
+            <RbacButton
+              icon="repeat"
+              tooltip={isPipelineInvalid ? getString('pipeline.cannotRunInvalidPipeline') : getString(rerunText)}
+              onClick={reRunPipeline}
+              {...commonButtonProps}
+              disabled={!canExecute || isPipelineInvalid}
+              featuresProps={getFeaturePropsForRunPipelineButton({ modules, getString })}
             />
           )}
 

--- a/src/modules/70-pipeline/components/ExecutionActions/ExecutionActions.tsx
+++ b/src/modules/70-pipeline/components/ExecutionActions/ExecutionActions.tsx
@@ -41,8 +41,6 @@ import type { ExecutionPathProps, GitQueryParams, PipelineType } from '@common/i
 import { killEvent } from '@common/utils/eventUtils'
 import { useFeatureFlags } from '@common/hooks/useFeatureFlag'
 import { isSimplifiedYAMLEnabled } from '@common/utils/utils'
-import { PipelineExecutionActions } from '@common/constants/TrackingConstants'
-import { useTelemetry } from '@common/hooks/useTelemetry'
 import { useRunPipelineModal } from '../RunPipelineModal/useRunPipelineModal'
 import { useExecutionCompareContext } from '../ExecutionCompareYaml/ExecutionCompareContext'
 import { useOpenRetryPipelineModal } from './useOpenRetryPipelineModal'
@@ -195,7 +193,6 @@ const ExecutionActions: React.FC<ExecutionActionsProps> = props => {
   const { isGitSyncEnabled: isGitSyncEnabledForProject, gitSyncEnabledOnlyForFF } = useAppStore()
   const isGitSyncEnabled = isGitSyncEnabledForProject && !gitSyncEnabledOnlyForFF
   const { isCompareMode } = useExecutionCompareContext()
-  const { trackEvent } = useTelemetry()
 
   const { openDialog: openAbortDialog } = useConfirmationDialog({
     cancelButtonText: getString('cancel'),
@@ -288,7 +285,6 @@ const ExecutionActions: React.FC<ExecutionActionsProps> = props => {
   /*--------------------------------------Retry Pipeline---------------------------------------------*/
   const { openRetryPipelineModal } = useOpenRetryPipelineModal({ modules, params })
   const retryPipeline = (): void => {
-    trackEvent(PipelineExecutionActions.RetryPipeline, { triggered_from: 'kebab-menu' })
     openRetryPipelineModal()
   }
   const showRetryPipelineOption = isRetryPipelineAllowed(executionStatus) && canRetry
@@ -297,7 +293,6 @@ const ExecutionActions: React.FC<ExecutionActionsProps> = props => {
 
   /*--------------------------------------Run Pipeline---------------------------------------------*/
   const reRunPipeline = (): void => {
-    trackEvent(PipelineExecutionActions.ReRunPipeline, { triggered_from: 'kebab-menu' })
     isSimplifiedYAMLEnabled(module, CI_YAML_VERSIONING) ? openRunPipelineModalV1() : openRunPipelineModal()
   }
 

--- a/src/modules/70-pipeline/components/ExecutionActions/__tests__/__snapshots__/ExecutionActions.test.tsx.snap
+++ b/src/modules/70-pipeline/components/ExecutionActions/__tests__/__snapshots__/ExecutionActions.test.tsx.snap
@@ -6,6 +6,40 @@ exports[`<ExecutionActions /> tests if feature restriction is applied on rerun b
     class="Layout--horizontal StyledProps--main"
   >
     <span
+      class="bp3-popover-wrapper"
+    >
+      <span
+        class="bp3-popover-target"
+      >
+        <button
+          aria-label="pipeline.execution.actions.rerunPipeline"
+          class="bp3-button Button--button StyledProps--font StyledProps--main Button--with-current-color Button--iconOnly Button--withLeftIcon Button--variation Button--variation-icon"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="bp3-icon bp3-icon-repeat StyledProps--main"
+            icon="repeat"
+          >
+            <svg
+              data-icon="repeat"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                repeat
+              </desc>
+              <path
+                d="M10 5c0 .55.45 1 1 1h4c.55 0 1-.45 1-1V1c0-.55-.45-1-1-1s-1 .45-1 1v1.74A7.95 7.95 0 008 0C3.58 0 0 3.58 0 8c0 4.06 3.02 7.4 6.94 7.92.02 0 .04.01.06.01.33.04.66.07 1 .07 4.42 0 8-3.58 8-8 0-.55-.45-1-1-1s-1 .45-1 1c0 3.31-2.69 6-6 6-.71 0-1.37-.15-2-.38v.01C3.67 12.81 2 10.61 2 8c0-3.31 2.69-6 6-6 1.77 0 3.36.78 4.46 2H11c-.55 0-1 .45-1 1z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </button>
+      </span>
+    </span>
+    <span
       class="bp3-popover-wrapper bp3-dark"
     >
       <span
@@ -136,6 +170,40 @@ exports[`<ExecutionActions /> tests snapshot tests "Aborted" status: container 1
   <div
     class="Layout--horizontal StyledProps--main"
   >
+    <span
+      class="bp3-popover-wrapper"
+    >
+      <span
+        class="bp3-popover-target"
+      >
+        <button
+          aria-label="pipeline.execution.actions.rerunPipeline"
+          class="bp3-button Button--button StyledProps--font StyledProps--main Button--with-current-color Button--iconOnly Button--withLeftIcon Button--variation Button--variation-icon"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="bp3-icon bp3-icon-repeat StyledProps--main"
+            icon="repeat"
+          >
+            <svg
+              data-icon="repeat"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                repeat
+              </desc>
+              <path
+                d="M10 5c0 .55.45 1 1 1h4c.55 0 1-.45 1-1V1c0-.55-.45-1-1-1s-1 .45-1 1v1.74A7.95 7.95 0 008 0C3.58 0 0 3.58 0 8c0 4.06 3.02 7.4 6.94 7.92.02 0 .04.01.06.01.33.04.66.07 1 .07 4.42 0 8-3.58 8-8 0-.55-.45-1-1-1s-1 .45-1 1c0 3.31-2.69 6-6 6-.71 0-1.37-.15-2-.38v.01C3.67 12.81 2 10.61 2 8c0-3.31 2.69-6 6-6 1.77 0 3.36.78 4.46 2H11c-.55 0-1 .45-1 1z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </button>
+      </span>
+    </span>
     <span
       class="bp3-popover-wrapper bp3-dark"
     >
@@ -268,6 +336,40 @@ exports[`<ExecutionActions /> tests snapshot tests "Expired" status: container 1
     class="Layout--horizontal StyledProps--main"
   >
     <span
+      class="bp3-popover-wrapper"
+    >
+      <span
+        class="bp3-popover-target"
+      >
+        <button
+          aria-label="pipeline.execution.actions.rerunPipeline"
+          class="bp3-button Button--button StyledProps--font StyledProps--main Button--with-current-color Button--iconOnly Button--withLeftIcon Button--variation Button--variation-icon"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="bp3-icon bp3-icon-repeat StyledProps--main"
+            icon="repeat"
+          >
+            <svg
+              data-icon="repeat"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                repeat
+              </desc>
+              <path
+                d="M10 5c0 .55.45 1 1 1h4c.55 0 1-.45 1-1V1c0-.55-.45-1-1-1s-1 .45-1 1v1.74A7.95 7.95 0 008 0C3.58 0 0 3.58 0 8c0 4.06 3.02 7.4 6.94 7.92.02 0 .04.01.06.01.33.04.66.07 1 .07 4.42 0 8-3.58 8-8 0-.55-.45-1-1-1s-1 .45-1 1c0 3.31-2.69 6-6 6-.71 0-1.37-.15-2-.38v.01C3.67 12.81 2 10.61 2 8c0-3.31 2.69-6 6-6 1.77 0 3.36.78 4.46 2H11c-.55 0-1 .45-1 1z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </button>
+      </span>
+    </span>
+    <span
       class="bp3-popover-wrapper bp3-dark"
     >
       <span
@@ -398,6 +500,40 @@ exports[`<ExecutionActions /> tests snapshot tests "Failed" status: container 1`
   <div
     class="Layout--horizontal StyledProps--main"
   >
+    <span
+      class="bp3-popover-wrapper"
+    >
+      <span
+        class="bp3-popover-target"
+      >
+        <button
+          aria-label="pipeline.execution.actions.rerunPipeline"
+          class="bp3-button Button--button StyledProps--font StyledProps--main Button--with-current-color Button--iconOnly Button--withLeftIcon Button--variation Button--variation-icon"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="bp3-icon bp3-icon-repeat StyledProps--main"
+            icon="repeat"
+          >
+            <svg
+              data-icon="repeat"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                repeat
+              </desc>
+              <path
+                d="M10 5c0 .55.45 1 1 1h4c.55 0 1-.45 1-1V1c0-.55-.45-1-1-1s-1 .45-1 1v1.74A7.95 7.95 0 008 0C3.58 0 0 3.58 0 8c0 4.06 3.02 7.4 6.94 7.92.02 0 .04.01.06.01.33.04.66.07 1 .07 4.42 0 8-3.58 8-8 0-.55-.45-1-1-1s-1 .45-1 1c0 3.31-2.69 6-6 6-.71 0-1.37-.15-2-.38v.01C3.67 12.81 2 10.61 2 8c0-3.31 2.69-6 6-6 1.77 0 3.36.78 4.46 2H11c-.55 0-1 .45-1 1z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </button>
+      </span>
+    </span>
     <span
       class="bp3-popover-wrapper bp3-dark"
     >
@@ -1520,6 +1656,40 @@ exports[`<ExecutionActions /> tests snapshot tests "Success" status: container 1
     class="Layout--horizontal StyledProps--main"
   >
     <span
+      class="bp3-popover-wrapper"
+    >
+      <span
+        class="bp3-popover-target"
+      >
+        <button
+          aria-label="pipeline.execution.actions.rerunPipeline"
+          class="bp3-button Button--button StyledProps--font StyledProps--main Button--with-current-color Button--iconOnly Button--withLeftIcon Button--variation Button--variation-icon"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="bp3-icon bp3-icon-repeat StyledProps--main"
+            icon="repeat"
+          >
+            <svg
+              data-icon="repeat"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                repeat
+              </desc>
+              <path
+                d="M10 5c0 .55.45 1 1 1h4c.55 0 1-.45 1-1V1c0-.55-.45-1-1-1s-1 .45-1 1v1.74A7.95 7.95 0 008 0C3.58 0 0 3.58 0 8c0 4.06 3.02 7.4 6.94 7.92.02 0 .04.01.06.01.33.04.66.07 1 .07 4.42 0 8-3.58 8-8 0-.55-.45-1-1-1s-1 .45-1 1c0 3.31-2.69 6-6 6-.71 0-1.37-.15-2-.38v.01C3.67 12.81 2 10.61 2 8c0-3.31 2.69-6 6-6 1.77 0 3.36.78 4.46 2H11c-.55 0-1 .45-1 1z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </button>
+      </span>
+    </span>
+    <span
       class="bp3-popover-wrapper bp3-dark"
     >
       <span
@@ -1650,6 +1820,40 @@ exports[`<ExecutionActions /> tests snapshot tests "Suspended" status: container
   <div
     class="Layout--horizontal StyledProps--main"
   >
+    <span
+      class="bp3-popover-wrapper"
+    >
+      <span
+        class="bp3-popover-target"
+      >
+        <button
+          aria-label="pipeline.execution.actions.rerunPipeline"
+          class="bp3-button Button--button StyledProps--font StyledProps--main Button--with-current-color Button--iconOnly Button--withLeftIcon Button--variation Button--variation-icon"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="bp3-icon bp3-icon-repeat StyledProps--main"
+            icon="repeat"
+          >
+            <svg
+              data-icon="repeat"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                repeat
+              </desc>
+              <path
+                d="M10 5c0 .55.45 1 1 1h4c.55 0 1-.45 1-1V1c0-.55-.45-1-1-1s-1 .45-1 1v1.74A7.95 7.95 0 008 0C3.58 0 0 3.58 0 8c0 4.06 3.02 7.4 6.94 7.92.02 0 .04.01.06.01.33.04.66.07 1 .07 4.42 0 8-3.58 8-8 0-.55-.45-1-1-1s-1 .45-1 1c0 3.31-2.69 6-6 6-.71 0-1.37-.15-2-.38v.01C3.67 12.81 2 10.61 2 8c0-3.31 2.69-6 6-6 1.77 0 3.36.78 4.46 2H11c-.55 0-1 .45-1 1z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </button>
+      </span>
+    </span>
     <span
       class="bp3-popover-wrapper bp3-dark"
     >

--- a/src/modules/70-pipeline/components/RetryPipeline/RetryPipeline.tsx
+++ b/src/modules/70-pipeline/components/RetryPipeline/RetryPipeline.tsx
@@ -106,7 +106,6 @@ interface RetryPipelineProps {
     stagesExecuted?: string[]
   }> &
     GitQueryParams
-  preSelectLastStage?: boolean
 }
 
 function RetryPipeline({
@@ -114,8 +113,7 @@ function RetryPipeline({
   pipelineIdentifier: pipelineIdf,
   modules,
   onClose,
-  params,
-  preSelectLastStage = false
+  params
 }: RetryPipelineProps): React.ReactElement {
   const {
     isGitSyncEnabled: isGitSyncEnabledForProject,
@@ -663,16 +661,7 @@ function RetryPipeline({
     [yamlHandler?.getLatestYaml]
   )
 
-  const handleParallelStagesSelection = (value: ParallelStageOption): void => {
-    if ((value as ParallelStageOption).isLastIndex === (stageResponse?.data?.groups as RetryGroup[])?.length - 1) {
-      setIsLastIndex(true)
-    } else {
-      setIsLastIndex(false)
-    }
-    setIsParallelStage(true)
-  }
-
-  const selectListOfSelectedStages = (value: ParallelStageOption): void => {
+  const handleStageChange = (value: ParallelStageOption): void => {
     const stagesList = stageResponse?.data?.groups?.filter((_, stageIdx) => stageIdx < value.isLastIndex)
     const listOfIds: string[] = []
 
@@ -681,42 +670,18 @@ function RetryPipeline({
         listOfIds.push(stageInfo.identifier as string)
       })
     })
-    setListOfSelectedStages(listOfIds)
-  }
 
-  useEffect(() => {
-    if (stageResponse?.data?.groups?.length && preSelectLastStage) {
-      let value: ParallelStageOption
-      stageResponse.data.groups.forEach((stageGroup, idx) => {
-        const [{ name, identifier }] = stageGroup.info || []
-        if (stageGroup.info?.length === 1) {
-          value = { label: name as string, value: identifier as string, isLastIndex: idx }
-          setSelectedStage(value)
-          selectListOfSelectedStages(value)
-        } else {
-          const parallelStagesLabel = stageGroup.info?.map(stageName => stageName.name).join(' | ')
-          const parallelStagesValue = stageGroup.info?.map(stageName => stageName.identifier).join(' | ')
-          value = {
-            label: parallelStagesLabel as string,
-            value: parallelStagesValue as string,
-            isLastIndex: idx
-          }
-          handleParallelStagesSelection(value)
-          setSelectedStage(value)
-          selectListOfSelectedStages(value)
-        }
-      })
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [stageResponse?.data, preSelectLastStage])
-
-  const handleStageChange = (value: ParallelStageOption): void => {
     if (value.label.includes('|')) {
-      handleParallelStagesSelection(value)
+      if ((value as ParallelStageOption).isLastIndex === (stageResponse?.data?.groups as RetryGroup[])?.length - 1) {
+        setIsLastIndex(true)
+      } else {
+        setIsLastIndex(false)
+      }
+      setIsParallelStage(true)
     } else {
       setIsParallelStage(false)
     }
-    selectListOfSelectedStages(value)
+    setListOfSelectedStages(listOfIds)
     setSelectedStage(value)
   }
   const handleStageType = (e: FormEvent<HTMLInputElement>): void => {

--- a/src/modules/70-pipeline/pages/execution/ExecutionLandingPage/ExecutionHeader/ExecutionHeader.module.scss
+++ b/src/modules/70-pipeline/pages/execution/ExecutionLandingPage/ExecutionHeader/ExecutionHeader.module.scss
@@ -56,6 +56,12 @@
     font-size: var(--font-size-small);
     column-gap: var(--spacing-5);
 
+    & .startTime {
+      display: flex;
+      align-items: center;
+      column-gap: var(--spacing-3);
+    }
+
     & .startTimeText {
       color: var(--grey-500);
     }
@@ -94,10 +100,4 @@
 }
 .viewLatest {
   cursor: pointer !important;
-}
-
-.startTime {
-  display: flex;
-  align-items: center;
-  column-gap: var(--spacing-3);
 }

--- a/src/modules/70-pipeline/pages/execution/ExecutionLandingPage/ExecutionHeader/ExecutionHeader.tsx
+++ b/src/modules/70-pipeline/pages/execution/ExecutionLandingPage/ExecutionHeader/ExecutionHeader.tsx
@@ -44,8 +44,6 @@ import { isSimplifiedYAMLEnabled } from '@common/utils/utils'
 import { useRunPipelineModalV1 } from '@pipeline/v1/components/RunPipelineModalV1/useRunPipelineModalV1'
 import { ModuleName } from 'framework/types/ModuleName'
 import { useOpenRetryPipelineModal } from '@pipeline/components/ExecutionActions/useOpenRetryPipelineModal'
-import { useTelemetry } from '@common/hooks/useTelemetry'
-import { PipelineExecutionActions } from '@common/constants/TrackingConstants'
 import css from './ExecutionHeader.module.scss'
 
 export interface ExecutionHeaderProps {
@@ -95,7 +93,6 @@ export function ExecutionHeader({ pipelineMetadata }: ExecutionHeaderProps): Rea
   const { getString } = useStrings()
   const { pipelineExecutionSummary = {} } = pipelineExecutionDetail || {}
   const { CI_REMOTE_DEBUG } = useFeatureFlags()
-  const { trackEvent } = useTelemetry()
 
   const [canView, canEdit, canExecute] = usePermission(
     {
@@ -197,16 +194,7 @@ export function ExecutionHeader({ pipelineMetadata }: ExecutionHeaderProps): Rea
   const showRetryPipelineOption = isRetryPipelineAllowed(status as ExecutionStatus) && canRetry
   const { openRetryPipelineModal } = useOpenRetryPipelineModal({ modules, params })
   const reRunPipeline = (): void => {
-    trackEvent(PipelineExecutionActions.ReRunPipeline, { triggered_from: 'button' })
     isSimplifiedYAMLEnabled(module, CI_YAML_VERSIONING) ? openRunPipelineModalV1() : openRunPipelineModal()
-  }
-
-  const retryPipeline = (fromLastStage?: boolean): void => {
-    trackEvent(PipelineExecutionActions.RetryPipeline, {
-      triggered_from: 'button',
-      type: fromLastStage ? 'last_failed_stage' : 'selected_stage'
-    })
-    openRetryPipelineModal(fromLastStage)
   }
 
   let moduleLabel = getString('common.pipelineExecution')
@@ -314,13 +302,13 @@ export function ExecutionHeader({ pipelineMetadata }: ExecutionHeaderProps): Rea
                 <>
                   <SplitButtonOption
                     data-test-id="retry-failed-pipeline"
-                    onClick={() => retryPipeline(true)}
+                    onClick={() => openRetryPipelineModal(true)}
                     text={getString('pipeline.execution.actions.reRunLastFailedStage')}
                     disabled={isPipelineInvalid}
                   />
                   <SplitButtonOption
                     data-test-id="retry-failed-pipeline-specific-stage"
-                    onClick={() => retryPipeline()}
+                    onClick={() => openRetryPipelineModal()}
                     text={getString('pipeline.execution.actions.reRunSelectedStage')}
                     disabled={isPipelineInvalid}
                   />

--- a/src/modules/70-pipeline/pages/execution/ExecutionLandingPage/ExecutionHeader/ExecutionHeader.tsx
+++ b/src/modules/70-pipeline/pages/execution/ExecutionLandingPage/ExecutionHeader/ExecutionHeader.tsx
@@ -8,14 +8,12 @@
 import React from 'react'
 import { Link, useParams } from 'react-router-dom'
 import { defaultTo, isEmpty } from 'lodash-es'
-import { ButtonSize, ButtonVariation, Icon, Layout, SplitButton, SplitButtonOption, Text } from '@harness/uicore'
-import { Color } from '@harness/design-system'
-import { PopoverInteractionKind } from '@blueprintjs/core'
+import { Icon } from '@harness/uicore'
 import routes from '@common/RouteDefinitions'
 import { Duration } from '@common/components/Duration/Duration'
 import { useDocumentTitle } from '@common/hooks/useDocumentTitle'
 import ExecutionStatusLabel from '@pipeline/components/ExecutionStatusLabel/ExecutionStatusLabel'
-import ExecutionActions, { getValidExecutionActions } from '@pipeline/components/ExecutionActions/ExecutionActions'
+import ExecutionActions from '@pipeline/components/ExecutionActions/ExecutionActions'
 import { formatDatetoLocale } from '@common/utils/dateUtils'
 import { PermissionIdentifier } from '@rbac/interfaces/PermissionIdentifier'
 import GitPopover from '@pipeline/components/GitPopover/GitPopover'
@@ -25,7 +23,7 @@ import { usePermission } from '@rbac/hooks/usePermission'
 import { ResourceType } from '@rbac/interfaces/ResourceType'
 import type { ExecutionPathProps, GitQueryParams, PipelineType } from '@common/interfaces/RouteInterfaces'
 import { StoreType } from '@common/constants/GitSyncTypes'
-import { ExecutionStatus, isRetryPipelineAllowed } from '@pipeline/utils/statusHelpers'
+import type { ExecutionStatus } from '@pipeline/utils/statusHelpers'
 import { useExecutionContext } from '@pipeline/context/ExecutionContext'
 import { TagsPopover } from '@common/components'
 import { useFeatureFlags } from '@common/hooks/useFeatureFlag'
@@ -43,37 +41,11 @@ import { useQueryParams } from '@common/hooks'
 import { isSimplifiedYAMLEnabled } from '@common/utils/utils'
 import { useRunPipelineModalV1 } from '@pipeline/v1/components/RunPipelineModalV1/useRunPipelineModalV1'
 import { ModuleName } from 'framework/types/ModuleName'
-import { useOpenRetryPipelineModal } from '@pipeline/components/ExecutionActions/useOpenRetryPipelineModal'
 import css from './ExecutionHeader.module.scss'
 
 export interface ExecutionHeaderProps {
   pipelineMetadata?: ResponsePMSPipelineSummaryResponse | null
 }
-
-interface TooltipContentProps {
-  pipelineExecutionSummary: PipelineExecutionSummary
-}
-
-const MemoizedTooltipContent = React.memo(({ pipelineExecutionSummary }: TooltipContentProps) => {
-  const { getString } = useStrings()
-  return (
-    <Layout.Vertical padding="medium">
-      <Duration
-        className={css.duration}
-        startTime={pipelineExecutionSummary.startTs}
-        endTime={pipelineExecutionSummary.endTs}
-        color={Color.WHITE}
-      />
-      {pipelineExecutionSummary.startTs && (
-        <Text inline color={Color.WHITE} className={css.startTime}>
-          {`${getString('pipeline.startTime')}: ${formatDatetoLocale(pipelineExecutionSummary.startTs)}`}
-        </Text>
-      )}
-    </Layout.Vertical>
-  )
-})
-
-MemoizedTooltipContent.displayName = 'MemoizedTooltipContent'
 
 export function ExecutionHeader({ pipelineMetadata }: ExecutionHeaderProps): React.ReactElement {
   const { orgIdentifier, projectIdentifier, executionIdentifier, accountId, pipelineIdentifier, module, source } =
@@ -93,7 +65,6 @@ export function ExecutionHeader({ pipelineMetadata }: ExecutionHeaderProps): Rea
   const { getString } = useStrings()
   const { pipelineExecutionSummary = {} } = pipelineExecutionDetail || {}
   const { CI_REMOTE_DEBUG } = useFeatureFlags()
-
   const [canView, canEdit, canExecute] = usePermission(
     {
       resourceScope: {
@@ -175,28 +146,6 @@ export function ExecutionHeader({ pipelineMetadata }: ExecutionHeaderProps): Rea
     isDebugMode: hasCI
   })
 
-  const { status, canRetry, modules, stagesExecuted } = pipelineExecutionSummary
-  const params = {
-    orgIdentifier,
-    pipelineIdentifier,
-    projectIdentifier,
-    accountId,
-    executionIdentifier,
-    module,
-    repoIdentifier,
-    connectorRef,
-    repoName,
-    branch,
-    storeType: pipelineMetadata?.data?.storeType,
-    stagesExecuted
-  }
-  const { canRerun } = getValidExecutionActions(canExecute, status as ExecutionStatus)
-  const showRetryPipelineOption = isRetryPipelineAllowed(status as ExecutionStatus) && canRetry
-  const { openRetryPipelineModal } = useOpenRetryPipelineModal({ modules, params })
-  const reRunPipeline = (): void => {
-    isSimplifiedYAMLEnabled(module, CI_YAML_VERSIONING) ? openRunPipelineModalV1() : openRunPipelineModal()
-  }
-
   let moduleLabel = getString('common.pipelineExecution')
   if (module) {
     switch (module.toUpperCase() as ModuleName) {
@@ -251,6 +200,12 @@ export function ExecutionHeader({ pipelineMetadata }: ExecutionHeaderProps): Rea
           {pipelineExecutionSummary.status ? (
             <ExecutionStatusLabel status={pipelineExecutionSummary.status as ExecutionStatus} />
           ) : null}
+          {pipelineExecutionSummary.startTs && (
+            <div className={css.startTime}>
+              <String tagName="div" className={css.startTimeText} stringID="pipeline.startTime" />
+              <span>{formatDatetoLocale(pipelineExecutionSummary.startTs)}</span>
+            </div>
+          )}
           <Duration
             className={css.duration}
             startTime={pipelineExecutionSummary.startTs}
@@ -258,11 +213,6 @@ export function ExecutionHeader({ pipelineMetadata }: ExecutionHeaderProps): Rea
             icon="time"
             iconProps={{ size: 12 }}
             durationText={' '}
-            tooltip={<MemoizedTooltipContent pipelineExecutionSummary={pipelineExecutionSummary} />}
-            tooltipProps={{
-              isDark: true,
-              interactionKind: PopoverInteractionKind.HOVER
-            }}
           />
           {pipelineExecutionSummary.showRetryHistory && (
             <RetryHistory
@@ -282,49 +232,25 @@ export function ExecutionHeader({ pipelineMetadata }: ExecutionHeaderProps): Rea
             <Icon name="Edit" size={12} />
             <String stringID="editPipeline" />
           </Link>
-          {canRerun && (
-            <SplitButton
-              variation={ButtonVariation.SECONDARY}
-              data-testid="retry-pipeline"
-              icon={'repeat'}
-              text={getString('pipeline.execution.actions.reRun')}
-              minimal
-              size={ButtonSize.SMALL}
-              iconProps={{ size: 12 }}
-              onClick={reRunPipeline}
-              tooltipProps={{
-                dataTooltipId: 'retry-pipeline'
-              }}
-              usePortal={true}
-              disabled={!canExecute || isPipelineInvalid}
-            >
-              {showRetryPipelineOption && (
-                <>
-                  <SplitButtonOption
-                    data-test-id="retry-failed-pipeline"
-                    onClick={() => openRetryPipelineModal(true)}
-                    text={getString('pipeline.execution.actions.reRunLastFailedStage')}
-                    disabled={isPipelineInvalid}
-                  />
-                  <SplitButtonOption
-                    data-test-id="retry-failed-pipeline-specific-stage"
-                    onClick={() => openRetryPipelineModal()}
-                    text={getString('pipeline.execution.actions.reRunSelectedStage')}
-                    disabled={isPipelineInvalid}
-                  />
-                </>
-              )}
-              <SplitButtonOption
-                onClick={reRunPipeline}
-                text={getString('pipeline.execution.actions.reRunEntirePipeline')}
-              />
-            </SplitButton>
-          )}
+
           <ExecutionActions
             executionStatus={pipelineExecutionSummary.status as ExecutionStatus}
             refetch={refetch}
             source={source}
-            params={params}
+            params={{
+              orgIdentifier,
+              pipelineIdentifier,
+              projectIdentifier,
+              accountId,
+              executionIdentifier,
+              module,
+              repoIdentifier,
+              connectorRef,
+              repoName,
+              branch,
+              storeType: pipelineMetadata?.data?.storeType,
+              stagesExecuted: pipelineExecutionSummary?.stagesExecuted
+            }}
             isPipelineInvalid={isPipelineInvalid}
             canEdit={canEdit}
             showEditButton={true}

--- a/src/modules/70-pipeline/pages/execution/ExecutionLandingPage/__tests__/__snapshots__/ExecutionLandingPage.test.tsx.snap
+++ b/src/modules/70-pipeline/pages/execution/ExecutionLandingPage/__tests__/__snapshots__/ExecutionLandingPage.test.tsx.snap
@@ -227,39 +227,30 @@ exports[`<ExecutionLandingPage /> tests for CI loading state - snapshot test for
               class="actionsBar"
             >
               <span
-                class="bp3-popover-wrapper"
+                class="StyledProps--font StyledProps--main duration StyledProps--inline"
+                style="display: inline-flex; align-items: center;"
               >
                 <span
-                  class="bp3-popover-target Text--targetClass"
+                  class="bp3-icon bp3-icon-time StyledProps--main Text--icon StyledProps--padding-right-xsmall"
+                  icon="time"
                 >
-                  <span
-                    class="StyledProps--font StyledProps--main duration StyledProps--inline"
-                    style="display: inline-flex; align-items: center;"
-                    tabindex="0"
+                  <svg
+                    data-icon="time"
+                    height="12"
+                    viewBox="0 0 16 16"
+                    width="12"
                   >
-                    <span
-                      class="bp3-icon bp3-icon-time StyledProps--main Text--icon StyledProps--padding-right-xsmall"
-                      icon="time"
-                    >
-                      <svg
-                        data-icon="time"
-                        height="12"
-                        viewBox="0 0 16 16"
-                        width="12"
-                      >
-                        <desc>
-                          time
-                        </desc>
-                        <path
-                          d="M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6s2.69-6 6-6 6 2.69 6 6-2.69 6-6 6zm1-6.41V4c0-.55-.45-1-1-1s-1 .45-1 1v4c0 .28.11.53.29.71l2 2a1.003 1.003 0 001.42-1.42L9 7.59z"
-                          fill-rule="evenodd"
-                        />
-                      </svg>
-                    </span>
-                     
-                    
-                  </span>
+                    <desc>
+                      time
+                    </desc>
+                    <path
+                      d="M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6s2.69-6 6-6 6 2.69 6 6-2.69 6-6 6zm1-6.41V4c0-.55-.45-1-1-1s-1 .45-1 1v4c0 .28.11.53.29.71l2 2a1.003 1.003 0 001.42-1.42L9 7.59z"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
                 </span>
+                 
+                
               </span>
               <a
                 class="view"
@@ -854,39 +845,30 @@ exports[`<ExecutionLandingPage /> tests loading state - snapshot test 1`] = `
               class="actionsBar"
             >
               <span
-                class="bp3-popover-wrapper"
+                class="StyledProps--font StyledProps--main duration StyledProps--inline"
+                style="display: inline-flex; align-items: center;"
               >
                 <span
-                  class="bp3-popover-target Text--targetClass"
+                  class="bp3-icon bp3-icon-time StyledProps--main Text--icon StyledProps--padding-right-xsmall"
+                  icon="time"
                 >
-                  <span
-                    class="StyledProps--font StyledProps--main duration StyledProps--inline"
-                    style="display: inline-flex; align-items: center;"
-                    tabindex="0"
+                  <svg
+                    data-icon="time"
+                    height="12"
+                    viewBox="0 0 16 16"
+                    width="12"
                   >
-                    <span
-                      class="bp3-icon bp3-icon-time StyledProps--main Text--icon StyledProps--padding-right-xsmall"
-                      icon="time"
-                    >
-                      <svg
-                        data-icon="time"
-                        height="12"
-                        viewBox="0 0 16 16"
-                        width="12"
-                      >
-                        <desc>
-                          time
-                        </desc>
-                        <path
-                          d="M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6s2.69-6 6-6 6 2.69 6 6-2.69 6-6 6zm1-6.41V4c0-.55-.45-1-1-1s-1 .45-1 1v4c0 .28.11.53.29.71l2 2a1.003 1.003 0 001.42-1.42L9 7.59z"
-                          fill-rule="evenodd"
-                        />
-                      </svg>
-                    </span>
-                     
-                    
-                  </span>
+                    <desc>
+                      time
+                    </desc>
+                    <path
+                      d="M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6s2.69-6 6-6 6 2.69 6 6-2.69 6-6 6zm1-6.41V4c0-.55-.45-1-1-1s-1 .45-1 1v4c0 .28.11.53.29.71l2 2a1.003 1.003 0 001.42-1.42L9 7.59z"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
                 </span>
+                 
+                
               </span>
               <a
                 class="view"


### PR DESCRIPTION
### Summary

- reverting changes for this release, as this feature needs to be shipped together with the `reTried stage` label in the next release. 

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
