### PR TITLE
fix: remove explicit calculation of step group size - WIP

### DIFF
--- a/src/modules/70-pipeline/components/PipelineDiagram/Nodes/CreateNode/CreateNodeStep.tsx
+++ b/src/modules/70-pipeline/components/PipelineDiagram/Nodes/CreateNode/CreateNodeStep.tsx
@@ -27,6 +27,7 @@ interface CreateNodeStepProps {
   node?: CreateNodeStepProps & { isSelected?: boolean }
   titleClassName?: string
   className?: string
+  wrapperClassname?: string
   hidden?: boolean
 }
 
@@ -41,7 +42,7 @@ function CreateNodeStep(props: CreateNodeStepProps): React.ReactElement {
       onMouseLeave={() => {
         props.onMouseLeave?.()
       }}
-      className={cssDefault.defaultNode}
+      className={cx(cssDefault.defaultNode, props.wrapperClassname)}
       onDragOver={event => {
         event.preventDefault()
         event.stopPropagation()

--- a/src/modules/70-pipeline/components/PipelineDiagram/Nodes/DefaultNode/DefaultNode.module.scss
+++ b/src/modules/70-pipeline/components/PipelineDiagram/Nodes/DefaultNode/DefaultNode.module.scss
@@ -224,6 +224,11 @@
     }
   }
 }
+
+.floatingAddNodeWrapper {
+  position: absolute;
+}
+
 .addNode {
   visibility: hidden;
   &.visible {

--- a/src/modules/70-pipeline/components/PipelineDiagram/Nodes/DefaultNode/DefaultNode.module.scss.d.ts
+++ b/src/modules/70-pipeline/components/PipelineDiagram/Nodes/DefaultNode/DefaultNode.module.scss.d.ts
@@ -20,6 +20,7 @@ declare const styles: {
   readonly draggable: string
   readonly fadeIn: string
   readonly failed: string
+  readonly floatingAddNodeWrapper: string
   readonly hoverName: string
   readonly icon: string
   readonly iconGroup: string

--- a/src/modules/70-pipeline/components/PipelineDiagram/Nodes/DefaultNode/PipelineStepNode/PipelineStepNode.tsx
+++ b/src/modules/70-pipeline/components/PipelineDiagram/Nodes/DefaultNode/PipelineStepNode/PipelineStepNode.tsx
@@ -345,6 +345,7 @@ function PipelineStepNode(props: PipelineStepNodeProps): JSX.Element {
             })
           }}
           className={cx(defaultCss.addNode, defaultCss.stepAddNode, { [defaultCss.visible]: showAddNode })}
+          wrapperClassname={defaultCss.floatingAddNodeWrapper}
           data-nodeid="add-parallel"
         />
       )}

--- a/src/modules/70-pipeline/components/PipelineDiagram/Nodes/StepGroupGraph/StepGroupGraph.module.scss
+++ b/src/modules/70-pipeline/components/PipelineDiagram/Nodes/StepGroupGraph/StepGroupGraph.module.scss
@@ -8,3 +8,7 @@
   stroke-width: 2;
   stroke-dasharray: 4;
 }
+
+.floatingAddNodeWrapper {
+  position: absolute;
+}

--- a/src/modules/70-pipeline/components/PipelineDiagram/Nodes/StepGroupGraph/StepGroupGraph.module.scss.d.ts
+++ b/src/modules/70-pipeline/components/PipelineDiagram/Nodes/StepGroupGraph/StepGroupGraph.module.scss.d.ts
@@ -7,6 +7,7 @@
  **/
 // this is an auto-generated file, do not update this manually
 declare const styles: {
+  readonly floatingAddNodeWrapper: string
   readonly main: string
   readonly stepGroupSvg: string
 }

--- a/src/modules/70-pipeline/components/PipelineDiagram/Nodes/StepGroupGraph/StepGroupGraph.tsx
+++ b/src/modules/70-pipeline/components/PipelineDiagram/Nodes/StepGroupGraph/StepGroupGraph.tsx
@@ -50,75 +50,6 @@ interface StepGroupGraphProps {
   type?: string
 }
 
-const getCalculatedStyles = (
-  data: PipelineGraphState[],
-  childrenDimensions: Dimensions,
-  type?: string
-): LayoutStyles => {
-  let width = 0
-  let height = 0
-  let maxChildLength = 0
-  let finalHeight = 0
-  data.forEach(node => {
-    const currentNodeId = node.id
-    const childrenNodesId = defaultTo(node?.children, []).map(o => o.id) // list of all parallel nodes of current node
-    const childNodesId = [currentNodeId, ...childrenNodesId] // node + all parallel nodes id list
-
-    if (childrenDimensions[currentNodeId]) {
-      // stepGroup child dimension from context
-      let nodeHeight = 0
-      let nodeWidth = 0
-      childNodesId.forEach((childNode, index) => {
-        // check all parallel nodes
-        const dimensionMetaData = childrenDimensions[childNode]
-
-        let hh = dimensionMetaData?.height + (dimensionMetaData?.isNodeCollapsed ? 0 : 60) // padding for StepGroupNode
-        let ww = dimensionMetaData?.width + (dimensionMetaData?.isNodeCollapsed ? 0 : 80) // padding for StepGroupNode
-
-        if (dimensionMetaData?.type === 'matrix') {
-          hh += 45
-          ww -= 25
-        }
-        nodeHeight += hh || 0 // height added for all child (68 -> padding of StepGroupNode)
-        nodeWidth = Math.max(nodeWidth, ww || 0) // width is max of all child nodes
-
-        nodeHeight += index > 0 ? 120 : 32 //nodeGap for parallel nodes
-      })
-      if (node.children?.length && data.length > 0) {
-        width += 40 // for parallel node -> parallel link joint
-      }
-
-      height = Math.max(height, nodeHeight) //+ 40 //(each node)
-      width = width + nodeWidth + 80 //+ 40 // gap
-      finalHeight = Math.max(finalHeight, height)
-    } else {
-      let nodeHeight = 0
-      let nodeWidth = 0
-      childNodesId.forEach((childNode, index) => {
-        const dimensionMetaData = childrenDimensions[childNode]
-        const sgDimension = dimensionMetaData?.height ? getSGDimensions(dimensionMetaData, index) : undefined
-        const hh = defaultTo(sgDimension?.height, 118) // 118 (node+text)
-        let ww = defaultTo(sgDimension?.width, 134)
-        nodeHeight += hh
-        if (index > 0) {
-          ww += 20
-          nodeHeight += 26 //26(padding beteween the text and next node)
-        }
-        nodeWidth = Math.max(nodeWidth, ww)
-      })
-      width += nodeWidth + 20
-
-      maxChildLength = Math.max(maxChildLength, node?.children?.length || 0)
-      finalHeight = Math.max(finalHeight, nodeHeight)
-    }
-  })
-
-  return {
-    height: finalHeight,
-    width: width - (stageGroupTypes.includes(type as StageType) ? 40 : 80)
-  } // 80 is link gap that we dont need for last stepgroup node
-}
-
 function StepGroupGraph(props: StepGroupGraphProps): React.ReactElement {
   const [svgPath, setSvgPath] = useState<SVGPathRecord[]>([])
   const [treeRectangle, setTreeRectangle] = useState<DOMRect | void>()
@@ -161,14 +92,22 @@ function StepGroupGraph(props: StepGroupGraphProps): React.ReactElement {
   useLayoutEffect(() => {
     if (state?.length) {
       setSVGLinks()
-      setLayoutStyles(getCalculatedStyles(state, childrenDimensions, props?.type))
+       // TODO: is this correct?
+      setLayoutStyles({
+        width:parseInt(graphRef.current?.style.width!, 10),
+        height: parseInt(graphRef.current?.style.height!, 10),
+      })
     }
   }, [state, props?.isNodeCollapsed])
 
   useDeepCompareEffect(() => {
     if (state?.length) {
       updateGraphLinks()
-      setLayoutStyles(getCalculatedStyles(state, childrenDimensions, props?.type))
+      // TODO: is this correct?
+      setLayoutStyles({
+        width:parseInt(graphRef.current?.style.width!, 10),
+        height: parseInt(graphRef.current?.style.height!, 10),
+      })
     }
   }, [childrenDimensions])
 
@@ -227,7 +166,6 @@ function StepGroupGraph(props: StepGroupGraphProps): React.ReactElement {
   return (
     <div
       className={css.main}
-      style={layoutStyles}
       data-stepGroup-name={props?.identifier}
       data-stepGroup-id={props?.id}
       ref={graphRef}

--- a/src/modules/70-pipeline/components/PipelineDiagram/Nodes/StepGroupNode/StepGroupNode.module.scss
+++ b/src/modules/70-pipeline/components/PipelineDiagram/Nodes/StepGroupNode/StepGroupNode.module.scss
@@ -84,22 +84,22 @@
   &.firstnode {
     top: -46px;
 
-    &.nestedGroup {
-      top: -10px;
-      .horizontalBar {
-        top: 36px;
-      }
+    // &.nestedGroup {
+    //   top: -10px;
+    //   .horizontalBar {
+    //     //top: 44px;
+    //   }
 
-      .markerStart {
-        top: 60px !important;
-      }
-      :global(#tree-container) {
-        top: -10px !important;
-      }
-      svg {
-        top: -10px !important;
-      }
-    }
+    //   .markerStart {
+    //     //top: 60px !important;
+    //   }
+    //   :global(#tree-container) {
+    //     top: -10px !important;
+    //   }
+    //   svg {
+    //     //top: -10px !important;
+    //   }
+    // }
   }
   &.parallelNodes {
     &.nestedGroup {
@@ -125,15 +125,15 @@
   }
   .nestedGroup {
     top: -10px;
-    :global(.default-node) {
-      top: 0px !important;
-    }
-    :global(.diamond-node) {
-      top: 0px !important;
-    }
-    :global(.icon-node) {
-      top: 0px !important;
-    }
+    // :global(.default-node) {
+    //   top: 0px !important;
+    // }
+    // :global(.diamond-node) {
+    //   top: 0px !important;
+    // }
+    // :global(.icon-node) {
+    //   top: 0px !important;
+    // }
   }
   .stepGroupHeader {
     padding: var(--spacing-small) var(--spacing-small) 0 var(--spacing-small);
@@ -150,7 +150,7 @@
   }
 
   .stepGroupBody {
-    padding: var(--spacing-large) var(--spacing-xxxlarge);
+    padding: var(--spacing-large) calc(var(--spacing-xxxlarge) * 1.5);
   }
 
   .conditional {

--- a/src/modules/70-pipeline/components/PipelineDiagram/Nodes/StepGroupNode/StepGroupNode.tsx
+++ b/src/modules/70-pipeline/components/PipelineDiagram/Nodes/StepGroupNode/StepGroupNode.tsx
@@ -428,6 +428,7 @@ export function StepGroupNode(props: any): JSX.Element {
                 { [defaultCss.visible]: showAdd },
                 { [defaultCss.marginBottom]: props?.isParallelNode }
               )}
+              wrapperClassname={defaultCss.floatingAddNodeWrapper}
               onMouseOver={() => allowAdd && setVisibilityOfAdd(true)}
               onMouseLeave={() => allowAdd && debounceHideVisibility()}
               onDragLeave={debounceHideVisibility}

--- a/src/modules/70-pipeline/components/PipelineDiagram/PipelineGraph/PipelineGraph.module.scss
+++ b/src/modules/70-pipeline/components/PipelineDiagram/PipelineGraph/PipelineGraph.module.scss
@@ -76,7 +76,7 @@
   align-items: center;
 }
 
-.common {
+.svg-paths {
   inset: 0px;
   position: absolute;
   transform-origin: 0px 0px;
@@ -94,7 +94,7 @@
 }
 
 .graph-tree {
-  display: flex;
+  display: inline-flex;
   column-gap: 80px;
   cursor: move;
 }

--- a/src/modules/70-pipeline/components/PipelineDiagram/PipelineGraph/PipelineGraph.module.scss.d.ts
+++ b/src/modules/70-pipeline/components/PipelineDiagram/PipelineGraph/PipelineGraph.module.scss.d.ts
@@ -7,7 +7,6 @@
  **/
 // this is an auto-generated file, do not update this manually
 declare const styles: {
-  readonly common: string
   readonly dash: string
   readonly draggableParent: string
   readonly graphMain: string
@@ -21,5 +20,6 @@ declare const styles: {
   readonly parallel: string
   readonly pathExecute: string
   readonly svgArrow: string
+  readonly svgPaths: string
 }
 export default styles

--- a/src/modules/70-pipeline/components/PipelineDiagram/PipelineGraph/PipelineGraph.tsx
+++ b/src/modules/70-pipeline/components/PipelineDiagram/PipelineGraph/PipelineGraph.tsx
@@ -297,7 +297,7 @@ export function SVGComponent({ svgPath, className }: SVGComponentProps): React.R
     }
   }
   return (
-    <svg className={css.common} id="graph-svg">
+    <svg className={css.svgPaths} id="graph-svg">
       {svgPathFlattened.map((path, idx) => {
         const [[nodeId, pathDetails]] = Object.entries(path)
         return (

--- a/src/modules/70-pipeline/components/PipelineDiagram/PipelineGraph/PipelineGraphNode.tsx
+++ b/src/modules/70-pipeline/components/PipelineDiagram/PipelineGraph/PipelineGraphNode.tsx
@@ -68,7 +68,7 @@ export function PipelineGraphRecursive({
   const EndNode: React.FC<BaseReactComponentProps> | undefined = getNode(NodeType.EndNode)?.component
   const PipelineNodeComponent = optimizeRender ? PipelineGraphNodeObserved : PipelineGraphNodeBasic
   return (
-    <div id="tree-container" className={classNames(css.graphTree, css.common)}>
+    <div id="tree-container" className={classNames(css.graphTree)}>
       {StartNode && startEndNodeNeeded && (
         <StartNode id={uniqueNodeIds?.startNode as string} className={classNames(css.graphNode)} />
       )}


### PR DESCRIPTION
### Summary

- Remove explicit  calculation of step group node size and make graph nodes layout only with html/css  - WIP
- Small visual changes

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
