### PR TITLE
fix: [OIP-274]: Pass TemplateScope while fetching InputSet

### DIFF
--- a/src/modules/85-cv/components/MonitoredServiceTemplate/components/MonitoredServiceTemplate.tsx
+++ b/src/modules/85-cv/components/MonitoredServiceTemplate/components/MonitoredServiceTemplate.tsx
@@ -15,6 +15,7 @@ import MonitoredServiceInputSetsTemplate from '@cv/pages/monitored-service/Monit
 import { Scope } from '@common/interfaces/SecretsInterface'
 import type { TemplateFormRef } from '@templates-library/components/TemplateStudio/TemplateStudioInternal'
 import { MonitoredTemplateCanvasWithRef } from './MonitoredServiceTemplateCanvas'
+import { getMonitoredServiceTemplateScope } from './MonitoredServiceTemplateCanvas.utils'
 
 export class MonitoredServiceTemplate extends Template {
   protected label = 'Monitored Service'
@@ -39,7 +40,9 @@ export class MonitoredServiceTemplate extends Template {
     }
   ): JSX.Element {
     const { template, accountId } = props
-    const { identifier = '', orgIdentifier = '', projectIdentifier = '', versionLabel = '', templateScope } = template
+    const { identifier = '', orgIdentifier = '', projectIdentifier = '', versionLabel = '' } = template
+
+    const templateScope = getMonitoredServiceTemplateScope(accountId, template)
 
     const templateData = {
       accountId,

--- a/src/modules/85-cv/components/MonitoredServiceTemplate/components/MonitoredServiceTemplateCanvas.utils.ts
+++ b/src/modules/85-cv/components/MonitoredServiceTemplate/components/MonitoredServiceTemplateCanvas.utils.ts
@@ -6,7 +6,9 @@
  */
 
 import { isEmpty } from 'lodash-es'
-import type { JsonNode, NGTemplateInfoConfig } from 'services/template-ng'
+import type { JsonNode, NGTemplateInfoConfig, TemplateSummaryResponse } from 'services/template-ng'
+import { getScopeFromDTO } from '@common/components/EntityReference/EntityReference'
+import type { TemplateInputsProps } from '@templates-library/components/TemplateInputs/TemplateInputs'
 import { DefaultSpec } from './MonitoredServiceTemplateCanvas.constants'
 
 /**
@@ -21,3 +23,21 @@ export const createdInitTemplateValue = (template: NGTemplateInfoConfig): NGTemp
         spec: { ...DefaultSpec } as JsonNode
       }
     : template
+
+export const getMonitoredServiceTemplateScope = (
+  accountId: string,
+  template: TemplateInputsProps['template'] & { templateScope: TemplateSummaryResponse['templateScope'] }
+): TemplateSummaryResponse['templateScope'] => {
+  const { orgIdentifier = '', projectIdentifier = '' } = template
+  let templateScope = template?.templateScope
+
+  if (!templateScope) {
+    templateScope = getScopeFromDTO({
+      accountIdentifier: accountId,
+      orgIdentifier,
+      projectIdentifier
+    })
+  }
+
+  return templateScope
+}

--- a/src/modules/85-cv/components/MonitoredServiceTemplate/components/__tests__/MonitoredServiceTemplateCanvas.test.tsx
+++ b/src/modules/85-cv/components/MonitoredServiceTemplate/components/__tests__/MonitoredServiceTemplateCanvas.test.tsx
@@ -8,6 +8,7 @@
 import React from 'react'
 import { render } from '@testing-library/react'
 import { Container, Button } from '@harness/uicore'
+import { omit } from 'lodash-es'
 import { TestWrapper } from '@common/utils/testUtils'
 import { Scope } from '@common/interfaces/SecretsInterface'
 import { TemplateType } from '@templates-library/utils/templatesUtils'
@@ -16,7 +17,7 @@ import { getTemplateContextMock } from '@templates-library/components/TemplateSt
 import { MonitoredTemplateCanvasWithRef } from '../MonitoredServiceTemplateCanvas'
 import { MonitoredServiceTemplate } from '../MonitoredServiceTemplate'
 import { monitoredServiceDefaultTemplateMock } from './MonitoredServiceTemplateCanvas.mock'
-import { createdInitTemplateValue } from '../MonitoredServiceTemplateCanvas.utils'
+import { createdInitTemplateValue, getMonitoredServiceTemplateScope } from '../MonitoredServiceTemplateCanvas.utils'
 import { DefaultSpec } from '../MonitoredServiceTemplateCanvas.constants'
 
 const monitoredServiceTemplateContextMock = getTemplateContextMock(TemplateType.MonitoredService)
@@ -141,5 +142,21 @@ describe('Test MonitoredTemplateCanvasWithRef', () => {
     monitoredServiceDefaultTemplateMock.name = 'MS Template'
     monitoredServiceDefaultTemplateMock.spec = { changeSource: [], healthSource: [] }
     expect(createdInitTemplateValue(monitoredServiceDefaultTemplateMock)).toEqual(monitoredServiceDefaultTemplateMock)
+  })
+
+  test('should validate getMonitoredServiceTemplateScope', () => {
+    expect(getMonitoredServiceTemplateScope('account1', { ...monitoredServiceDefaultTemplateMock } as any)).toEqual(
+      Scope.PROJECT
+    )
+    expect(
+      getMonitoredServiceTemplateScope('account1', {
+        ...omit(monitoredServiceDefaultTemplateMock, 'projectIdentifier')
+      } as any)
+    ).toEqual(Scope.ORG)
+    expect(
+      getMonitoredServiceTemplateScope('account1', {
+        ...omit(monitoredServiceDefaultTemplateMock, ['projectIdentifier', 'orgIdentifier'])
+      } as any)
+    ).toEqual(Scope.ACCOUNT)
   })
 })

--- a/src/modules/85-cv/pages/monitored-service/MonitoredServiceInputSetsTemplate/MonitoredServiceInputSetsTemplate.tsx
+++ b/src/modules/85-cv/pages/monitored-service/MonitoredServiceInputSetsTemplate/MonitoredServiceInputSetsTemplate.tsx
@@ -202,7 +202,8 @@ export default function MonitoredServiceInputSetsTemplate({
       versionLabel: selectedTemplateVersionLabel = '',
       accountId: selectedTemplateAccountId = '',
       orgIdentifier: selectedTemplateOrgIdentifier = '',
-      projectIdentifier: selectedTemplateProjectIdentifier = ''
+      projectIdentifier: selectedTemplateProjectIdentifier = '',
+      templateScope: selectedTemplateScope = ''
     } = template
     if (selectedTemplateVersionLabel && selectedTemplateIdentifier) {
       updateQueryParams({
@@ -211,7 +212,8 @@ export default function MonitoredServiceInputSetsTemplate({
           versionLabel: selectedTemplateVersionLabel,
           accountId: selectedTemplateAccountId,
           orgIdentifier: selectedTemplateOrgIdentifier,
-          projectIdentifier: selectedTemplateProjectIdentifier
+          projectIdentifier: selectedTemplateProjectIdentifier,
+          templateScope: selectedTemplateScope
         })
       })
     }


### PR DESCRIPTION
### Summary

<!-- ✍️ A clear and concise description...-->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
