### PR TITLE
feat: [FFM-8241]: All Environments view design fixes

### DIFF
--- a/src/modules/75-cf/pages/feature-flags/components/AllEnvironmentsFlagsListing.module.scss
+++ b/src/modules/75-cf/pages/feature-flags/components/AllEnvironmentsFlagsListing.module.scss
@@ -18,16 +18,14 @@
 }
 
 .environmentTypeContainer {
-  border-radius: var(--spacing-medium);
+  border-radius: var(--spacing-4);
   height: 85px;
+  --layout-spacing: var(--spacing-4) !important;
   &.prod {
     background-color: var(--purple-50);
   }
   &.nonProd {
     background-color: var(--teal-50);
-  }
-  :last-child {
-    margin-right: var(--spacing-small) !important;
   }
 }
 
@@ -35,10 +33,11 @@
   padding: var(--spacing-small) !important;
   box-shadow: var(--elevation-0) !important;
   height: 100%;
+  width: 125px !important;
+  border-radius: var(--spacing-small) !important;
 }
 
 .flagEnvironmentStatus {
-  width: 100px !important;
   > .enabled {
     background-color: var(--green-50);
     border-radius: var(--spacing-xsmall);
@@ -46,16 +45,16 @@
     font-weight: bold !important;
   }
   > .disabled {
-    border: 1px solid var(--grey-600);
     border-radius: var(--spacing-xsmall);
-    color: var(--grey-600) !important;
+    color: var(--grey-700) !important;
+    background-color: var(--grey-200) !important;
     font-weight: bold !important;
   }
 }
 
 .rotatedLabel {
   height: 85px;
-  width: var(--spacing-xlarge);
+  width: var(--spacing-small);
   position: relative;
   > p {
     transform: rotate(-90deg);

--- a/src/modules/75-cf/pages/feature-flags/components/FlagEnvironmentsState.tsx
+++ b/src/modules/75-cf/pages/feature-flags/components/FlagEnvironmentsState.tsx
@@ -30,9 +30,8 @@ const FlagEnvironmentsState: FC<FlagEnvironmentsStateProps> = ({ environmentsByT
         .map(envType => (
           <Layout.Horizontal
             key={envType}
-            flex={{ distribution: 'space-between', align: 'center-center' }}
+            flex={{ justifyContent: 'space-between', alignItems: 'center' }}
             padding="small"
-            spacing="medium"
             className={cx(css.environmentTypeContainer, envType === 'prod' ? css.prod : css.nonProd)}
             data-testid="environmentTypeContainer"
           >


### PR DESCRIPTION
### Summary
During testing it was found that the ‘Disabled’ status indicator was mistaken for a button due to how it looks to the user and some spacing and border radius values were incorrect

#### Screenshots
Before:
<img width="858" alt="image" src="https://github.com/harness/harness-core-ui/assets/5584348/0aafbc2e-3276-4d23-ad46-baf37de23156">
<img width="846" alt="image" src="https://github.com/harness/harness-core-ui/assets/5584348/03542aa4-43e8-45af-9adc-9aa0020e7e31">

After:
<img width="905" alt="image" src="https://github.com/harness/harness-core-ui/assets/5584348/72753e26-3801-4fe6-bc46-a08dbb5384e8">
<img width="854" alt="image" src="https://github.com/harness/harness-core-ui/assets/5584348/30013312-8d18-4fa2-a378-fa8bd0e2e39c">

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
