### PR TITLE
feat: [CET-1330]: Require license to use ET in CI

### DIFF
--- a/src/modules/70-pipeline/pages/execution/ExecutionLandingPage/ExecutionTabs/ExecutionTabs.tsx
+++ b/src/modules/70-pipeline/pages/execution/ExecutionLandingPage/ExecutionTabs/ExecutionTabs.tsx
@@ -69,7 +69,7 @@ export default function ExecutionTabs(props: ExecutionTabsProps): React.ReactEle
   const { updateQueryParams } = useUpdateQueryParams<ExecutionQueryParams>()
   const { licenseInformation } = useLicenseStore()
   const isSecurityEnabled = licenseInformation['STO']?.status === 'ACTIVE'
-  const isErrorTrackingEnabled = useFeatureFlag(FeatureFlag.CVNG_ENABLED)
+  const isErrorTrackingEnabled = licenseInformation['CET']?.status === 'ACTIVE'
   const isIACMEnabled = useFeatureFlag(FeatureFlag.IACM_ENABLED)
   const isSSCAEnabled = useFeatureFlag(FeatureFlag.SSCA_ENABLED)
   const canUsePolicyEngine = useAnyEnterpriseLicense()

--- a/src/modules/75-ci/components/PipelineSteps/RunTestsStep/RunTestsStepBase.tsx
+++ b/src/modules/75-ci/components/PipelineSteps/RunTestsStep/RunTestsStepBase.tsx
@@ -38,6 +38,7 @@ import { useVariablesExpression } from '@pipeline/components/PipelineStudio/Pipl
 import { useStrings, UseStringsReturn } from 'framework/strings'
 import type { StringsMap } from 'stringTypes'
 import { useFeatureFlags } from '@common/hooks/useFeatureFlag'
+import { useLicenseStore } from 'framework/LicenseStore/LicenseStoreContext'
 import { MultiTypeTextField } from '@common/components/MultiTypeText/MultiTypeText'
 import StepCommonFields from '@ci/components/PipelineSteps/StepCommonFields/StepCommonFields'
 import { validate } from '@pipeline/components/PipelineSteps/Steps/StepsValidateUtils'
@@ -59,7 +60,6 @@ import { CIStep } from '../CIStep/CIStep'
 import { ConnectorRefWithImage } from '../CIStep/ConnectorRefWithImage'
 import { getCIStageInfraType } from '../../../utils/CIPipelineStudioUtils'
 import css from '@pipeline/components/PipelineSteps/Steps/Steps.module.scss'
-import { useLicenseStore } from 'framework/LicenseStore/LicenseStoreContext'
 
 interface FieldRenderProps {
   name: string

--- a/src/modules/75-ci/components/PipelineSteps/RunTestsStep/RunTestsStepBase.tsx
+++ b/src/modules/75-ci/components/PipelineSteps/RunTestsStep/RunTestsStepBase.tsx
@@ -59,6 +59,7 @@ import { CIStep } from '../CIStep/CIStep'
 import { ConnectorRefWithImage } from '../CIStep/ConnectorRefWithImage'
 import { getCIStageInfraType } from '../../../utils/CIPipelineStudioUtils'
 import css from '@pipeline/components/PipelineSteps/Steps/Steps.module.scss'
+import { useLicenseStore } from 'framework/LicenseStore/LicenseStoreContext'
 
 interface FieldRenderProps {
   name: string
@@ -258,7 +259,9 @@ export const RunTestsStepBase = (
       selectionState: { selectedStageId }
     }
   } = usePipelineContext()
-  const { TI_DOTNET, CVNG_ENABLED, CI_PYTHON_TI } = useFeatureFlags()
+  const { TI_DOTNET, CI_PYTHON_TI } = useFeatureFlags()
+  const { licenseInformation } = useLicenseStore()
+  const isErrorTrackingEnabled = licenseInformation['CET']?.status === 'ACTIVE'
   // temporary enable in QA for docs
   const isQAEnvironment = window.location.origin === qaLocation
   const [mavenSetupQuestionAnswer, setMavenSetupQuestionAnswer] = React.useState('yes')
@@ -588,7 +591,7 @@ export const RunTestsStepBase = (
                 allowableTypes: [MultiTypeInputType.FIXED]
               })}
             </Container>
-            {CVNG_ENABLED && selectedLanguageValue === Language.Java && (
+            {isErrorTrackingEnabled && selectedLanguageValue === Language.Java && (
               <Container className={css.bottomMargin5}>
                 <Text
                   tooltipProps={{ dataTooltipId: 'runTestErrorTracking' }}

--- a/src/modules/75-ci/components/PipelineSteps/RunTestsStep/__test__/RunTestsStep.test.tsx
+++ b/src/modules/75-ci/components/PipelineSteps/RunTestsStep/__test__/RunTestsStep.test.tsx
@@ -17,6 +17,7 @@ import type { ResponseConnectorResponse } from 'services/cd-ng'
 import { factory, TestStepWidget } from '@pipeline/components/PipelineSteps/Steps/__tests__/StepTestUtil'
 import { CIBuildInfrastructureType } from '@pipeline/utils/constants'
 import { RunTestsStep } from '../RunTestsStep'
+import * as licenseStoreContextMock from 'framework/LicenseStore/LicenseStoreContext'
 
 jest.mock('@common/components/MonacoEditor/MonacoEditor')
 jest.mock('@common/components/YAMLBuilder/YamlBuilder')
@@ -107,6 +108,13 @@ describe('RunTests Step', () => {
         TI_DOTNET: true,
         CVNG_ENABLED: true
       })
+
+      jest.spyOn(licenseStoreContextMock, 'useLicenseStore').mockReturnValue({
+        licenseInformation: {
+          CET: { status: 'ACTIVE' }
+        }
+      } as any)
+
       const { container, getByText } = render(
         <TestStepWidget initialValues={{}} type={StepType.RunTests} stepViewType={StepViewType.Edit} />
       )

--- a/src/modules/75-ci/components/PipelineSteps/RunTestsStep/__test__/RunTestsStep.test.tsx
+++ b/src/modules/75-ci/components/PipelineSteps/RunTestsStep/__test__/RunTestsStep.test.tsx
@@ -11,13 +11,13 @@ import { RUNTIME_INPUT_VALUE } from '@harness/uicore'
 import { StepViewType, StepFormikRef } from '@pipeline/components/AbstractSteps/Step'
 import { InputTypes, fillAtForm } from '@common/utils/JestFormHelper'
 import * as FeatureFlag from '@common/hooks/useFeatureFlag'
+import * as licenseStoreContextMock from 'framework/LicenseStore/LicenseStoreContext'
 import { StepType } from '@pipeline/components/PipelineSteps/PipelineStepInterface'
 import { findPopoverContainer, UseGetReturnData } from '@common/utils/testUtils'
 import type { ResponseConnectorResponse } from 'services/cd-ng'
 import { factory, TestStepWidget } from '@pipeline/components/PipelineSteps/Steps/__tests__/StepTestUtil'
 import { CIBuildInfrastructureType } from '@pipeline/utils/constants'
 import { RunTestsStep } from '../RunTestsStep'
-import * as licenseStoreContextMock from 'framework/LicenseStore/LicenseStoreContext'
 
 jest.mock('@common/components/MonacoEditor/MonacoEditor')
 jest.mock('@common/components/YAMLBuilder/YamlBuilder')

--- a/src/modules/75-ci/components/PipelineSteps/RunTestsStep/__test__/__snapshots__/RunTestsStep.test.tsx.snap
+++ b/src/modules/75-ci/components/PipelineSteps/RunTestsStep/__test__/__snapshots__/RunTestsStep.test.tsx.snap
@@ -2640,6 +2640,58 @@ exports[`RunTests Step Edit View renders runtime inputs 1`] = `
           </div>
         </div>
         <div
+          class="StyledProps--font StyledProps--main bottomMargin5"
+        >
+          <div
+            class="Text--withDocsTooltip"
+            data-tooltip-id="runTestErrorTracking"
+          >
+            <p
+              class="StyledProps--font StyledProps--main inpLabel StyledProps--color StyledProps--color-grey600 StyledProps--font-size-small StyledProps--font-weight-semi-bold"
+            >
+              ci.runTestsErrorTrackingSetupText
+            </p>
+          </div>
+          <div
+            class="StyledProps--main StyledProps--margin-bottom-small"
+          >
+            
+            <div
+              class="RadioButtonGroup--inline"
+            >
+              <label
+                class="RadioButton--radio StyledProps--main"
+              >
+                <input
+                  class="RadioButton--input"
+                  name="error-tracking-setup"
+                  type="radio"
+                  value="on"
+                />
+                <span
+                  class="RadioButton--radioIcon"
+                />
+                yes
+              </label>
+              <label
+                class="RadioButton--radio StyledProps--main"
+              >
+                <input
+                  checked=""
+                  class="RadioButton--input"
+                  name="error-tracking-setup"
+                  type="radio"
+                  value="off"
+                />
+                <span
+                  class="RadioButton--radioIcon"
+                />
+                no
+              </label>
+            </div>
+          </div>
+        </div>
+        <div
           class="StyledProps--font StyledProps--main formGroup lg bottomMargin5"
         >
           <div>


### PR DESCRIPTION
### Summary

Since the release of CET and the support of licensing. We are now requiring an active license to use CET in CI pipeline executions.

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [X] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
