### PR TITLE
fix: [CDS-70566]: removed useEffect and used setToFalseWhenEmpty prop in FormMultiTypeCheckboxField

### DIFF
--- a/src/modules/75-cd/components/PipelineSteps/DeployServiceEntityStep/DeployServiceEntityInputStep.tsx
+++ b/src/modules/75-cd/components/PipelineSteps/DeployServiceEntityStep/DeployServiceEntityInputStep.tsx
@@ -5,7 +5,7 @@
  * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
  */
 
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useMemo, useState } from 'react'
 import {
   AllowedTypes,
   getMultiTypeFromValue,
@@ -15,7 +15,7 @@ import {
   SelectOption,
   useToaster
 } from '@harness/uicore'
-import { cloneDeep, defaultTo, get, isEmpty, isNil, merge, set } from 'lodash-es'
+import { defaultTo, get, isEmpty, isNil, merge } from 'lodash-es'
 import { Spinner } from '@blueprintjs/core'
 import { useFormikContext } from 'formik'
 import { v4 as uuid } from 'uuid'
@@ -157,18 +157,6 @@ export function DeployServiceEntityInputStep({
     }
   }, [servicesList])
 
-  useEffect(() => {
-    const clonedFormikValue = cloneDeep(formik.values) as any
-    if (getMultiTypeFromValue(deployParallelTemplate) === MultiTypeInputType.RUNTIME)
-      set(
-        clonedFormikValue,
-        `${localPathPrefix}metadata.parallel`,
-        get(formik, `values.${localPathPrefix}metadata.parallel`) || false
-      )
-
-    formik.setValues({ ...clonedFormikValue })
-  }, [])
-
   useDeepCompareEffect(() => {
     // This is specific handling for service as expression in templatized views
     if (serviceIdentifiers.length === 1 && isValueExpression(serviceValue)) {
@@ -295,7 +283,7 @@ export function DeployServiceEntityInputStep({
 
   return (
     <>
-      <Layout.Horizontal style={{ flexDirection: 'column' }}>
+      <Layout.Vertical>
         <div className={css.inputFieldLayout}>
           {getMultiTypeFromValue(serviceTemplate) === MultiTypeInputType.RUNTIME ? (
             CDS_OrgAccountLevelServiceEnvEnvGroup ? (
@@ -382,6 +370,7 @@ export function DeployServiceEntityInputStep({
                   label={getString('cd.pipelineSteps.serviceTab.multiServicesParallelDeployLabel')}
                   name={`${localPathPrefix}metadata.parallel`}
                   disabled={inputSetData?.readonly}
+                  setToFalseWhenEmpty
                   checkboxStyle={{ flexGrow: 'unset' }}
                   multiTypeTextbox={{
                     expressions,
@@ -394,7 +383,7 @@ export function DeployServiceEntityInputStep({
           </>
         ) : null}
         {loading ? <Spinner className={css.inputSetSpinner} size={16} /> : null}
-      </Layout.Horizontal>
+      </Layout.Vertical>
     </>
   )
 }

--- a/src/modules/75-cd/components/PipelineSteps/DeployServiceEntityStep/DeployServiceEntityWidget.tsx
+++ b/src/modules/75-cd/components/PipelineSteps/DeployServiceEntityStep/DeployServiceEntityWidget.tsx
@@ -99,7 +99,8 @@ const DIALOG_PROPS: Omit<ModalDialogProps, 'isOpen'> = {
 }
 
 function getInitialValues(data: DeployServiceEntityData): FormState {
-  const parallelValue = get(data, 'services.metadata.parallel', false)
+  const parallelValue = get(data, 'services.metadata.parallel', true)
+
   if (data.service && data.service.serviceRef) {
     return {
       service: data.service.serviceRef,

--- a/src/modules/75-cd/components/PipelineSteps/DeployServiceEntityStep/DeployServiceEntityWidget.tsx
+++ b/src/modules/75-cd/components/PipelineSteps/DeployServiceEntityStep/DeployServiceEntityWidget.tsx
@@ -708,8 +708,7 @@ export default function DeployServiceEntityWidget({
                         label={getString('cd.pipelineSteps.serviceTab.multiServicesParallelDeployLabel')}
                         name="parallel"
                         multiTypeTextbox={{
-                          allowableTypes: [MultiTypeInputType.FIXED, MultiTypeInputType.RUNTIME],
-                          width: 300
+                          allowableTypes: [MultiTypeInputType.FIXED, MultiTypeInputType.RUNTIME]
                         }}
                         style={{ width: '300px' }}
                       />

--- a/src/modules/75-cd/components/PipelineSteps/DeployServiceEntityStep/DeployServiceEntityWidget.tsx
+++ b/src/modules/75-cd/components/PipelineSteps/DeployServiceEntityStep/DeployServiceEntityWidget.tsx
@@ -99,10 +99,7 @@ const DIALOG_PROPS: Omit<ModalDialogProps, 'isOpen'> = {
 }
 
 function getInitialValues(data: DeployServiceEntityData): FormState {
-  const parallelValue = defaultTo(
-    get(data, 'services.metadata.parallel', true),
-    !!get(data, 'services.metadata.parallel', true)
-  )
+  const parallelValue = get(data, 'services.metadata.parallel', false)
   if (data.service && data.service.serviceRef) {
     return {
       service: data.service.serviceRef,

--- a/src/modules/75-cd/components/PipelineSteps/DeployServiceEntityStep/__tests__/__snapshots__/DeployServiceEntityWidget.MultiService.test.tsx.snap
+++ b/src/modules/75-cd/components/PipelineSteps/DeployServiceEntityStep/__tests__/__snapshots__/DeployServiceEntityWidget.MultiService.test.tsx.snap
@@ -190,7 +190,7 @@ exports[`DeployServiceEntityWidget - multi services tests user can delete select
             >
               <div
                 class="Layout--horizontal StyledProps--main MultiTypeInput--main"
-                style="flex-grow: 1; width: 300px;"
+                style="flex-grow: 1;"
               >
                 <label
                   class="bp3-control bp3-checkbox StyledProps--font Checkbox--checkbox input StyledProps--main"


### PR DESCRIPTION


### Summary

<!-- ✍️ A clear and concise description...-->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
