### PR TITLE
feat: [PL-39029]: Added `All` tab in select or create connector modal

### DIFF
--- a/cypress/integration/70-pipeline/JenkinsStep.spec.ts
+++ b/cypress/integration/70-pipeline/JenkinsStep.spec.ts
@@ -1,4 +1,4 @@
-import { connectorInfo, connectorsListWithoutSort } from '../../support/35-connectors/constants'
+import { connectorInfo, connectorListScopeTab, connectorsListWithoutSort } from '../../support/35-connectors/constants'
 import {
   gitSyncEnabledCall,
   runPipelineTemplateCall,
@@ -42,6 +42,9 @@ describe('Connectors list', () => {
     cy.intercept('GET', connectorInfo, { fixture: 'pipeline/api/jenkinsStep/connectorInfo.json' }).as('connectorInfo')
     cy.intercept('GET', jobDetailsCall, { fixture: 'pipeline/api/jenkinsStep/jobDetails.json' }).as('jobDetailsCall')
     cy.intercept('POST', connectorsListWithoutSort, { fixture: 'pipeline/api/connector/connectorList.json' }).as(
+      'connectorsListCall'
+    )
+    cy.intercept('POST', connectorListScopeTab, { fixture: 'pipeline/api/connector/connectorList.json' }).as(
       'connectorsListCall'
     )
     cy.intercept('GET', jobDetailsCallAfterConnectorChange, { fixture: 'pipeline/api/jenkinsStep/jobDetails.json' }).as(

--- a/cypress/support/35-connectors/constants.ts
+++ b/cypress/support/35-connectors/constants.ts
@@ -14,7 +14,7 @@ const connectorName = 'testConnector'
 const connectorType = 'Jenkins'
 
 export const connectorsListAPI = `/ng/api/connectors/listV2?routingId=${accountId}&sortOrders=lastModifiedAt%2CDESC&pageIndex=0&pageSize=10&projectIdentifier=${projectId}&orgIdentifier=${orgIdentifier}&accountIdentifier=${accountId}`
-export const connectorsListWithoutSort = `/ng/api/connectors/listV2?accountIdentifier=${accountId}&searchTerm=&projectIdentifier=${projectId}&orgIdentifier=${orgIdentifier}&pageIndex=0&pageSize=10`
+export const connectorsListWithoutSort = `/ng/api/connectors/listV2?accountIdentifier=${accountId}&searchTerm=&projectIdentifier=${projectId}&orgIdentifier=${orgIdentifier}&pageIndex=0&pageSize=10&includeAllConnectorsAvailableAtScope=true`
 export const accountConnectorsListAPI = `/ng/api/connectors/listV2?routingId=${accountId}&sortOrders=lastModifiedAt%2CDESC&pageIndex=0&pageSize=10&accountIdentifier=${accountId}*`
 export const connectorsCatalogueAPI = `/ng/api/connectors/catalogue?routingId=${accountId}&accountIdentifier=${accountId}`
 export const delegatesListAPI = `/api/setup/delegates/delegate-selectors-up-the-hierarchy?routingId=${accountId}&accountId=${accountId}&orgId=${orgIdentifier}&projectId=${projectId}`

--- a/cypress/support/35-connectors/constants.ts
+++ b/cypress/support/35-connectors/constants.ts
@@ -15,6 +15,7 @@ const connectorType = 'Jenkins'
 
 export const connectorsListAPI = `/ng/api/connectors/listV2?routingId=${accountId}&sortOrders=lastModifiedAt%2CDESC&pageIndex=0&pageSize=10&projectIdentifier=${projectId}&orgIdentifier=${orgIdentifier}&accountIdentifier=${accountId}`
 export const connectorsListWithoutSort = `/ng/api/connectors/listV2?accountIdentifier=${accountId}&searchTerm=&projectIdentifier=${projectId}&orgIdentifier=${orgIdentifier}&pageIndex=0&pageSize=10&includeAllConnectorsAvailableAtScope=true`
+export const connectorListScopeTab = `/ng/api/connectors/listV2?accountIdentifier=${accountId}&searchTerm=&projectIdentifier=${projectId}&orgIdentifier=${orgIdentifier}&pageIndex=0&pageSize=10&includeAllConnectorsAvailableAtScope=false`
 export const accountConnectorsListAPI = `/ng/api/connectors/listV2?routingId=${accountId}&sortOrders=lastModifiedAt%2CDESC&pageIndex=0&pageSize=10&accountIdentifier=${accountId}*`
 export const connectorsCatalogueAPI = `/ng/api/connectors/catalogue?routingId=${accountId}&accountIdentifier=${accountId}`
 export const delegatesListAPI = `/api/setup/delegates/delegate-selectors-up-the-hierarchy?routingId=${accountId}&accountId=${accountId}&orgId=${orgIdentifier}&projectId=${projectId}`

--- a/src/modules/10-common/components/ReferenceSelect/ReferenceSelect.tsx
+++ b/src/modules/10-common/components/ReferenceSelect/ReferenceSelect.tsx
@@ -258,6 +258,7 @@ export function ReferenceSelect<T extends MinimalObject>(props: ReferenceSelectP
             selectedRecord={selectedRecord}
             isRecordDisabled={isRecordDisabled}
             renderRecordDisabledWarning={renderRecordDisabledWarning}
+            showAllTab={props.showAllTab}
           />
         </div>
       </Dialog>

--- a/src/modules/10-common/components/ReferenceSelect/ReferenceSelect.tsx
+++ b/src/modules/10-common/components/ReferenceSelect/ReferenceSelect.tsx
@@ -74,6 +74,7 @@ export interface ReferenceSelectProps<T extends MinimalObject>
   componentName?: string
   isMultiSelect?: boolean
   isOnlyFixedtype?: boolean
+  showAllTab?: boolean
   selectedReferences?: string[] | Item[]
   onMultiSelectChange?: (records: ScopeAndIdentifier[]) => void
   isRecordDisabled?: (item: any) => boolean
@@ -243,7 +244,6 @@ export function ReferenceSelect<T extends MinimalObject>(props: ReferenceSelectP
               setOpen(false)
               onChange(record, scope)
             }}
-            showAllTab
             onMultiSelect={records => {
               setOpen(false)
               onMultiSelectChange?.(records)

--- a/src/modules/10-common/components/ReferenceSelect/ReferenceSelect.tsx
+++ b/src/modules/10-common/components/ReferenceSelect/ReferenceSelect.tsx
@@ -243,6 +243,7 @@ export function ReferenceSelect<T extends MinimalObject>(props: ReferenceSelectP
               setOpen(false)
               onChange(record, scope)
             }}
+            showAllTab
             onMultiSelect={records => {
               setOpen(false)
               onMultiSelectChange?.(records)

--- a/src/modules/35-connectors/components/ConnectorReferenceField/ConnectorReferenceField.tsx
+++ b/src/modules/35-connectors/components/ConnectorReferenceField/ConnectorReferenceField.tsx
@@ -910,7 +910,7 @@ export const ConnectorReferenceField: React.FC<ConnectorReferenceFieldProps> = p
           ></RbacButton>
         }
         onMultiSelectChange={onMultiSelectChange}
-        showAllTab
+        showAllTab={true}
       />
     </FormGroup>
   )

--- a/src/modules/35-connectors/components/ConnectorReferenceField/ConnectorReferenceField.tsx
+++ b/src/modules/35-connectors/components/ConnectorReferenceField/ConnectorReferenceField.tsx
@@ -84,19 +84,21 @@ interface AdditionalParams {
 const getAdditionalParams = ({
   scope,
   projectIdentifier,
-  orgIdentifier
+  orgIdentifier,
+  allTabSelected
 }: {
   scope?: string
   projectIdentifier?: string
   orgIdentifier?: string
+  allTabSelected?: boolean
 }): AdditionalParams => {
   const additionalParams: AdditionalParams = {}
 
-  if (scope === Scope.PROJECT) {
+  if (scope === Scope.PROJECT || allTabSelected) {
     additionalParams.projectIdentifier = projectIdentifier
   }
 
-  if (scope === Scope.PROJECT || scope === Scope.ORG) {
+  if (scope === Scope.PROJECT || scope === Scope.ORG || allTabSelected) {
     additionalParams.orgIdentifier = orgIdentifier
   }
 
@@ -473,7 +475,7 @@ export function getReferenceFieldProps({
     // recordClassName: css.listItem,
     isNewConnectorLabelVisible: true,
     fetchRecords: (done, search, page, scope, signal = undefined, allTabSelected) => {
-      const additionalParams = getAdditionalParams({ scope, projectIdentifier, orgIdentifier })
+      const additionalParams = getAdditionalParams({ scope, projectIdentifier, orgIdentifier, allTabSelected })
       const gitFilterParams =
         gitScope?.repo && gitScope?.branch
           ? {
@@ -499,8 +501,9 @@ export function getReferenceFieldProps({
               ...(!category && { types: Array.isArray(type) ? type : [type] }),
               category,
               filterType: 'Connector',
-              projectIdentifier: scope === Scope.PROJECT ? [projectIdentifier as string] : undefined,
-              orgIdentifier: scope === Scope.PROJECT || scope === Scope.ORG ? [orgIdentifier as string] : undefined
+              projectIdentifier: scope === Scope.PROJECT || allTabSelected ? [projectIdentifier as string] : undefined,
+              orgIdentifier:
+                scope === Scope.PROJECT || scope === Scope.ORG || allTabSelected ? [orgIdentifier as string] : undefined
             },
             connectorFilterProperties
           ) as ConnectorFilterProperties

--- a/src/modules/35-connectors/components/ConnectorReferenceField/ConnectorReferenceField.tsx
+++ b/src/modules/35-connectors/components/ConnectorReferenceField/ConnectorReferenceField.tsx
@@ -472,7 +472,7 @@ export function getReferenceFieldProps({
     createNewLabel: getString('newConnector'),
     // recordClassName: css.listItem,
     isNewConnectorLabelVisible: true,
-    fetchRecords: (done, search, page, scope, signal = undefined) => {
+    fetchRecords: (done, search, page, scope, signal = undefined, allTabSelected) => {
       const additionalParams = getAdditionalParams({ scope, projectIdentifier, orgIdentifier })
       const gitFilterParams =
         gitScope?.repo && gitScope?.branch
@@ -491,7 +491,8 @@ export function getReferenceFieldProps({
             ...gitFilterParams,
             pageIndex: page || 0,
             pageSize: 10,
-            version
+            version,
+            includeAllConnectorsAvailableAtScope: allTabSelected
           },
           body: merge(
             {

--- a/src/modules/35-connectors/components/ConnectorReferenceField/ConnectorReferenceField.tsx
+++ b/src/modules/35-connectors/components/ConnectorReferenceField/ConnectorReferenceField.tsx
@@ -493,7 +493,7 @@ export function getReferenceFieldProps({
             ...gitFilterParams,
             pageIndex: page || 0,
             pageSize: 10,
-            version,
+            ...(version ? { version } : undefined),
             includeAllConnectorsAvailableAtScope: allTabSelected
           },
           body: merge(
@@ -910,6 +910,7 @@ export const ConnectorReferenceField: React.FC<ConnectorReferenceFieldProps> = p
           ></RbacButton>
         }
         onMultiSelectChange={onMultiSelectChange}
+        showAllTab
       />
     </FormGroup>
   )

--- a/src/modules/35-connectors/components/ConnectorReferenceField/FormMultiTypeConnectorField.tsx
+++ b/src/modules/35-connectors/components/ConnectorReferenceField/FormMultiTypeConnectorField.tsx
@@ -442,6 +442,7 @@ export const MultiTypeConnectorField = (props: MultiTypeConnectorFieldProps): Re
           // Other connectors will need to onboard this and add details in collapsed view.
           // Please update the details in RenderConnectorDetails inside ConnectorReferenceField.
           disableCollapse: !(type === 'Github'),
+          showAllTab: true,
           pagination: {
             itemCount: pagedConnectorData?.data?.totalItems || 0,
             pageSize: pagedConnectorData?.data?.pageSize || 10,

--- a/src/modules/40-gitsync/components/GitSyncForm/__tests__/mockdata.ts
+++ b/src/modules/40-gitsync/components/GitSyncForm/__tests__/mockdata.ts
@@ -124,6 +124,7 @@ export const fetchSupportedConnectorsListPayload = {
   },
   queryParams: {
     accountIdentifier: 'dummy',
+    includeAllConnectorsAvailableAtScope: true,
     orgIdentifier: 'default',
     pageIndex: 0,
     pageSize: 10,

--- a/src/modules/40-gitsync/components/gitSyncRepoForm/__tests__/__snapshots__/GitSyncRepoForm.test.tsx.snap
+++ b/src/modules/40-gitsync/components/gitSyncRepoForm/__tests__/__snapshots__/GitSyncRepoForm.test.tsx.snap
@@ -91,10 +91,33 @@ exports[`Git Sync - repo tab Filling gitSync repo form: connectorSelectorDialog 
               />
             </div>
             <div
-              aria-controls="bp3-tab-panel_selectScope_project"
+              aria-controls="bp3-tab-panel_selectScope_all"
               aria-disabled="false"
               aria-expanded="true"
               aria-selected="true"
+              class="bp3-tab"
+              data-tab-id="all"
+              id="bp3-tab-title_selectScope_all"
+              role="tab"
+              tabindex="0"
+            >
+              <div
+                class="Layout--horizontal Layout--layout-spacing-xsmall StyledProps--main StyledProps--flex StyledProps--flex-alignItems-center StyledProps--flex-justifyContent-flex-start StyledProps--padding-left-xsmall StyledProps--padding-right-xsmall"
+              >
+                <p
+                  class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--font-variation-h6 StyledProps--font-weight-light"
+                  style="--text-line-clamp: 1;"
+                >
+                  common.all
+                </p>
+                
+              </div>
+            </div>
+            <div
+              aria-controls="bp3-tab-panel_selectScope_project"
+              aria-disabled="false"
+              aria-expanded="false"
+              aria-selected="false"
               class="bp3-tab"
               data-tab-id="project"
               id="bp3-tab-title_selectScope_project"
@@ -222,9 +245,9 @@ exports[`Git Sync - repo tab Filling gitSync repo form: connectorSelectorDialog 
           </div>
           <div
             aria-hidden="false"
-            aria-labelledby="bp3-tab-title_selectScope_project"
+            aria-labelledby="bp3-tab-title_selectScope_all"
             class="bp3-tab-panel"
-            id="bp3-tab-panel_selectScope_project"
+            id="bp3-tab-panel_selectScope_all"
             role="tabpanel"
           >
             <div
@@ -2147,10 +2170,33 @@ exports[`Git Sync - repo tab Updating the status of connector: connectorSelector
               />
             </div>
             <div
-              aria-controls="bp3-tab-panel_selectScope_project"
+              aria-controls="bp3-tab-panel_selectScope_all"
               aria-disabled="false"
               aria-expanded="true"
               aria-selected="true"
+              class="bp3-tab"
+              data-tab-id="all"
+              id="bp3-tab-title_selectScope_all"
+              role="tab"
+              tabindex="0"
+            >
+              <div
+                class="Layout--horizontal Layout--layout-spacing-xsmall StyledProps--main StyledProps--flex StyledProps--flex-alignItems-center StyledProps--flex-justifyContent-flex-start StyledProps--padding-left-xsmall StyledProps--padding-right-xsmall"
+              >
+                <p
+                  class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--font-variation-h6 StyledProps--font-weight-light"
+                  style="--text-line-clamp: 1;"
+                >
+                  common.all
+                </p>
+                
+              </div>
+            </div>
+            <div
+              aria-controls="bp3-tab-panel_selectScope_project"
+              aria-disabled="false"
+              aria-expanded="false"
+              aria-selected="false"
               class="bp3-tab"
               data-tab-id="project"
               id="bp3-tab-title_selectScope_project"
@@ -2278,9 +2324,9 @@ exports[`Git Sync - repo tab Updating the status of connector: connectorSelector
           </div>
           <div
             aria-hidden="false"
-            aria-labelledby="bp3-tab-title_selectScope_project"
+            aria-labelledby="bp3-tab-title_selectScope_all"
             class="bp3-tab-panel"
-            id="bp3-tab-panel_selectScope_project"
+            id="bp3-tab-panel_selectScope_all"
             role="tabpanel"
           >
             <div


### PR DESCRIPTION
### Summary

<!-- ✍️ A clear and concise description...-->

#### Screenshots

<img width="1005" alt="Screenshot 2023-05-29 at 4 22 05 PM" src="https://github.com/harness/harness-core-ui/assets/62028553/a4a263f6-0992-4b09-8ab5-08865a735feb">


NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
