### PR TITLE
feat: [CET-1364] Add audit trail entries for CET resource events

### DIFF
--- a/src/modules/10-common/strings/strings.en.yaml
+++ b/src/modules/10-common/strings/strings.en.yaml
@@ -351,6 +351,8 @@ purpose:
     shortName: IDP
   cet:
     continuous: Continuous Error Tracking
+    criticalEvent: Critical Event
+    agentToken: Agent Token
     moduleSelectionSubHeading: Identify and fix errors faster with complete visibility into code level data using Harness Continuous Error Tracking.
 trialCommingSoon: Trial - Coming soon
 trialInProgress: Trial in progress

--- a/src/modules/75-cet/RouteDestinations.tsx
+++ b/src/modules/75-cet/RouteDestinations.tsx
@@ -26,6 +26,8 @@ import DelegateListing from '@delegates/pages/delegates/DelegateListing'
 import AccessControlPage from '@rbac/pages/AccessControl/AccessControlPage'
 import UsersPage from '@rbac/pages/Users/UsersPage'
 import SettingsList from '@default-settings/pages/SettingsList'
+import AuditTrailFactory, { ResourceScope } from 'framework/AuditTrail/AuditTrailFactory'
+import type { ResourceDTO } from 'services/audit'
 import { CETMonitoredServices } from './pages/CETMonitoredServices'
 import SideNav from './components/SideNav/SideNav'
 import CETHomePage from './pages/CETHomePage'
@@ -33,6 +35,40 @@ import CETTrialPage from './pages/trialPage/CETTrialPage'
 import { CETEventsSummary } from './pages/events-summary/CETEventsSummary'
 import { CETAgents } from './pages/CET-agent-control/CET-agents/CETAgents'
 import CETSettings from './pages/CET-agent-control/CETSettings'
+
+AuditTrailFactory.registerResourceHandler('CET_AGENT_TOKEN', {
+  moduleIcon: {
+    name: 'cet'
+  },
+  moduleLabel: 'common.purpose.cet.continuous',
+  resourceLabel: 'common.purpose.cet.agentToken',
+  resourceUrl: (_resource_: ResourceDTO, resourceScope: ResourceScope) => {
+    const { accountIdentifier, orgIdentifier, projectIdentifier } = resourceScope
+    const url = routes.toCETAgentsTokens({
+      orgIdentifier: orgIdentifier || '',
+      accountId: accountIdentifier,
+      projectIdentifier: projectIdentifier || ''
+    })
+    return url
+  }
+})
+
+AuditTrailFactory.registerResourceHandler('CET_CRITICAL_EVENT', {
+  moduleIcon: {
+    name: 'cet'
+  },
+  moduleLabel: 'common.purpose.cet.continuous',
+  resourceLabel: 'common.purpose.cet.criticalEvent',
+  resourceUrl: (_resource_: ResourceDTO, resourceScope: ResourceScope) => {
+    const { accountIdentifier, orgIdentifier, projectIdentifier } = resourceScope
+    const url = routes.toCETCriticalEvents({
+      orgIdentifier: orgIdentifier || '',
+      accountId: accountIdentifier,
+      projectIdentifier: projectIdentifier || ''
+    })
+    return url
+  }
+})
 
 export const CETSideNavProps: SidebarContext = {
   navComponent: SideNav,

--- a/src/services/audit/index.tsx
+++ b/src/services/audit/index.tsx
@@ -1597,7 +1597,8 @@ export interface ResourceDTO {
     | 'NG_ACCOUNT_DETAILS'
     | 'BUDGET_GROUP'
     | 'IP_ALLOWLIST_CONFIG'
-    | 'NETWORK_MAP'
+    | 'CET_AGENT_TOKEN'
+    | 'CET_CRITICAL_EVENT'
 }
 
 export interface ResourceFilter {

--- a/src/services/audit/index.tsx
+++ b/src/services/audit/index.tsx
@@ -1597,7 +1597,7 @@ export interface ResourceDTO {
     | 'NG_ACCOUNT_DETAILS'
     | 'BUDGET_GROUP'
     | 'IP_ALLOWLIST_CONFIG'
-    | 'NETORK_MAP'
+    | 'NETWORK_MAP'
     | 'CET_AGENT_TOKEN'
     | 'CET_CRITICAL_EVENT'
 }

--- a/src/services/audit/index.tsx
+++ b/src/services/audit/index.tsx
@@ -1597,6 +1597,7 @@ export interface ResourceDTO {
     | 'NG_ACCOUNT_DETAILS'
     | 'BUDGET_GROUP'
     | 'IP_ALLOWLIST_CONFIG'
+    | 'NETORK_MAP'
     | 'CET_AGENT_TOKEN'
     | 'CET_CRITICAL_EVENT'
 }

--- a/src/stringTypes.ts
+++ b/src/stringTypes.ts
@@ -835,7 +835,9 @@ export interface StringsMap {
   'common.purpose.ce.optimizationCard.description': string
   'common.purpose.ce.subtitle': string
   'common.purpose.ce.visibilityCard.description': string
+  'common.purpose.cet.agentToken': string
   'common.purpose.cet.continuous': string
+  'common.purpose.cet.criticalEvent': string
   'common.purpose.cet.moduleSelectionSubHeading': string
   'common.purpose.cf.continuous': string
   'common.purpose.cf.description': string


### PR DESCRIPTION
### Summary

Added two new resources using AuditTrailFactory.registerResouceHandler() to enable viewing of CET audit trail entries for related to CET agent tokens and CET critical event definitions

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
